### PR TITLE
use base58 encoding for public key

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,12 +48,13 @@
     "src"
   ],
   "dependencies": {
-    "axios": "^0.19.2",
-    "ecdsa-secp256k1-signature-2019": "^1.0.0",
     "@polkadot/api": "^1.8.1",
-    "vc-js": "^0.5.0",
+    "axios": "^0.19.2",
+    "bs58": "^4.0.1",
     "did-resolver": "^1.1.0",
+    "ecdsa-secp256k1-signature-2019": "^1.0.0",
     "elliptic": "^6.5.2",
-    "ethr-did-resolver": "^2.2.0"
+    "ethr-did-resolver": "^2.2.0",
+    "vc-js": "^0.5.0"
   }
 }

--- a/src/modules/did.js
+++ b/src/modules/did.js
@@ -1,4 +1,5 @@
 import {encodeAddress} from '@polkadot/util-crypto';
+import b58 from 'bs58';
 
 import {getHexIdentifierFromDID, DockDIDQualifier} from '../utils/did';
 import {getStateChange} from '../utils/misc';
@@ -74,24 +75,24 @@ class DIDModule {
     const id = (did === hexId) ? this.getFullyQualifiedDID(encodeAddress(hexId)) : did;
 
     // Determine the type of the public key
-    let type, publicKeyBase58;
+    let type, publicKeyRaw;
     if (detail.public_key.isSr25519) {
       type = 'Sr25519VerificationKey2018';
-      publicKeyBase58 = detail.public_key.asSr25519;
+      publicKeyRaw = detail.public_key.asSr25519;
     } else if (detail.public_key.isEd25519) {
       type = 'Ed25519VerificationKey2018';
-      publicKeyBase58 = detail.public_key.asEd25519;
+      publicKeyRaw = detail.public_key.asEd25519;
     } else {
       type = 'EcdsaSecp256k1VerificationKey2019';
-      publicKeyBase58 = detail.public_key.asSecp256K1;
+      publicKeyRaw = detail.public_key.asSecp256K1;
     }
 
     // The DID has only one key as of now.
     const publicKey = {
       id: `${id}#keys-1`,
       type,
-      controller: `${DockDIDQualifier}${detail.controller}`,
-      publicKeyBase58,
+      controller: this.getFullyQualifiedDID(encodeAddress(detail.controller)),
+      publicKeyBase58: b58.encode(publicKeyRaw.value),
       // publicKeyPem: '-----BEGIN PUBLIC KEY...END PUBLIC KEY-----\r\n', // TODO: add proper value
     };
 


### PR DESCRIPTION
Adding base58 library as node-forge is temporary and a bigger library compared to base58

Signed-off-by: lovesh <lovesh.bond@gmail.com>