### PR TITLE
Rename types.json to types.js

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -3,7 +3,7 @@ import {cryptoWaitReady} from '@polkadot/util-crypto';
 
 import RevocationModule from './modules/revocation';
 import DIDModule from './modules/did';
-import types from './types.json';
+import types from './types';
 
 import {
   PublicKey,

--- a/src/types.js
+++ b/src/types.js
@@ -1,4 +1,4 @@
-{
+export default {
   "dock::did::Did": "[u8;32]",
   "Bytes32": {
     "value": "[u8;32]"


### PR DESCRIPTION
has issues using client-sdk as a package with no json loader

edit: closed, transpilation should catch this it was because i was experimenting with client-sdk as es6 package