### PR TITLE
Optimize CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,15 +4,12 @@ on: [pull_request]
 jobs:
   build:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node: [ '13.x', '12.x', '10.x' ]
     steps:
       - uses: actions/checkout@v2
       - run: ./scripts/checkout_submodule
       - uses: actions/setup-node@v1
         with:
-          node-version: ${{ matrix.node }}
+          node-version: '10.x'
       - run: yarn install
       - run: yarn build
       - run: yarn test-with-node


### PR DESCRIPTION
The node version test matrix provides only marginal benefit.
This commit changes integration tests to only test against
one version of nodejs to save around 66% of CI minutes.