### PR TITLE
Refactor SDK import and build process

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -14,6 +14,10 @@ jobs:
           node-version: '10.x'
           registry-url: https://registry.npmjs.org/
       - run: yarn install
-      - run: npm publish --access public
+      - run: yarn build
+      - run: cp -rf dist/index.cjs.js src
+      - run: cp -rf dist/index.esm.js src
+      - run: cp -rf package.json src
+      - run: cd src && npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@docknetwork/sdk",
-  "version": "0.0.2",
-  "main": "dist/sdk.cjs.js",
-  "module": "dist/sdk.esm.js",
+  "version": "0.0.3",
+  "main": "index.cjs.js",
+  "module": "index.esm.js",
   "license": "MIT",
   "type": "module",
   "repository": {
@@ -34,7 +34,6 @@
   },
   "scripts": {
     "lint": "eslint \"{src,example}/**/*.js\"",
-    "prepare": "yarn build",
     "build": "rollup -c",
     "watch": "rollup -c -w",
     "test": "jest --verbose ./tests/unit",
@@ -53,7 +52,6 @@
     "testEnvironment": "node"
   },
   "files": [
-    "dist",
     "src"
   ],
   "dependencies": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -28,8 +28,8 @@ export default [
     input: 'src/api.js',
     external: [],
     output: [
-      { file: pkg.main, format: 'cjs' },
-      { file: pkg.module, format: 'es' },
+      { file: 'dist/' + pkg.main, format: 'cjs' },
+      { file: 'dist/' + pkg.module, format: 'es' },
     ],
   },
 ];


### PR DESCRIPTION
1. Import from src directory so when importing user doesnt need to prepend /src/ to paths
2. Rollup directly into index.*.js in src directory
3. Build before package publish not on pull (yarn prepare script)
4. Remove dist directory