### PR TITLE
Disable MJS build temporarily as it has issues in certain web build systems

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,9 +2,7 @@
   "name": "@docknetwork/sdk",
   "version": "0.0.5",
   "main": "index.js",
-  "module": "index.mjs",
   "license": "MIT",
-  "type": "module",
   "repository": {
     "type": "git",
     "url": "https://github.com/docknetwork/sdk"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -31,11 +31,12 @@ export default async function() {
       json(),
     ],
     input,
-    output: [{
-        dir: 'dist',
-        format: 'esm',
-        entryFileNames: '[name].mjs'
-      },
+    output: [
+      // {
+      //   dir: 'dist',
+      //   format: 'esm',
+      //   entryFileNames: '[name].mjs'
+      // },
       {
         dir: 'dist',
         format: 'cjs'


### PR DESCRIPTION
NextJS for example has issues using mjs files that import other modules in the node_modules directory. Webpack in general doesnt seem to be able to resolve importing non-ES modules from ES code as well as node itself can.