### PR TITLE
exercise Master functionality from client

### DIFF
--- a/scripts/config
+++ b/scripts/config
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-CONFIG_DOCK_NODE_IMAGE=${CONFIG_DOCK_NODE_IMAGE:-docknetwork/dock-substrate:b1fb6b48a220d4d901eb810618ae19e64b7b10be-fastblock}
+CONFIG_DOCK_NODE_IMAGE=${CONFIG_DOCK_NODE_IMAGE:-docknetwork/dock-substrate:4b408258339a8d0cb48434ea3d17482ac0ba70a8-fastblock}

--- a/src/types.json
+++ b/src/types.json
@@ -90,6 +90,15 @@
     "locked_reward": "Option<Balance>",
     "unlocked_reward": "Option<Balance>"
   },
+  "Payload": {
+    "proposal": "Vec<u8>",
+    "round_no": "u64"
+  },
+  "Membership": {
+    "members": "BTreeSet<Did>",
+    "vote_requirement": "u64"
+  },
+  "PMAuth": "BTreeMap<Did, DidSignature>",
   "StateChange": {
     "_enum": {
       "KeyUpdate": "KeyUpdate",
@@ -97,7 +106,8 @@
       "Revoke": "Revoke",
       "UnRevoke": "UnRevoke",
       "RemoveRegistry": "RemoveRegistry",
-      "Blob": "Blob"
+      "Blob": "Blob",
+      "MasterVote": "Payload"
     }
   }
 }

--- a/tests/integration/master.test.js
+++ b/tests/integration/master.test.js
@@ -1,0 +1,155 @@
+import types from '../../src/types.json';
+import { ApiPromise, WsProvider, Keyring } from '@polkadot/api';
+import { cryptoWaitReady } from '@polkadot/util-crypto';
+import { FullNodeEndpoint, TestAccountURI, TestKeyringOpts } from '../test-constants';
+import { assert, u8aToU8a } from '@polkadot/util';
+import Bytes from '@polkadot/types/primitive/Bytes';
+
+describe('Master Module', () => {
+  // node client
+  let nc;
+
+  beforeAll(async (done) => {
+    nc = await connect();
+    done();
+  }, 40000);
+
+  afterAll(async () => {
+    await nc.disconnect();
+  }, 10000);
+
+  test('Can authenticate and execute a root call', async () => {
+    let key = add_len_prefix([0xaa, 0xbb]);
+    let val = add_len_prefix([0xcc, 0xdd]);
+
+    // construct call
+    let call = nc.tx.system.setStorage([(key, val)]);
+
+    // sign call
+    let payload = {
+      proposal: nc.createType('Call', call).toU8a(),
+      round_no: await nc.query.master.round(),
+    };
+    let encoded_state_change = nc.createType('StateChange', { MasterVote: payload }).toU8a();
+
+    // submit without votes
+    await (async () => {
+      let res = await sign_send_tx(nc.tx.master.execute(call, []));
+      assert(res.status.isFinalized, "transaction was not included in block");
+      let sto = await nc.rpc.state.getStorage(key);
+      assert(sto.isNone, "storage item should not have been set");
+    })();
+
+    // // submit with invalid votes
+    // await (async () => {
+    //   let res = await sign_send_tx(nc.tx.master.execute(call, ));
+    //   assert(res.status.isFinalized, "transaction was not included in block");
+    //   let sto = await nc.rpc.state.getStorage(key);
+    //   assert(sto.isNone, "storage item should not have been set");
+    // })();
+
+    // submit with valid votes
+    await (async () => {
+      const bts = str => new TextEncoder("utf-8").encode(str);
+      const did_to_key = [
+        [
+          bts("Alice\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0"),
+          await keypair(bts("Alicesk\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0"))
+        ],
+        [
+          bts("Bob\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0"),
+          await keypair(bts("Bobsk\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0"))
+        ],
+        [
+          bts("Charlie\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0"),
+          await keypair(bts("Charliesk\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0"))
+        ],
+      ];
+      let votes = new Set(did_to_key.map(([did, key]) => {
+        let sig = key.sign(encoded_state_change);
+        return [did, { Sr25519: sig }]
+      }));
+      let res = await sign_send_tx(nc.tx.master.execute(call, votes));
+      assert(res.status.isFinalized, "transaction was not included in block");
+      let sto = await nc.rpc.state.getStorage(key);
+      assert(sto.asSome === val, "storage item should have been set");
+    })();
+  }, 40000);
+});
+
+// connect to running node
+async function connect() {
+  const extraTypes = {
+    Address: 'AccountId',
+    LookupSource: 'AccountId',
+  };
+  return await ApiPromise.create({
+    provider: new WsProvider(FullNodeEndpoint),
+    types: {
+      ...types,
+      ...extraTypes,
+    },
+  });
+}
+
+// load a DID kp from secret
+async function keypair(seed /* Uint8Array */) {
+  await cryptoWaitReady();
+  let keyring = new Keyring({ type: 'sr25519' });
+  let key = keyring.addFromSeed(seed);
+  return key
+}
+
+// sign a payload using DID kp
+function sign(kp, payload) {
+  assert(Uint8Array)
+}
+
+async function sign_send_tx(extrinsic) {
+  let key = await get_test_account_key();
+  await extrinsic.signAsync(key);
+
+  const promise = new Promise((resolve, reject) => {
+    try {
+      let unsubFunc = null;
+      return extrinsic.send(({ events = [], status }) => {
+        if (status.isFinalized) {
+          unsubFunc();
+          resolve({
+            events,
+            status,
+          });
+        }
+      })
+        .catch((error) => {
+          reject(error);
+        })
+        .then((unsub) => {
+          unsubFunc = unsub;
+        });
+    } catch (error) {
+      reject(error);
+    }
+
+    return this;
+  });
+
+  return await promise;
+}
+
+async function get_test_account_key() {
+  await cryptoWaitReady();
+  let keyring = new Keyring(TestKeyringOpts);
+  let key = keyring.addFromUri('//Alice');
+  return key
+}
+
+// prepend a length tag to a byte list
+// tag will encoded according to "Scale Codec"
+function add_len_prefix(bs /* array of integers */) {
+  return new Bytes(null, bs).toU8a()
+}
+
+function todo(t) {
+  throw t || "TODO";
+}

--- a/tests/integration/master.test.js
+++ b/tests/integration/master.test.js
@@ -33,7 +33,7 @@ describe('Master Module', () => {
     let key = add_len_prefix([0xaa, 0xbb]);
     let val = add_len_prefix([0xcc, 0xdd]);
 
-    let call = nc.tx.system.setStorage([(key, val)]);
+    let call = nc.tx.system.setStorage([[key, val]]);
     let proposal = [...nc.createType('Call', call).toU8a()];
     expect(proposal).toEqual([0, 6, 4, 8, 204, 221, 0]);
     let payload = {
@@ -147,7 +147,7 @@ async function connect() {
 
 // load a DID kp from secret
 async function keypair(seed) {
-  assert(seed instanceof Uint8Array);
+  assert(seed instanceof Uint8Array, "wrong type");
   await cryptoWaitReady();
   let keyring = new Keyring({ type: 'sr25519' });
   let key = keyring.addFromSeed(seed);
@@ -195,7 +195,7 @@ async function get_test_account_key() {
 
 // represent a Uint8Array as hex with a "0x" prefix
 function u8a_hex(bs) {
-  assert(bs instanceof Uint8Array);
+  assert(bs instanceof Uint8Array, "wrong type");
   return '0x' + [...bs].map(bt => ('0' + bt.toString(16)).slice(-2)).join('');
 }
 expect(u8a_hex(new Uint8Array([]))).toEqual('0x');
@@ -235,15 +235,15 @@ async function master_set_storage(
 
 /// convert a string to utf-8 encoded bytes
 function bts(str) {
-  return new Uint8Array([...new TextEncoder("utf-8").encode(str)]);
+  return new Uint8Array([...new TextEncoder().encode(str)]);
 }
 
 // return -1 if a < b, 0 if a == b, 1 if a > b
 function compare_u8a_32(a, b) {
-  assert(a instanceof Uint8Array);
-  assert(b instanceof Uint8Array);
-  assert(a.length === 32);
-  assert(b.length === 32);
+  assert(a instanceof Uint8Array, "wrong type");
+  assert(b instanceof Uint8Array, "wrong type");
+  assert(a.length === 32, "wrong len");
+  assert(b.length === 32, "wrong len");
   for (let i = 0; i < a.length; i++) {
     if (a[i] < b[i]) {
       return -1;

--- a/tests/integration/master.test.js
+++ b/tests/integration/master.test.js
@@ -141,11 +141,6 @@ async function keypair(seed /* Uint8Array */) {
   return key
 }
 
-// sign a payload using DID kp
-function sign(kp, payload) {
-  assert(Uint8Array)
-}
-
 async function sign_send_tx(extrinsic) {
   let key = await get_test_account_key();
   await extrinsic.signAsync(key);

--- a/tests/integration/master.test.js
+++ b/tests/integration/master.test.js
@@ -2,9 +2,15 @@ import types from '../../src/types.json';
 import { ApiPromise, WsProvider, Keyring } from '@polkadot/api';
 import { cryptoWaitReady } from '@polkadot/util-crypto';
 import { FullNodeEndpoint, TestAccountURI, TestKeyringOpts } from '../test-constants';
-import { assert, u8aToU8a } from '@polkadot/util';
+import { assert } from '@polkadot/util';
 import Bytes from '@polkadot/types/primitive/Bytes';
-import StorageKey from '@polkadot/types/primitive/StorageKey';
+
+const ALICE_DID = bts("Alice\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0");
+const BOB_DID = bts("Bob\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0");
+const CHARLIE_DID = bts("Charlie\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0");
+const ALICE_SK = bts("Alicesk\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0");
+const BOB_SK = bts("Bobsk\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0");
+const CHARLIE_SK = bts("Charliesk\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0");
 
 describe('Master Module', () => {
   // node client
@@ -15,107 +21,113 @@ describe('Master Module', () => {
     done();
   }, 40000);
 
-  afterAll(async () => {
-    await nc.disconnect();
-  }, 10000);
+  afterAll(async () => { await nc.disconnect(); }, 10000);
 
   test('scale endoding of call', async () => {
-    /// TODO: these key-value declarations should be randomly generated for all tests
+    // prepend a length tag to a byte list
+    // tag will encoded according to "Scale Codec"
+    function add_len_prefix(bs) {
+      return new Bytes(null, bs).toU8a()
+    }
+
     let key = add_len_prefix([0xaa, 0xbb]);
     let val = add_len_prefix([0xcc, 0xdd]);
 
-    // construct call
     let call = nc.tx.system.setStorage([(key, val)]);
-
-    // sign call
     let proposal = [...nc.createType('Call', call).toU8a()];
-    assert(array_eq(proposal, [0, 6, 4, 8, 204, 221, 0]), proposal);
+    expect(proposal).toEqual([0, 6, 4, 8, 204, 221, 0]);
     let payload = {
       proposal,
       round_no: 0,
     };
     let encoded_state_change = nc.createType('StateChange', { MasterVote: payload }).toU8a();
-    assert(uint8array_eq(
-      encoded_state_change,
-      new Uint8Array([
-        6, // enum tag?
-        28,
-        0, 6, 4, 8, 204, 221, 0, // encoded call
-        0, 0, 0, 0, 0, 0, 0, 0 // padding?
-      ])
-    ), encoded_state_change);
+    expect(encoded_state_change).toEqual(new Uint8Array([
+      6, // enum tag
+      7 << 2, // length tag of encoded call
+      0, 6, 4, 8, 204, 221, 0, // encoded call
+      0, 0, 0, 0, 0, 0, 0, 0 // 64 bit round number
+    ]));
   })
 
   test('control: set and get bytes as sudo', async () => {
-    let key = add_len_prefix([0xaa, 0xba]);
-    let val = add_len_prefix([0xcc, 0xda]);
-
-    // construct call
-    let call = nc.tx.system.setStorage([(key, val)]);
-    let sudocall = nc.tx.sudo.sudo(call);
+    let key = u8a_hex(randomish_u8a());
+    let val = u8a_hex(randomish_u8a());
+    let sudocall = nc.tx.sudo.sudo(nc.tx.system.setStorage([[key, val]]));
     await sign_send_tx(sudocall);
+    let bs = (await nc.rpc.state.getStorage(key)).unwrap();
+    expect(u8a_hex(bs)).toEqual(val);
+  }, 20000)
+
+  test('Root call with no votes', async () => {
+    let key = u8a_hex(randomish_u8a());
+    let val = u8a_hex(randomish_u8a());
+    await master_set_storage(nc, key, val, []);
     let sto = await nc.rpc.state.getStorage(key);
-    assert(uint8array_eq(sto.unwrap(), val), "storage item should have been set");
-  }, 40000)
+    assert(sto.isNone, "storage item should not have been set");
+  }, 20000);
 
-  test('Can authenticate and execute a root call', async () => {
-    let key = add_len_prefix([0xaa, 0xbb]);
-    let val = add_len_prefix([0xcc, 0xdd]);
+  test('Root call with invalid votes', async () => {
+    let key = u8a_hex(randomish_u8a());
+    let val = u8a_hex(randomish_u8a());
+    const did_to_key = [
+      [ALICE_DID, await keypair(randomish_u8a())],
+      [CHARLIE_DID, await keypair(randomish_u8a())],
+    ];
+    await master_set_storage(nc, key, val, did_to_key);
+    let sto = await nc.rpc.state.getStorage(key);
+    assert(sto.isNone, "storage item should not have been set");
+  }, 20000);
 
-    // construct call
-    let call = nc.tx.system.setStorage([(key, val)]);
+  test('Root call with valid votes', async () => {
+    let key = u8a_hex(randomish_u8a());
+    let val = u8a_hex(randomish_u8a());
+    const did_to_key = [
+      [ALICE_DID, await keypair(ALICE_SK)],
+      [CHARLIE_DID, await keypair(CHARLIE_SK)],
+    ];
+    await master_set_storage(nc, key, val, did_to_key);
+    let sto = await nc.rpc.state.getStorage(key);
+    let u8a = sto.unwrap();
+    expect(u8a_hex(u8a)).toEqual(val);
+  }, 20000);
 
-    // sign call
-    let payload = {
-      proposal: [...nc.createType('Call', call).toU8a()],
-      round_no: await nc.query.master.round(),
-    };
-    let encoded_state_change = nc.createType('StateChange', { MasterVote: payload }).toU8a();
+  test('Root call with valid votes but insufficient vote count', async () => {
+    let key = u8a_hex(randomish_u8a());
+    let val = u8a_hex(randomish_u8a());
+    const did_to_key = [
+      [ALICE_DID, await keypair(ALICE_SK)]
+    ];
+    await master_set_storage(nc, key, val, did_to_key);
+    let sto = await nc.rpc.state.getStorage(key);
+    assert(sto.isNone, "storage item should not have been set");
+  }, 20000);
 
-    // submit without votes
-    await (async () => {
-      let res = await sign_send_tx(nc.tx.master.execute(call, []));
-      assert(res.status.isFinalized, "transaction was not included in block");
-      let sto = await nc.rpc.state.getStorage(key);
-      assert(sto.isNone, "storage item should not have been set");
-    })();
+  test('Root call with valid votes and oversufficient vote count', async () => {
+    let key = u8a_hex(randomish_u8a());
+    let val = u8a_hex(randomish_u8a());
+    const did_to_key = [
+      [ALICE_DID, await keypair(ALICE_SK)],
+      [BOB_DID, await keypair(BOB_SK)],
+      [CHARLIE_DID, await keypair(CHARLIE_SK)],
+    ];
+    await master_set_storage(nc, key, val, did_to_key);
+    let sto = await nc.rpc.state.getStorage(key);
+    let u8a = sto.unwrap();
+    expect(u8a_hex(u8a)).toEqual(val);
+  }, 20000);
 
-    // submit with invalid votes
-    await (async () => {
-      let res = await sign_send_tx(nc.tx.master.execute(call, todo("pass some invalid sigs")));
-      assert(res.status.isFinalized, "transaction was not included in block");
-      let sto = await nc.rpc.state.getStorage(key);
-      assert(sto.isNone, "storage item should not have been set");
-    })();
-
-    // submit with valid votes
-    await (async () => {
-      const bts = str => new TextEncoder("utf-8").encode(str);
-      const did_to_key = [
-        [
-          bts("Alice\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0"),
-          await keypair(bts("Alicesk\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0"))
-        ],
-        [
-          bts("Bob\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0"),
-          await keypair(bts("Bobsk\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0"))
-        ],
-        [
-          bts("Charlie\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0"),
-          await keypair(bts("Charliesk\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0"))
-        ],
-      ];
-      let votes = new Map();
-      for (let [did, key] of did_to_key) {
-        votes.set(did, { Sr25519: key.sign(encoded_state_change) });
-      }
-      let res = await sign_send_tx(nc.tx.master.execute(call, votes));
-      assert(res.status.isFinalized, "transaction was not included in block");
-      let sto = await nc.rpc.state.getStorage(new Bytes(null, [0xaa, 0xbb]).toU8a());
-      let bytes = sto.unwrap(); // this value is expected not to be None
-      assert(uint8array_eq(bytes, val), "storage item should have been set");
-    })();
-  }, 40000);
+  test('Root call with votes not sorted lexically', async () => {
+    let key = u8a_hex(randomish_u8a());
+    let val = u8a_hex(randomish_u8a());
+    const did_to_key = [
+      [BOB_DID, await keypair(BOB_SK)],
+      [ALICE_DID, await keypair(ALICE_SK)],
+    ];
+    await master_set_storage(nc, key, val, did_to_key);
+    let sto = await nc.rpc.state.getStorage(key);
+    let u8a = sto.unwrap();
+    expect(u8a_hex(u8a)).toEqual(val);
+  }, 20000);
 });
 
 // connect to running node
@@ -134,7 +146,8 @@ async function connect() {
 }
 
 // load a DID kp from secret
-async function keypair(seed /* Uint8Array */) {
+async function keypair(seed) {
+  assert(seed instanceof Uint8Array);
   await cryptoWaitReady();
   let keyring = new Keyring({ type: 'sr25519' });
   let key = keyring.addFromSeed(seed);
@@ -176,29 +189,67 @@ async function sign_send_tx(extrinsic) {
 async function get_test_account_key() {
   await cryptoWaitReady();
   let keyring = new Keyring(TestKeyringOpts);
-  let key = keyring.addFromUri('//Alice');
+  let key = keyring.addFromUri(TestAccountURI);
   return key
 }
 
-// prepend a length tag to a byte list
-// tag will encoded according to "Scale Codec"
-function add_len_prefix(bs /* array of integers */) {
-  assert(bs instanceof Array);
-  return new Bytes(null, bs).toU8a()
+// represent a Uint8Array as hex with a "0x" prefix
+function u8a_hex(bs) {
+  assert(bs instanceof Uint8Array);
+  return '0x' + [...bs].map(bt => ('0' + bt.toString(16)).slice(-2)).join('');
+}
+expect(u8a_hex(new Uint8Array([]))).toEqual('0x');
+expect(u8a_hex(new Uint8Array([0x01]))).toEqual('0x01');
+expect(u8a_hex(new Uint8Array([0xaa, 0xbb]))).toEqual('0xaabb');
+
+function randomish_u8a() {
+  let ret = new Uint8Array(32);
+  for (let i = 0; i < ret.length; i++) {
+    ret[i] = Math.random() * (2 ** 8);
+  }
+  return ret;
 }
 
-function todo(t) {
-  throw t || "TODO";
+async function master_set_storage(
+  nc, // node client
+  key, // hex encoded bytes
+  val, // hex encoded bytes
+  did_to_key, // list of (did, key) pairs with which to vote
+) {
+  let call = nc.tx.system.setStorage([[key, val]]); // this is a root-only extrinsic
+  let payload = {
+    proposal: [...nc.createType('Call', call).toU8a()],
+    round_no: await nc.query.master.round(),
+  };
+  let encoded_state_change = nc.createType('StateChange', { MasterVote: payload }).toU8a();
+
+  let dtk_sorted = [...did_to_key];
+  dtk_sorted.sort(([dida, _a], [didb, _b]) => compare_u8a_32(dida, didb));
+
+  let votes = new Map();
+  for (let [did, key] of dtk_sorted) {
+    votes.set(did, { Sr25519: key.sign(encoded_state_change) });
+  }
+  await sign_send_tx(nc.tx.master.execute(call, votes));
 }
 
-function uint8array_eq(a, b) {
+/// convert a string to utf-8 encoded bytes
+function bts(str) {
+  return new Uint8Array([...new TextEncoder("utf-8").encode(str)]);
+}
+
+// return -1 if a < b, 0 if a == b, 1 if a > b
+function compare_u8a_32(a, b) {
   assert(a instanceof Uint8Array);
   assert(b instanceof Uint8Array);
-  return a.byteLength === b.byteLength && a.every((_, i) => a[i] === b[i]);
-}
-
-function array_eq(a, b) {
-  assert(a instanceof Array);
-  assert(b instanceof Array);
-  return a.length === b.length && a.every((_, i) => a[i] === b[i]);
+  assert(a.length === 32);
+  assert(b.length === 32);
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] < b[i]) {
+      return -1;
+    } else if (b[i] < a[i]) {
+      return 1;
+    }
+  }
+  return 0;
 }

--- a/tests/integration/master.test.js
+++ b/tests/integration/master.test.js
@@ -3,7 +3,6 @@ import { ApiPromise, WsProvider, Keyring } from '@polkadot/api';
 import { cryptoWaitReady } from '@polkadot/util-crypto';
 import { FullNodeEndpoint, TestAccountURI, TestKeyringOpts } from '../test-constants';
 import { assert } from '@polkadot/util';
-import Bytes from '@polkadot/types/primitive/Bytes';
 
 const ALICE_DID = bts("Alice\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0");
 const BOB_DID = bts("Bob\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0");
@@ -22,32 +21,6 @@ describe('Master Module', () => {
   }, 40000);
 
   afterAll(async () => { await nc.disconnect(); }, 10000);
-
-  test('scale endoding of call', async () => {
-    // prepend a length tag to a byte list
-    // tag will encoded according to "Scale Codec"
-    function add_len_prefix(bs) {
-      return new Bytes(null, bs).toU8a()
-    }
-
-    let key = add_len_prefix([0xaa, 0xbb]);
-    let val = add_len_prefix([0xcc, 0xdd]);
-
-    let call = nc.tx.system.setStorage([[key, val]]);
-    let proposal = [...nc.createType('Call', call).toU8a()];
-    expect(proposal).toEqual([0, 6, 4, 8, 204, 221, 0]);
-    let payload = {
-      proposal,
-      round_no: 0,
-    };
-    let encoded_state_change = nc.createType('StateChange', { MasterVote: payload }).toU8a();
-    expect(encoded_state_change).toEqual(new Uint8Array([
-      6, // enum tag
-      7 << 2, // length tag of encoded call
-      0, 6, 4, 8, 204, 221, 0, // encoded call
-      0, 0, 0, 0, 0, 0, 0, 0 // 64 bit round number
-    ]));
-  })
 
   test('control: set and get bytes as sudo', async () => {
     let key = u8a_hex(randomish_u8a());

--- a/yarn.lock
+++ b/yarn.lock
@@ -2330,10 +2330,10 @@ elliptic@=3.0.3:
     hash.js "^1.0.0"
     inherits "^2.0.1"
 
-elliptic@^6.5.0, elliptic@^6.5.2, elliptic@^6.5.3:
-  version "6.5.3"
-  resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.5.3.tgz#cb59eb2efdaf73a0bd78ccd7015a62ad6e0f93d6"
-  integrity sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==
+elliptic@^6.5.0, elliptic@^6.5.2:
+  version "6.5.2"
+  resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.5.2.tgz#05c5678d7173c049d8ca433552224a495d0e3762"
+  integrity sha512-f4x70okzZbIQl/NSRLkI/+tteV/9WqL98zx+SQ69KbXxmVrmjwsNUPn/gYJJ0sHvEak24cZgHIPegRePAtA/xw==
   dependencies:
     bn.js "^4.4.0"
     brorand "^1.0.1"


### PR DESCRIPTION
This pr introduces integration tests for the Master module on the node. The tests are intended to be run against node at the head of `poa-1` in the dock-sdk repo: e4c5e318cd78d58a4af8de8907e4d90705138b66.

As mentioned in the comment below, this branch should be rebased onto `poa-1` of this repo. TODO

This branch has failing tests and lints but not related to the changes introduced. I think those failing tests and lints should be fixed separately, after merging.

You'll notice `master.test.js` does not use functions exported by the sdk.