### PR TITLE
implement keyupdate script

### DIFF
--- a/scripts/change_did_key.js
+++ b/scripts/change_did_key.js
@@ -1,21 +1,41 @@
+/// This script assumes that all keys are sr25519.
+///
+/// Warning: This script only supports sr25519 keys. Do not use it to set an non-sr25519 public key.
+///          If you do, you will lose control of your DID.
+
 import { Keyring } from '@polkadot/api';
 import { cryptoWaitReady } from '@polkadot/util-crypto';
-import { u8aToHex } from '@polkadot/util';
+import { u8aToHex, assert } from '@polkadot/util';
 import { createSignedKeyUpdate } from '../src/utils/did';
 import { getPublicKeyFromKeyringPair } from '../src/utils/misc';
 import { DockAPI, PublicKeySr25519 } from '../src/api';
 import b58 from 'bs58';
 
-/// This script is not configurable via command line. You will need to maually edit `main()`
-/// to input your own values.
-///
+require('dotenv').config();
+
 /// Use (with node running locally):
 ///
 /// ```bash
 /// cd sdk
 /// yarn
-/// npx babel-node ./scripts/change_did_key.js
+/// npx babel-node ./scripts/change_did_key.js args..
 /// ```
+
+const USAGE = `\
+npx babel-node ./scripts/change_did_key.js <did> <new_pk>
+  where
+    <did> is a 32 byte, 0x prefixed hex string.
+    <new_pk> is a 32 byte, 0x prefixed hex string.
+
+env vars:
+  - FullNodeEndpoint: websocket Url of a trusted node
+  - DidHolderSecret:  current secret key of the did. provided as a substrate secret URI
+  - PayerSecret:      secret key to the on-chain account that will submit the transaction
+                      this account pays transaction fees. provided as a substrate secret URI
+
+Warning: This script only supports sr25519 keys. Do not use it to set an non-sr25519 public key.
+         If you do, you will lose control of your DID.
+`;
 
 (async () => {
   await main();
@@ -26,36 +46,31 @@ import b58 from 'bs58';
 });
 
 async function main() {
-  /// This did is preregistered for local development chains.
-  const ALICE_DID = '0x416c696365000000000000000000000000000000000000000000000000000000';
-  /// The default keypair for "Alice\0\0\0..." on local developnent chains.
-  const ALICE_KP = {
-    sk: '0x416c696365736b00000000000000000000000000000000000000000000000000',
-    pk: '0xb8b868f83227df83240fdbefcaa2636bebf16304c9249069897b510b7d8bbd0b',
-  };
-  /// Some arbitray sr25519 keypair.
-  const TEST_KP = {
-    sk: '0x6b9abb2153e0e3989bb53869b4a88806941a0a86cefa08a7977aff73379df734',
-    pk: '0xc081a33d27d66ceda4e9f634f2f3a1b3b7f4ad898662036416250862ffae623f',
-  };
+  const {
+    FullNodeEndpoint,
+    DidHolderSecret,
+    PayerSecret,
+  } = process.env;
+  assert(FullNodeEndpoint !== undefined, "env var FullNodeEndpoint must be defined");
+  assert(DidHolderSecret !== undefined, "env var DidHolderSecret must be defined");
+  assert(PayerSecret !== undefined, "env var PayerSecret must be defined");
 
-  // set key to TEST_KP
+  if (process.argv.length !== 4) {
+    throw USAGE;
+  }
+  const [_, __, did, new_pk] = process.argv;
+  assertHex32(did);
+  assertHex32(new_pk);
+
   await updateDIDKey({
-    nodeWsUrl: 'ws://localhost:9944',
-    did: ALICE_DID,
-    currentSk: ALICE_KP.sk,
-    newPk: TEST_KP.pk,
-    payerSk: "//Bob"
+    nodeWsUrl: FullNodeEndpoint,
+    did,
+    currentSk: DidHolderSecret,
+    newPk: new_pk,
+    payerSk: PayerSecret,
   });
 
-  // set it back to the default
-  await updateDIDKey({
-    nodeWsUrl: 'ws://localhost:9944',
-    did: ALICE_DID,
-    currentSk: TEST_KP.sk,
-    newPk: ALICE_KP.pk,
-    payerSk: "//Bob"
-  });
+  console.log(`Public key for did ${did} successfully updated to ${new_pk}.`)
 }
 
 // This function assumes all keys are sr25519.
@@ -85,9 +100,7 @@ async function updateDIDKey({ nodeWsUrl, did, currentSk, newPk, payerSk }) {
   const finalPk = await getSr25519PkHex(dock, did);
   assert_equal(finalPk, newPk, "paid transaction did not take effect, something went wrong");
 
-  // when this script was written there was a bug that would cause the sript to block forever when
-  // this line was uncommented.
-  // await dock.disconnect();
+  await dock.disconnect();
 }
 
 // Load a sr25519 keypair from secret, secret may be "0x" prefixed hex seed
@@ -110,4 +123,28 @@ async function getSr25519PkHex(dock, did) {
   const pk = doc.publicKey[0];
   assert_equal(pk.type, 'Sr25519VerificationKey2020', "this script assumes sr25519");
   return u8aToHex(b58.decode(pk.publicKeyBase58));
+}
+
+function assertHex32(v) {
+  if (!isHex32(v)) {
+    throw `"${v}" is not valid as a 32 byte lowecase 0x-prefixed hex-string`;
+  }
+}
+
+function isHex32(v) {
+  if ((typeof v) !== 'string') {
+    throw "bad type passed to isHex32";
+  }
+  if (!v.startsWith("0x")) {
+    return false;
+  }
+  for (let c of v.slice(2)) {
+    if (!"0123456789abcdef".includes(c)) {
+      return false;
+    }
+  }
+  if (v.length !== 66) {
+    return false;
+  }
+  return true;
 }

--- a/scripts/change_did_key.js
+++ b/scripts/change_did_key.js
@@ -1,0 +1,113 @@
+import { Keyring } from '@polkadot/api';
+import { cryptoWaitReady } from '@polkadot/util-crypto';
+import { u8aToHex } from '@polkadot/util';
+import { createSignedKeyUpdate } from '../src/utils/did';
+import { getPublicKeyFromKeyringPair } from '../src/utils/misc';
+import { DockAPI, PublicKeySr25519 } from '../src/api';
+import b58 from 'bs58';
+
+/// This script is not configurable via command line. You will need to maually edit `main()`
+/// to input your own values.
+///
+/// Use (with node running locally):
+///
+/// ```bash
+/// cd sdk
+/// yarn
+/// npx babel-node ./scripts/change_did_key.js
+/// ```
+
+(async () => {
+  await main();
+  process.exit(0);
+})().catch(e => {
+  console.error(e);
+  process.exit(1);
+});
+
+async function main() {
+  /// This did is preregistered for local development chains.
+  const ALICE_DID = '0x416c696365000000000000000000000000000000000000000000000000000000';
+  /// The default keypair for "Alice\0\0\0..." on local developnent chains.
+  const ALICE_KP = {
+    sk: '0x416c696365736b00000000000000000000000000000000000000000000000000',
+    pk: '0xb8b868f83227df83240fdbefcaa2636bebf16304c9249069897b510b7d8bbd0b',
+  };
+  /// Some arbitray sr25519 keypair.
+  const TEST_KP = {
+    sk: '0x6b9abb2153e0e3989bb53869b4a88806941a0a86cefa08a7977aff73379df734',
+    pk: '0xc081a33d27d66ceda4e9f634f2f3a1b3b7f4ad898662036416250862ffae623f',
+  };
+
+  // set key to TEST_KP
+  await updateDIDKey({
+    nodeWsUrl: 'ws://localhost:9944',
+    did: ALICE_DID,
+    currentSk: ALICE_KP.sk,
+    newPk: TEST_KP.pk,
+    payerSk: "//Bob"
+  });
+
+  // set it back to the default
+  await updateDIDKey({
+    nodeWsUrl: 'ws://localhost:9944',
+    did: ALICE_DID,
+    currentSk: TEST_KP.sk,
+    newPk: ALICE_KP.pk,
+    payerSk: "//Bob"
+  });
+}
+
+// This function assumes all keys are sr25519.
+async function updateDIDKey({ nodeWsUrl, did, currentSk, newPk, payerSk }) {
+  const dock = new DockAPI();
+  await dock.init({ address: nodeWsUrl });
+  dock.setAccount(await keypair(payerSk));
+
+  const currentPair = await keypair(currentSk);
+  const currentPk = getPublicKeyFromKeyringPair(currentPair).value;
+
+  // check
+  let initialPk = await getSr25519PkHex(dock, did);
+  assert_equal(initialPk, currentPk, "provided secret key does not control this did");
+
+  const [keyUpdate, signature] = await createSignedKeyUpdate(
+    dock.did,
+    did,
+    new PublicKeySr25519(newPk),
+    currentPair,
+    undefined // we are not updating the controller
+  );
+
+  await dock.did.updateKey(keyUpdate, signature);
+
+  // check
+  const finalPk = await getSr25519PkHex(dock, did);
+  assert_equal(finalPk, newPk, "paid transaction did not take effect, something went wrong");
+
+  // when this script was written there was a bug that would cause the sript to block forever when
+  // this line was uncommented.
+  // await dock.disconnect();
+}
+
+// Load a sr25519 keypair from secret, secret may be "0x" prefixed hex seed
+// or seed phrase or "//DevKey/Derivation/Path".
+async function keypair(seed) {
+  await cryptoWaitReady();
+  let keyring = new Keyring({ type: 'sr25519' });
+  let key = keyring.addFromUri(seed);
+  return key
+}
+
+function assert_equal(a, b, note = 'equality assertion false') {
+  if (a !== b) {
+    throw `${note}\n${a} !== ${b}`;
+  }
+}
+
+async function getSr25519PkHex(dock, did) {
+  const doc = await dock.did.getDocument(did);
+  const pk = doc.publicKey[0];
+  assert_equal(pk.type, 'Sr25519VerificationKey2020', "this script assumes sr25519");
+  return u8aToHex(b58.decode(pk.publicKeyBase58));
+}

--- a/scripts/change_did_key.js
+++ b/scripts/change_did_key.js
@@ -6,7 +6,7 @@
 import { Keyring } from '@polkadot/api';
 import { cryptoWaitReady } from '@polkadot/util-crypto';
 import { u8aToHex, assert } from '@polkadot/util';
-import { createSignedKeyUpdate } from '../src/utils/did';
+import { createSignedKeyUpdate, getHexIdentifierFromDID } from '../src/utils/did';
 import { getPublicKeyFromKeyringPair } from '../src/utils/misc';
 import { DockAPI, PublicKeySr25519 } from '../src/api';
 import b58 from 'bs58';
@@ -24,7 +24,7 @@ require('dotenv').config();
 const USAGE = `\
 npx babel-node ./scripts/change_did_key.js <did> <new_pk>
   where
-    <did> is a 32 byte, 0x prefixed hex string.
+    <did> either a fully qualified dock did (did:dock:..) or a 32 byte hex string.
     <new_pk> is a 32 byte, 0x prefixed hex string.
 
 env vars:
@@ -35,6 +35,10 @@ env vars:
 
 Warning: This script only supports sr25519 keys. Do not use it to set an non-sr25519 public key.
          If you do, you will lose control of your DID.
+
+examples:
+- npx babel-node ./scripts/change_did_key.js 0x416c696365000000000000000000000000000000000000000000000000000000 0xb8b868f83227df83240fdbefcaa2636bebf16304c9249069897b510b7d8bbd0b
+- npx babel-node ./scripts/change_did_key.js did:dock:5DYVB5ouXwTKXwMJvKZP49Tv5RFUhJ2i6i4GXou6LpPQDtEL 0xb8b868f83227df83240fdbefcaa2636bebf16304c9249069897b510b7d8bbd0b
 `;
 
 (async () => {
@@ -58,7 +62,8 @@ async function main() {
   if (process.argv.length !== 4) {
     throw USAGE;
   }
-  const [_, __, did, new_pk] = process.argv;
+  const [_, __, did_arg, new_pk] = process.argv;
+  const did = getHexIdentifierFromDID(did_arg);
   assertHex32(did);
   assertHex32(new_pk);
 
@@ -70,7 +75,7 @@ async function main() {
     payerSk: PayerSecret,
   });
 
-  console.log(`Public key for did ${did} successfully updated to ${new_pk}.`)
+  console.log(`Public key for did ${did_arg} successfully updated to ${new_pk}.`)
 }
 
 // This function assumes all keys are sr25519.


### PR DESCRIPTION
Adds a script to update your own did key. This is needed in order to update the keys of master members on the vulcan testnet.

To save time I didn't add any argument parsing. Users will need to edit this script manually for now.

edit: I added argument parsing.
