### PR TITLE
update ssh agent github action to latest

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -31,7 +31,7 @@ jobs:
         run: yarn mdbook
 
       - name: Install SSH Client 🔑
-        uses: webfactory/ssh-agent@v0.2.0
+        uses: webfactory/ssh-agent@v0.4.1
         with:
           ssh-private-key: ${{ secrets.DEPLOY_KEY }}
 


### PR DESCRIPTION
Why? Because of this: https://github.com/docknetwork/sdk/runs/1427368060?check_suite_focus=true