### PR TITLE
Remove requirement for ID field to exist on credentialSubject in addSubject method

### DIFF
--- a/src/verifiable-credential.js
+++ b/src/verifiable-credential.js
@@ -147,7 +147,6 @@ class VerifiableCredential {
    * @returns {VerifiableCredential}
    */
   addSubject(subject) {
-    ensureObjectWithId(subject, 'credentialSubject');
     if (!this.credentialSubject || this.credentialSubject.length === 0) {
       this.credentialSubject = [subject];
     }

--- a/tests/unit/issuing.test.js
+++ b/tests/unit/issuing.test.js
@@ -306,10 +306,6 @@ describe('Verifiable Credential incremental creation', () => {
     }).toThrowError('needs to be a string.');
 
     expect(() => {
-      credential.addSubject({ some: 'value' });
-    }).toThrowError('"credentialSubject" must include the \'id\' property.');
-
-    expect(() => {
       credential.setStatus({ some: 'value', type: 'something' });
     }).toThrowError('"credentialStatus" must include the \'id\' property.');
     expect(() => {


### PR DESCRIPTION
It should be upto the creator to determine if ID is required or if they want to use other identifiable data in subject