### PR TITLE
Documentation legibility fixes

### DIFF
--- a/tutorials/src/concepts_vcdm.md
+++ b/tutorials/src/concepts_vcdm.md
@@ -1,9 +1,25 @@
 # Verifiable Credentials
-Credentials are a part of our daily lives: driver's licenses are used to assert that we are capable of operating a motor vehicle, university degrees can be used to assert our level of education, and government-issued passports enable us to travel between countries. These credentials provide benefits to us when used in the physical world, but their use on the Web continues to be elusive.
 
-Currently it is difficult to express education qualifications, healthcare data, financial account details, and other sorts of third-party verified machine-readable personal information on the Web. The difficulty of expressing digital credentials on the Web makes it challenging to receive the same benefits through the Web that physical credentials provide us in the physical world.
+Credentials are a part of our daily lives: driver's licenses are used to
+assert that we are capable of operating a motor vehicle, university degrees
+can be used to assert our level of education, and government-issued passports
+enable us to travel between countries.
 
-The [Verifiable Credentials Data Model 1.0 (VCDM)](https://www.w3.org/TR/vc-data-model/) specification provides a standard way to express credentials on the Web in a way that is cryptographically secure, privacy respecting, and machine-verifiable.
+These credentials provide benefits to us when used in the physical world, but
+their use on the Web continues to be elusive.
+
+Currently it is difficult to express education qualifications, healthcare
+data, financial account details, and other sorts of third-party verified
+machine-readable personal information on the Web.
+
+The difficulty of expressing digital credentials on the Web makes it
+challenging to receive the same benefits through the Web that physical
+credentials provide us in the physical world.
+
+The [Verifiable Credentials Data Model 1.0 (VCDM)](https://www.w3.org/TR/vc-data-model/)
+specification provides a standard way to express credentials on the Web in a
+way that is cryptographically secure, privacy respecting, and
+machine-verifiable.
 
 ## Participants and workflow
 - Credentials are issued by an entity called the **issuer**.

--- a/tutorials/src/tutorial_did.md
+++ b/tutorials/src/tutorial_did.md
@@ -4,14 +4,18 @@ If you are not familiar with DIDs, you can get a conceptual overview [here](./co
 
 ## Overview
 DIDs in Dock are created by choosing a 32 byte unique (on Dock chain) identifier along with a public key. The public key
-can be changed by providing a signature with the currently active key. The DID can also be removed by providing a signature
-with the currently active key. As of now, a DID can have only one key at a time.
+can be changed by providing a signature with the currently active key.
+
+The DID can also be removed by providing a signature with the currently active key. As of now, a DID can have only one key
+at a time.
+
 The chain-state stores a few things for a DID, the current public key, the controller and the block number when the DID was
 last updated, so in the beginning the block number would be the one where the DID was created, when a DID's key is updated,
-that block number is changed to the one in which the key got updated. This is done for replay protection as every
-update (or removal) to the DID must include the last block number where the DID was updated and after each update the block
-number changes, thus giving replay protection. This detail however is hidden in the API so the caller should not have to worry
-about this.
+that block number is changed to the one in which the key got updated.
+
+This is done for replay protection as every update (or removal) to the DID must include the last block number where the DID
+was updated and after each update the block number changes, thus giving replay protection. This detail however is hidden in
+the API so the caller should not have to worry about this.
 
 ## DID creation
 Create a new random DID.
@@ -25,8 +29,11 @@ The DID is not yet registered on the chain. Before the DID can be registered, a 
 
 ## Public key creation
 Dock supports 3 kinds of public keys, Sr25519, Ed25519 and EcdsaSecp256k1. These public keys are supported
-through 3 classes, `PublicKeySr25519`, `PublicKeyEd25519` and `PublicKeySecp256k1` respectively. These 3 classes
-extend from the same class called `PublicKey`. These can be instantiated directly by passing them as hex encoded bytes
+through 3 classes, `PublicKeySr25519`, `PublicKeyEd25519` and `PublicKeySecp256k1` respectively.
+
+These 3 classes extend from the same class called `PublicKey`. These can be instantiated directly by passing them as hex
+encoded bytes.
+
 ```js
 import {PublicKeySr25519, PublicKeyEd25519, PublicKeySecp256k1} from '@docknetwork/sdk/api';
 
@@ -69,8 +76,11 @@ const publicKey = getPublicKeyFromKeyringPair(pair);
 Now that you have a DID and a public key, the DID can be registered on the Dock chain. Note that this public key associated
 with DID is independent of the key used for sending the transaction and paying the fees.
 1. First create a key detail object. The first argument of this function is a `PublicKey` and the second argument is
-the controller. The controller is the DID that controls the public key and this can be the same as the DID being
-registered.
+the controller.
+
+    The controller is the DID that controls the public key and this can be the same as the DID being
+    registered.
+
     ```js
     import {createKeyDetail} from '@docknetwork/sdk/utils/did';
     const keyDetail = createKeyDetail(publicKey, did);
@@ -137,6 +147,8 @@ with `createDidRemoval` to pass to the signer and get the signature
    ```
 
 
-Note that they accounts used to send the transactions are independent of the keys associated with the DID. So the DID could
-have been created with one account, updated with another account and removed with another account. The accounts are not relevant
-in the data model and not associated with the DID in the chain-state.
+Note that they accounts used to send the transactions are independent of the keys associated with the DID.
+
+So the DID could have been created with one account, updated with another account and removed with another account.
+
+The accounts are not relevant in the data model and not associated with the DID in the chain-state.

--- a/tutorials/src/tutorial_ipv.md
+++ b/tutorials/src/tutorial_ipv.md
@@ -45,12 +45,22 @@ This Credential isn't signed since we only just initialized it. It brings howeve
 >    vc.credentialSubject
 <-   []
 ```
-The default `context` is an array with `"https://www.w3.org/2018/credentials/v1"` as first element. This is required by the VCDMv1 specs so having it as default helps ensure your Verifiable Credentials will be valid in the end.
-A similar approach was taken on the `type` property, where the default is an array with `"VerifiableCredential"` already populated. This is also required by the specs.
-The `subject` property is required to exist, so this is already initialized for you as well although it is empty for now.
-Finally the `issuanceDate` is also set to the moment you initialized the `VerifiableCredential` object. You can change this later if desired but it helps having it in the right format from the get go.
+The default `context` is an array with
+`"https://www.w3.org/2018/credentials/v1"` as first element. This is required
+by the VCDMv1 specs so having it as default helps ensure your Verifiable
+Credentials will be valid in the end.
 
-We could also have checked those defaults more easily by checking the Verifiable Credential's JSON representation.
+A similar approach was taken on the `type` property, where the default is an
+array with `"VerifiableCredential"` already populated. This is also required
+by the specs. The `subject` property is required to exist, so this is already
+initialized for you as well although it is empty for now. Finally the
+`issuanceDate` is also set to the moment you initialized the
+`VerifiableCredential` object. You can change this later if desired but it
+helps having it in the right format from the get go.
+
+We could also have checked those defaults more easily by checking the
+Verifiable Credential's JSON representation.
+
 This can be achieved by calling the `toJSON()` method on it:
 ```javascript
 >    vc.toJSON()
@@ -64,9 +74,20 @@ This can be achieved by calling the `toJSON()` method on it:
        "issuanceDate": "2020-04-14T14:48:48.486Z"
      }
 ```
-An interesting thing to note here is the transformation happening to some of the root level keys in the JSON representation of a `VerifiableCredential` object. For example `context` gets transformed into `@context` and `subject` into `credentialSubject`. This is to ensure compliance with the Verifiable Credential Data Model specs while at the same time providing you with a clean interface to the `VerifiableCredential` class in your code.
+An interesting thing to note here is the transformation happening to some of
+the root level keys in the JSON representation of a `VerifiableCredential`
+object.
 
-Once your Verifiable Credential has been initialized, you can proceed to use the rest of the building functions to define it completely before finally signing it.
+For example `context` gets transformed into `@context` and `subject`
+into `credentialSubject`.
+
+This is to ensure compliance with the Verifiable Credential Data Model specs
+while at the same time providing you with a clean interface to the
+`VerifiableCredential` class in your code.
+
+Once your Verifiable Credential has been initialized, you can proceed to use
+the rest of the building functions to define it completely before finally
+signing it.
 
 #### Adding a Context
 A context can be added with the `addContext` method. It accepts a single argument `context` which can either be a string (in which case it needs to be a valid URI), or an object:
@@ -110,8 +131,16 @@ A status can be set with the `setStatus` function. It accepts a single argument 
 ```
 
 #### Setting the Issuance Date
-The issuance date is set by default to the datetime you first initialize your `VerifiableCredential` object. This means that you don't necessarily need to call this method to achieve a valid Verifiable Credential (which are required to have an issuanceDate property).
-However, if you need to change this date you can use the `setIssuanceDate` method. It takes a single argument `issuanceDate` that needs to be a string with a valid ISO formatted datetime:
+The issuance date is set by default to the datetime you first initialize your
+`VerifiableCredential` object.
+
+This means that you don't necessarily need to
+call this method to achieve a valid Verifiable Credential (which are required
+to have an issuanceDate property).
+
+However, if you need to change this date you can use the `setIssuanceDate`
+method. It takes a single argument `issuanceDate` that needs to be a string
+with a valid ISO formatted datetime:
 ```javascript
 >   vc.issuanceDate
 <-  "2020-04-14T14:48:48.486Z"
@@ -121,7 +150,11 @@ However, if you need to change this date you can use the `setIssuanceDate` metho
 ```
 
 #### Setting an Expiration Date
-An expiration date is not set by default as it isn't required by the specs. If you wish to set one, you can use the `setExpirationDate` method. It takes a single argument `expirationDate` that needs to be a string with a valid ISO formatted datetime:
+An expiration date is not set by default as it isn't required by the specs.
+If you wish to set one, you can use the `setExpirationDate` method.
+
+It takes a single argument `expirationDate` that needs to be a string with a
+valid ISO formatted datetime:
 ```javascript
 >   vc.setExpirationDate("2029-01-01T14:48:48.486Z")
 >   vc.expirationDate
@@ -129,7 +162,12 @@ An expiration date is not set by default as it isn't required by the specs. If y
 ```
 
 ### Signing a Verifiable Credential
-Once you've crafted your Verifiable Credential it is time to sign it. This can be achieved with the `sign` method. It requires a `keyDoc` parameter (an object with the params and keys you'll use for signing) and it also accepts a boolean `compactProof` that determines whether you want to compact the JSON-LD or not:
+Once you've crafted your Verifiable Credential it is time to sign it. This
+can be achieved with the `sign` method.
+
+It requires a `keyDoc` parameter (an object with the params and keys you'll
+use for signing) and it also accepts a boolean `compactProof` that determines
+whether you want to compact the JSON-LD or not:
 ```javascript
 >   await vc.sign(keyDoc)
 ```
@@ -147,9 +185,23 @@ Once done, your `vc` object will have a new `proof` field:
 ```
 
 ### Verifying a Verifiable Credential
-Once your Verifiable Credential has been signed you can proceed to verify it with the `verify` method. The `verify` method takes an object of arguments, and is optional. If you've used DIDs you need to pass a `resolver` for them. You can also use the booleans `compactProof` (to compact the JSON-LD) and `forceRevocationCheck` (to force revocation check). Please beware that setting `forceRevocationCheck` to false can allow false positives when verifying revocable credentials.
-If your credential has uses the `status` field, you can pass a `revocationApi` param that accepts an object describing the API to use for the revocation check. No params are required for the simplest cases:
-If your credential uses schema and requires blob resolution, you can pass a `schemaApi` param that accepts an object describing the API to pull the schema from chain. No params are required for the simplest cases:
+Once your Verifiable Credential has been signed you can proceed to verify it
+with the `verify` method. The `verify` method takes an object of arguments,
+and is optional.
+
+If you've used DIDs you need to pass a `resolver` for them.
+You can also use the booleans `compactProof` (to compact the JSON-LD) and
+`forceRevocationCheck` (to force revocation check). Please beware that
+setting `forceRevocationCheck` to false can allow false positives when
+verifying revocable credentials.
+
+If your credential has uses the `status` field, you can pass a
+`revocationApi` param that accepts an object describing the API to use for
+the revocation check. No params are required for the simplest cases:
+
+If your credential uses schema and requires blob resolution, you can pass a
+`schemaApi` param that accepts an object describing the API to pull the
+schema from chain. No params are required for the simplest cases:
 ```javascript
 >   const result = await vc.verify({ ... })
 >   result
@@ -172,21 +224,33 @@ If your credential uses schema and requires blob resolution, you can pass a `sch
       ]
     }
 ```
-Please note that the verification is an async process that returns an object when the promise resolves. A boolean value for the entire verification process can be checked at the root level `verified` property.
+Please note that the verification is an async process that returns an object
+when the promise resolves. A boolean value for the entire verification
+process can be checked at the root level `verified` property.
 
 -------------
 
 ## Incremental creation and verification of Verifiable Presentations
-The `client-sdk` exposes a `VerifiablePresentation` class that is useful to incrementally create valid Verifiable Presentations of any type, sign them and verify them.
-Once the presentation is initialized, you can sequentially call the different methods provided by the class to add `contexts`, `types`, `holders` and `credentials`.
+The `client-sdk` exposes a `VerifiablePresentation` class that is useful to
+incrementally create valid Verifiable Presentations of any type, sign them
+and verify them.
+
+Once the presentation is initialized, you can sequentially call the different
+methods provided by the class to add `contexts`, `types`, `holders` and
+`credentials`.
 
 ### Building a Verifiable Presentation
-The first step to build a Verifiable Presentation is to initialize it, we can do that using the `VerifiablePresentation` class constructor which takes an `id` as sole argument:
+The first step to build a Verifiable Presentation is to initialize it, we can
+do that using the `VerifiablePresentation` class constructor which takes an
+`id` as sole argument:
 ```javascript
 let vp = new VerifiablePresentation('http://example.edu/credentials/1986');
 ```
+
 You now have an unsigned Verifiable Presentation in the `vp` variable!
-This Presentation isn't signed since we only just initialized it. It brings however some useful defaults to make your life easier.
+
+This Presentation isn't signed since we only just initialized it. It brings
+however some useful defaults to make your life easier.
 ```javascript
 >    vp.context
 <-   ["https://www.w3.org/2018/credentials/v1"]
@@ -195,11 +259,21 @@ This Presentation isn't signed since we only just initialized it. It brings howe
 >    vp.credentials
 <-   []
 ```
-The default `context` is an array with `"https://www.w3.org/2018/credentials/v1"` as first element. This is required by the VCDMv1 specs so having it as default helps ensure your Verifiable Presentations will be valid in the end.
-A similar approach was taken on the `type` property, where the default is an array with `"VerifiablePresentation"` already populated. This is also required by the specs.
-The `credentials` property is required to exist, so this is already initialized for you as well although it is empty for now.
+The default `context` is an array with
+`"https://www.w3.org/2018/credentials/v1"` as first element. This is required
+by the VCDMv1 specs so having it as default helps ensure your Verifiable
+Presentations will be valid in the end.
 
-We could also have checked those defaults more easily by checking the Verifiable Presentation's JSON representation.
+A similar approach was taken on the `type` property, where the default is an
+array with `"VerifiablePresentation"` already populated. This is also
+required by the specs.
+
+The `credentials` property is required to exist, so this is already
+initialized for you as well although it is empty for now.
+
+We could also have checked those defaults more easily by checking the
+Verifiable Presentation's JSON representation.
+
 This can be achieved by calling the `toJSON()` method on it:
 ```javascript
 >    vp.toJSON()
@@ -212,12 +286,23 @@ This can be achieved by calling the `toJSON()` method on it:
        "verifiableCredential": [],
      }
 ```
-An interesting thing to note here is the transformation happening to some of the root level keys in the JSON representation of a `VerifiablePresentation` object. For example `context` gets transformed into `@context` and `credentials` into `verifiableCredential`. This is to ensure compliance with the Verifiable Credentials Data Model specs while at the same time providing you with a clean interface to the `VerifiablePresentation` class in your code.
+An interesting thing to note here is the transformation happening to some of
+the root level keys in the JSON representation of a `VerifiablePresentation`
+object.
 
-Once your Verifiable Presentation has been initialized, you can proceed to use the rest of the building functions to define it completely before finally signing it.
+For example `context` gets transformed into `@context` and `credentials` into
+`verifiableCredential`. This is to ensure compliance with the Verifiable
+Credentials Data Model specs while at the same time providing you with a
+clean interface to the `VerifiablePresentation` class in your code.
+
+Once your Verifiable Presentation has been initialized, you can proceed to
+use the rest of the building functions to define it completely before finally
+signing it.
 
 #### Adding a Context
-A context can be added with the `addContext` method. It accepts a single argument `context` which can either be a string (in which case it needs to be a valid URI), or an object
+A context can be added with the `addContext` method. It accepts a single
+argument `context` which can either be a string (in which case it needs to be
+a valid URI), or an object
 ```javascript
 >   vp.addContext('https://www.w3.org/2018/credentials/examples/v1')
 >   vp.context
@@ -239,7 +324,9 @@ A type can be added with the `addType` function. It accepts a single argument `t
 ```
 
 #### Setting a Holder
-Setting a Holder is optional and it can be achieved using the `setHolder` method. It accepts a single argument `type` that needs to be a string (a URI for the entity that is generating the presentation):
+Setting a Holder is optional and it can be achieved using the `setHolder`
+method. It accepts a single argument `type` that needs to be a string (a URI
+for the entity that is generating the presentation):
 ```javascript
 >   vp.setHolder('https://example.com/credentials/1234567890');
 >   vp.holder
@@ -248,7 +335,10 @@ Setting a Holder is optional and it can be achieved using the `setHolder` method
 
 #### Adding a Verifiable Credential
 Your Verifiable Presentations can contain one or more Verifiable Credentials inside.
-Adding a Verifiable Credential can be achieved using the `addCredential` method. It accepts a single argument `credential` that needs to be an object (a valid, signed Verifiable Credential):
+
+Adding a Verifiable Credential can be achieved using the `addCredential`
+method. It accepts a single argument `credential` that needs to be an object
+(a valid, signed Verifiable Credential):
 ```javascript
 >   vp.addCredential(vc);
 >   vp.credentials
@@ -260,8 +350,16 @@ Please note that the example was truncated to enhance readability.
 
 
 ### Signing a Verifiable Presentation
-Once you've crafted your Verifiable Presentation and added your Verifiable Credentials to it, it is time to sign it.
-This can be achieved with the `sign` method. It requires a `keyDoc` parameter (an object with the params and keys you'll use for signing), and a `challenge` string for the proof. It also accepts a `domain` string for the proof, a `resolver` in case you're using DIDs and a boolean `compactProof` that determines whether you want to compact the JSON-LD or not:
+Once you've crafted your Verifiable Presentation and added your Verifiable
+Credentials to it, it is time to sign it.
+
+This can be achieved with the `sign` method. It requires a `keyDoc` parameter
+(an object with the params and keys you'll use for signing), and a
+`challenge` string for the proof.
+
+It also accepts a `domain` string for the proof, a `resolver` in case you're
+using DIDs and a boolean `compactProof` that determines whether you want to
+compact the JSON-LD or not:
 ```javascript
 >   await vp.sign(
           keyDoc,
@@ -285,10 +383,20 @@ Once done, your `vp` object will have a new `proof` field:
 ```
 
 ### Verifying a Verifiable Presentation
-Once your Verifiable Presentation has been signed you can proceed to verify it with the `verify` method.
-If you've used DIDs you need to pass a `resolver` for them. You can also use the booleans `compactProof` (to compact the JSON-LD) and `forceRevocationCheck` (to force revocation check). Please beware that setting `forceRevocationCheck` to false can allow false positives when verifying revocable credentials.
-If your credential has uses the `status` field, you can pass a `revocationApi` param that accepts an object describing the API to use for the revocation check.
-For the simplest cases you only need a `challenge` string and possibly a `domain` string:
+Once your Verifiable Presentation has been signed you can proceed to verify
+it with the `verify` method.
+
+If you've used DIDs you need to pass a `resolver` for them. You can also use
+the booleans `compactProof` (to compact the JSON-LD) and
+`forceRevocationCheck` (to force revocation check). Please beware that
+setting `forceRevocationCheck` to false can allow false positives when
+verifying revocable credentials.
+
+If your credential has uses the `status` field, you can pass a
+`revocationApi` param that accepts an object describing the API to use for
+the revocation check.
+For the simplest cases you only need a `challenge` string and possibly a
+`domain` string:
 ```javascript
 >   const results = await vp.verify({ challenge: 'some_challenge', domain: 'some_domain' });
 >   results
@@ -332,13 +440,26 @@ For the simplest cases you only need a `challenge` string and possibly a `domain
       ]
     }
 ```
-Please note that the verification is an async process that returns an object when the promise resolves. This object contains separate results for the verification processes of the included Verifiable Credentials and the overall Verifiable Presentation. A boolean value for the entire verification process can be checked at the root level `verified` property.
+Please note that the verification is an async process that returns an object
+when the promise resolves.
+
+This object contains separate results for the verification processes of the
+included Verifiable Credentials and the overall Verifiable Presentation.
+
+A boolean value for the entire verification process can be checked at the
+root level `verified` property.
 
 ## Using DIDs
-The examples shown above use different kinds of URIs as `id` property of different sections. It is worth mentioning that the use of DIDs is not only supported but also encouraged.
+The examples shown above use different kinds of URIs as `id` property of
+different sections. It is worth mentioning that the use of DIDs is not only
+supported but also encouraged.
+
 Their usage is very simple: create as many DIDs as you need and then use them instead of the URIs shown above.
+
 For example when adding a subject to a Verifiable Credential here we're using a DID instead of a regular URI in the `id` property of the object:`vc.addSubject({ id: 'did:dock:123qwe123qwe123qwe', alumniOf: 'Example University' })`.
+
 If you don't know how to create a DID there's a specific [tutorial on DIDs](tutorial_did.md) you can read.
+
 Bear in mind that you will need to provide a `resolver` method if you decide to use DIDs in your Verifiable Credentials or Verifiable Presentations. More on resolvers can be found in the [tutorial on Resolvers](tutorial_resolver.md).
 
 Here's an example of issuing a Verifiable Credential using DIDs, provided that you've created and a DID that you store in `issuerDID`:
@@ -350,10 +471,19 @@ console.log(verificationResult.verified); // Should print `true`
 ```
 
 ## Creating a keyDoc
-It can be seen from the above examples that signing of credentials and presentations require keypairs to be formatted into a `keyDoc` object.
-There is a helper function to help with this formatting, it's called `getKeyDoc` and it is located in the `vc` helpers.
-Its usage is very simple, it accepts a `did` string which is a DID in fully qualified form, a `keypair` object (generated by either using polkadot-js's keyring for Sr25519 and Ed25519 or keypair generated with `generateEcdsaSecp256k1Keypair` for curve secp256k1)
-and a `type` string containing the type of the provided key (one of the supported 'Sr25519VerificationKey2020', 'Ed25519VerificationKey2018' or 'EcdsaSecp256k1VerificationKey2019'):
+It can be seen from the above examples that signing of credentials and
+presentations require keypairs to be formatted into a `keyDoc` object.
+
+There is a helper function to help with this formatting, it's called
+`getKeyDoc` and it is located in the `vc` helpers.
+
+Its usage is very simple, it accepts a `did` string which is a DID in fully
+qualified form, a `keypair` object (generated by either using polkadot-js's
+keyring for Sr25519 and Ed25519 or keypair generated with
+`generateEcdsaSecp256k1Keypair` for curve secp256k1)
+and a `type` string containing the type of the provided key (one of the
+supported 'Sr25519VerificationKey2020', 'Ed25519VerificationKey2018' or
+'EcdsaSecp256k1VerificationKey2019'):
 ```javascript
   const keyDoc = getKeyDoc(did, keypair, type)
 ```

--- a/tutorials/src/tutorial_resolver.md
+++ b/tutorials/src/tutorial_resolver.md
@@ -1,18 +1,26 @@
 # DID resolver
 
 The process of learning the DID Document of a DID is called DID resolution and tool that does the resolution is called the
-resolver. Resolution involves looking at the DID method and then fetching the DID Document from the registry, the registry
-might be a centralized database or a blockchain. The SDK supports resolving Dock DIDs natively.
-For other DIDs, resolving the DID through the [Universal Resolver](https://uniresolver.io) is supported.
+resolver.
+
+Resolution involves looking at the DID method and then fetching the DID Document from the registry, the registry
+might be a centralized database or a blockchain.
+
+The SDK supports resolving Dock DIDs natively. For other DIDs, resolving the DID through the
+[Universal Resolver](https://uniresolver.io) is supported.
 
 Each resolver should extend the class `DIDResolver` and implement the `resolve` method that accepts a DID and returns the
-DID document. There is another class called `MultiResolver` that can accept several types of resolvers (objects of subclasses
+DID document.
+
+There is another class called `MultiResolver` that can accept several types of resolvers (objects of subclasses
 of `DIDResolver`) and once the `MultiResolver` is initialized with the resolvers of different DID methods, it can resolve
 DIDs of those methods.
 
 ## Dock resolver
-The resolver for Dock DIDs `DockResolver` connects to the Dock blockchain to get the DID details. The resolver is
-constructed by passing it a Dock API object so that it can connect to a Dock node. This is how you resolve a Dock DID:
+The resolver for Dock DIDs `DockResolver` connects to the Dock blockchain to get the DID details.
+
+The resolver is constructed by passing it a Dock API object so that it can connect to a Dock node.
+This is how you resolve a Dock DID:
 ```js
 import { DockResolver } from '@docknetwork/sdk/resolver';
 
@@ -24,8 +32,10 @@ const didDocument = dockResolver.resolve('dock:did:5D.....');
 
 ## Creating a resolver class for a different method
 If you want to resolve DIDs other than Dock and do not have/want access to the universal resolver, you can extend the
-`DIDResolver` class to create a custom resolver. Following is an example to build a custom Ethereum resolver. It uses the
-library [ethr-did-resolver](https://github.com/decentralized-identity/ethr-did-resolver) and accepts a provider information
+`DIDResolver` class to create a custom resolver.
+
+Following is an example to build a custom Ethereum resolver. It uses the library
+[ethr-did-resolver](https://github.com/decentralized-identity/ethr-did-resolver) and accepts a provider information
 as configuration. The example below uses Infura to get access to an Ethereum node and read the DID off Ethereum.
 
 ```js
@@ -83,9 +93,13 @@ const didDocument = universalResolver.resolve('did:btcr:xk....');
 
 ## Resolving DIDs of several DID methods with a single resolver
 In case you need to resolve DIDs from more than one method, a `MultiResolver` object can be created by passing
-resolvers of various DID methods. The `MultiResolver` also accepts a `UniversalResolver` as an optional parameter which
+resolvers of various DID methods.
+
+The `MultiResolver` also accepts a `UniversalResolver` as an optional parameter which
 is used when a DID for an unknown method needs to be resolved. The `resolvers` object below has resolvers for DID methods
-`dock` and `ethr`. For resolving DID of any other method, the given `UniversalResolver` object will be used.
+`dock` and `ethr`.
+
+For resolving DID of any other method, the given `UniversalResolver` object will be used.
 ```js
 import { MultiResolver } from '@docknetwork/sdk/resolver';
 


### PR DESCRIPTION
When I was reading the documentation I found it very hard for my eyes to scan the text, this PR fixes some of that.

For example, I changed:
![image](https://user-images.githubusercontent.com/160117/108445973-1c19f700-723c-11eb-8d46-bdd573f52ae7.png)

to:
![image](https://user-images.githubusercontent.com/160117/108445986-220fd800-723c-11eb-809d-68540863f53d.png)
