### PR TITLE
Quads

### DIFF
--- a/example/claim-deduction.js
+++ b/example/claim-deduction.js
@@ -46,7 +46,7 @@ const sampleRules = [
         { Unbound: 'p' },
         { Unbound: 'o' },
         { Bound: { Iri: 'did:sample:issuer' } },
-      ]
+      ],
     ],
     then: [
       [

--- a/example/claim-deduction.js
+++ b/example/claim-deduction.js
@@ -42,31 +42,18 @@ const sampleRules = [
   {
     if_all: [
       [
-        { Bound: { Iri: 'did:sample:issuer' } },
-        { Bound: { Iri: 'https://www.dock.io/rdf2020#claimsV1' } },
-        { Unbound: 'c' },
-      ],
-      [
-        { Unbound: 'c' },
-        { Bound: { Iri: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#subject' } },
         { Unbound: 's' },
-      ],
-      [
-        { Unbound: 'c' },
-        { Bound: { Iri: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate' } },
         { Unbound: 'p' },
-      ],
-      [
-        { Unbound: 'c' },
-        { Bound: { Iri: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#object' } },
         { Unbound: 'o' },
-      ],
+        { Bound: { Iri: 'did:sample:issuer' } },
+      ]
     ],
     then: [
       [
         { Unbound: 's' },
         { Unbound: 'p' },
         { Unbound: 'o' },
+        { Bound: { DefaultGraph: true } },
       ],
     ],
   },
@@ -77,6 +64,7 @@ const sampleRules = [
         { Unbound: 'a' },
         { Bound: { Iri: frobs } },
         { Unbound: 'b' },
+        { Unbound: 'g' },
       ],
     ],
     then: [
@@ -84,6 +72,7 @@ const sampleRules = [
         { Unbound: 'b' },
         { Bound: { Iri: frobs } },
         { Unbound: 'a' },
+        { Unbound: 'g' },
       ],
     ],
   },
@@ -94,6 +83,7 @@ const sampleToProve = [
   { Iri: 'https://example.com/bbb' },
   { Iri: frobs },
   { Iri: 'https://example.com/aaa' },
+  { DefaultGraph: true },
 ];
 
 // accept a presentation with a proof of composite claims

--- a/package.json
+++ b/package.json
@@ -97,6 +97,6 @@
     "jsonld-signatures": "https://github.com/docknetwork/jsonld-signatures",
     "jsonschema": "^1.2.6",
     "mrklt": "^0.2.0",
-    "rify": "^0.6.0-rc.1"
+    "rify": "^0.6.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -97,6 +97,6 @@
     "jsonld-signatures": "https://github.com/docknetwork/jsonld-signatures",
     "jsonschema": "^1.2.6",
     "mrklt": "^0.2.0",
-    "rify": "^0.4.0"
+    "rify": "^0.6.0-rc.1"
   }
 }

--- a/src/utils/canonicalize.js
+++ b/src/utils/canonicalize.js
@@ -93,6 +93,8 @@ function orderKeys(a) {
         ret[k] = orderKeys(a[k]);
       }
       return ret;
+    case 'boolean':
+      return a;
     default:
       throw new TypeError(`type error: orderKeys() does not accept type ${typeof a}`);
   }

--- a/src/utils/claimgraph.js
+++ b/src/utils/claimgraph.js
@@ -1,13 +1,20 @@
-// A claimgraph is expressed as list of rdf triples.
-// A triple contains three Nodes, subject, property, and object.
-// A Node may be either:
+// A claimgraph is expressed as list of rdf quads.
+// A quad contains four Terms, subject, property, object and graph.
+// A Term may be either:
 // an IRI: `{ Iri: '<iri>' }`,
 // a blank node: `{ Blank: '<string>' }`,
-// or a literal node: `{ Literal: { value: '<string>', datatype: '<iri>' } }`
+// a literal node: `{ Literal: { value: '<string>', datatype: '<iri>' } }`
+// or the default graph: `{ DefaultGraph: true }`
 //
 // In compliance with https://www.w3.org/TR/rdf11-concepts/#section-Graph-Literal
 // a literal node must have a language tag if and only if datatype is
 // `http://www.w3.org/1999/02/22-rdf-syntax-ns#langString`
+//
+// The value of any DefualtGraph object must be `true`.
+//   Valid: `{ DefaultGraph: true }`
+//   Invalid: `{ DefaultGraph: false }`
+//   Invalid: `{ DefaultGraph: '' }`
+//   Invalid: `{ DefaultGraph: null }`
 //
 // ```
 // { Literal: {
@@ -20,7 +27,7 @@
 // This module implements utilities for operating on claimgraphs if the above format.
 
 import { assert } from '@polkadot/util';
-import { deepClone, assertValidClaimGraph, assertType } from './common';
+import { deepClone, assertValidClaimGraph } from './common';
 
 export const claims = { Iri: 'https://www.dock.io/rdf2020#claimsV1' };
 
@@ -28,15 +35,17 @@ export const claims = { Iri: 'https://www.dock.io/rdf2020#claimsV1' };
 // https://github.com/digitalbazaar/jsonld.js/blob/983cd849f56180e2ee4552ca25dd52b293174830/lib/toRdf.js
 // to this module's representation.
 export function fromJsonldjsCg(jcg) {
-  return jcg.map(
-    ({ subject, predicate, object }) => [subject, predicate, object].map(fromJsonldjsNode),
-  );
+  return jcg.map(({
+    subject, predicate, object, graph,
+  }) => [subject, predicate, object, graph].map(fromJsonldjsNode));
 }
 
 // convert a single node from json-ld claimgraph representation to this module's representation.
 function fromJsonldjsNode(jn) {
   let ret;
   switch (jn.termType) {
+    case 'DefaultGraph':
+      return { DefaultGraph: true };
     case 'NamedNode':
       return { Iri: jn.value };
     case 'BlankNode':
@@ -100,42 +109,6 @@ export function merge(claimgraphs) {
     namer.reallocateNames(cg);
   }
   return cgs.flat(1);
-}
-
-//
-
-/**
- * Convert claimgraph to Explicit Ethos form.
- * https://www.w3.org/TR/WD-rdf-syntax-971002/ , 2.2. Utility Relations; "Layer 1", reification
- *
- * @param {Object[]} claimgraph
- * @param {string} issuerIRI
- * @returns {Object[]}
- */
-export function asEE(claimgraph, issuerIRI) {
-  assertType(issuerIRI, 'string');
-  const cg = deepClone(claimgraph);
-  const namer = new Namer();
-  namer.reallocateNames(cg);
-  const ret = [];
-  for (const [s, p, o] of cg) {
-    const statement = namer.next();
-    ret.push([{ Iri: issuerIRI }, claims, statement]);
-    ret.push([statement, rdf('subject'), s]);
-    ret.push([statement, rdf('predicate'), p]);
-    ret.push([statement, rdf('object'), o]);
-  }
-  return ret;
-}
-
-// It's common to use shorthand like `rdf:type`. This function let's us do something similar.
-// expect(rdf('type')).toEqual({ Iri: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type' });
-function rdf(keyword) {
-  assert(
-    ['type', 'subject', 'predicate', 'object'].includes(keyword),
-    'unknown member of the rdf: context',
-  );
-  return { Iri: `http://www.w3.org/1999/02/22-rdf-syntax-ns#${keyword}` };
 }
 
 // return the Set() of all bank node names in a claimgraph

--- a/src/utils/common.js
+++ b/src/utils/common.js
@@ -1,6 +1,5 @@
 // Helpers for internal use by sdk utilities.
-// The api of this module is not guaranteed to be stable
-// and may change.
+// The api of this module is not guaranteed to be stable.
 
 import { assert } from '@polkadot/util';
 
@@ -12,6 +11,7 @@ export function deepClone(obj) {
 
 export function assertValidClaimGraph(cg) {
   for (const claim of cg) {
+    assert(claim.length === 4, 'claimgraphs must be quads');
     for (const node of claim) {
       assertValidNode(node);
     }
@@ -24,6 +24,9 @@ export function assertValidNode(node) {
   const tag = ks[0];
   const value = node[tag];
   switch (tag) {
+    case 'DefaultGraph':
+      assert(value === true, 'DefaultGraph must be true'); // asserting both type and value
+      break;
     case 'Iri':
       assertType(value, 'string');
       break;

--- a/tests/unit/claim-deduction.test.js
+++ b/tests/unit/claim-deduction.test.js
@@ -2,7 +2,6 @@ import { Ed25519KeyPair, suites } from 'jsonld-signatures';
 import jsonld from 'jsonld';
 import axios from 'axios';
 import { randomAsHex } from '@polkadot/util-crypto';
-import check from '@polkadot/util-crypto/address/check';
 import {
   expandedLogicProperty,
   acceptCompositeClaims,
@@ -129,119 +128,50 @@ describe('Composite claim soundness checker', () => {
     const all = await checkSoundness(presentation, rules);
     expect(all).toEqual([
       [
-        { Iri: issuer },
-        { Iri: 'https://www.dock.io/rdf2020#claimsV1' },
-        { Blank: '_:b0' },
-      ],
-      [
-        { Blank: '_:b0' },
-        { Iri: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#subject' },
         { Iri: 'did:example:ebfeb1f712ebc6f1c276e12ec21' },
-      ],
-      [
-        { Blank: '_:b0' },
-        { Iri: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate' },
         { Iri: 'http://schema.org/alumniOf' },
-      ],
-      [
-        { Blank: '_:b0' },
-        { Iri: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#object' },
         {
           Literal: {
             value: 'Example University',
             datatype: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML',
           },
         },
-      ],
-      [
         { Iri: issuer },
-        { Iri: 'https://www.dock.io/rdf2020#claimsV1' },
-        { Blank: '_:b1' },
       ],
       [
-        { Blank: '_:b1' },
-        { Iri: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#subject' },
         { Iri: 'https://example.com/credentials/1872' },
-      ],
-      [
-        { Blank: '_:b1' },
-        { Iri: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate' },
         { Iri: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type' },
-      ],
-      [
-        { Blank: '_:b1' },
-        { Iri: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#object' },
         { Iri: 'https://www.w3.org/2018/credentials#VerifiableCredential' },
-      ],
-      [
         { Iri: issuer },
-        { Iri: 'https://www.dock.io/rdf2020#claimsV1' },
-        { Blank: '_:b2' },
       ],
       [
-        { Blank: '_:b2' },
-        { Iri: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#subject' },
         { Iri: 'https://example.com/credentials/1872' },
-      ],
-      [
-        { Blank: '_:b2' },
-        { Iri: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate' },
         { Iri: 'https://www.w3.org/2018/credentials#credentialSubject' },
-      ],
-      [
-        { Blank: '_:b2' },
-        { Iri: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#object' },
         { Iri: 'did:example:ebfeb1f712ebc6f1c276e12ec21' },
-      ],
-      [
         { Iri: issuer },
-        { Iri: 'https://www.dock.io/rdf2020#claimsV1' },
-        { Blank: '_:b3' },
       ],
       [
-        { Blank: '_:b3' },
-        { Iri: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#subject' },
         { Iri: 'https://example.com/credentials/1872' },
-      ],
-      [
-        { Blank: '_:b3' },
-        { Iri: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate' },
         { Iri: 'https://www.w3.org/2018/credentials#issuanceDate' },
-      ],
-      [
-        { Blank: '_:b3' },
-        { Iri: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#object' },
         {
           Literal: {
             value: '2010-01-01T19:23:24Z',
             datatype: 'http://www.w3.org/2001/XMLSchema#dateTime',
           },
         },
-      ],
-      [
         { Iri: issuer },
-        { Iri: 'https://www.dock.io/rdf2020#claimsV1' },
-        { Blank: '_:b4' },
       ],
       [
-        { Blank: '_:b4' },
-        { Iri: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#subject' },
         { Iri: 'https://example.com/credentials/1872' },
-      ],
-      [
-        { Blank: '_:b4' },
-        { Iri: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate' },
         { Iri: 'https://www.w3.org/2018/credentials#issuer' },
-      ],
-      [
-        { Blank: '_:b4' },
-        { Iri: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#object' },
+        { Iri: issuer },
         { Iri: issuer },
       ],
       [
         { Iri: 'https://example.com/a' },
         { Iri: 'https://example.com/frobs' },
         { Iri: 'https://example.com/b' },
+        { DefaultGraph: true },
       ],
     ]);
   }, 30000);
@@ -263,6 +193,7 @@ describe('Composite claim soundness checker', () => {
         { Iri: 'http://example.com/joeThePig' },
         { Iri: 'https://example.com/Ability' },
         { Iri: 'https://example.com/Flight' },
+        { DefaultGraph: true },
       ]);
   });
 
@@ -302,11 +233,13 @@ describe('Composite claim soundness checker', () => {
           { Unbound: 'pig' },
           { Bound: { Iri: 'https://example.com/Ability' } },
           { Bound: { Iri: 'https://example.com/Flight' } },
+          { Bound: { DefaultGraph: true } },
         ],
         [
           { Unbound: 'pig' },
           { Bound: rdf('type') },
           { Bound: { Iri: 'https://example.com/Pig' } },
+          { Bound: { DefaultGraph: true } },
         ],
       ],
       then: [
@@ -321,49 +254,39 @@ describe('Composite claim soundness checker', () => {
               },
             },
           },
+          { Bound: { DefaultGraph: true } },
         ],
       ],
     };
     const licensing = {
-      // if licenser? claims [a? lp? lo?]
+      // if  a? lp? lo? licenser?
       // and licenser? mayLicence li?
       // and li? predicate lp?
       // and li? object lo?
       if_all: [
         [
-          { Unbound: 'licenser' },
-          { Bound: claims },
-          { Unbound: 'c0' },
-        ],
-        [
-          { Unbound: 'c0' },
-          { Bound: rdf('subject') },
           { Unbound: 'a' },
-        ],
-        [
-          { Unbound: 'c0' },
-          { Bound: rdf('predicate') },
           { Unbound: 'lp' },
-        ],
-        [
-          { Unbound: 'c0' },
-          { Bound: rdf('object') },
           { Unbound: 'lo' },
+          { Unbound: 'licenser' },
         ],
         [
           { Unbound: 'licenser' },
           { Bound: { Iri: 'https://example.com/mayLicense' } },
           { Unbound: 'li' },
+          { Bound: { DefaultGraph: true } },
         ],
         [
           { Unbound: 'li' },
           { Bound: rdf('predicate') },
           { Unbound: 'lp' },
+          { Bound: { DefaultGraph: true } },
         ],
         [
           { Unbound: 'li' },
           { Bound: rdf('object') },
           { Unbound: 'lo' },
+          { Bound: { DefaultGraph: true } },
         ],
       ],
       // then [a? lp? lo?],
@@ -372,6 +295,7 @@ describe('Composite claim soundness checker', () => {
           { Unbound: 'a' },
           { Unbound: 'lp' },
           { Unbound: 'lo' },
+          { Bound: { DefaultGraph: true } },
         ],
       ],
     };
@@ -383,32 +307,38 @@ describe('Composite claim soundness checker', () => {
           { Bound: { Iri: faa } },
           { Bound: { Iri: 'https://example.com/mayLicense' } },
           { Bound: { Iri: 'uuid:5c4cfa6b-d96f-4a53-8786-2cce46cc51c4' } },
+          { Bound: { DefaultGraph: true } },
         ],
         [
           { Bound: { Iri: 'uuid:5c4cfa6b-d96f-4a53-8786-2cce46cc51c4' } },
           { Bound: rdf('predicate') },
           { Bound: { Iri: 'https://example.com/Ability' } },
+          { Bound: { DefaultGraph: true } },
         ],
         [
           { Bound: { Iri: 'uuid:5c4cfa6b-d96f-4a53-8786-2cce46cc51c4' } },
           { Bound: rdf('object') },
           { Bound: { Iri: 'https://example.com/Flight' } },
+          { Bound: { DefaultGraph: true } },
         ],
         // pigchecker is trusted to check whether something is a pig
         [
           { Bound: { Iri: pigchecker } },
           { Bound: { Iri: 'https://example.com/mayLicense' } },
           { Bound: { Iri: 'uuid:6f165460-894a-4e51-a2a5-79b537678720' } },
+          { Bound: { DefaultGraph: true } },
         ],
         [
           { Bound: { Iri: 'uuid:6f165460-894a-4e51-a2a5-79b537678720' } },
           { Bound: rdf('predicate') },
           { Bound: rdf('type') },
+          { Bound: { DefaultGraph: true } },
         ],
         [
           { Bound: { Iri: 'uuid:6f165460-894a-4e51-a2a5-79b537678720' } },
           { Bound: rdf('object') },
           { Bound: { Iri: 'https://example.com/Pig' } },
+          { Bound: { DefaultGraph: true } },
         ],
       ],
     };
@@ -460,6 +390,7 @@ describe('Composite claim soundness checker', () => {
           datatype: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral',
         },
       },
+      { DefaultGraph: true },
     ];
     expect(presentation_claimgraph).not.toContainEqual(claim_to_prove);
     const proof = proveh(
@@ -480,6 +411,7 @@ describe('Composite claim soundness checker', () => {
       { Iri: 'https://example.com/a' },
       { Iri: 'https://example.com/frobs' },
       { Iri: 'https://example.com/b' },
+      { DefaultGraph: true },
     ];
     const rules = sampleRules();
     const proof = await proveCompositeClaims(expandedPresentation, [compositeClaim], rules);
@@ -631,6 +563,7 @@ function sampleRules() {
           { Bound: { Iri: 'https://example.com/a' } },
           { Bound: { Iri: 'https://example.com/frobs' } },
           { Bound: { Iri: 'https://example.com/b' } },
+          { Bound: { DefaultGraph: true } },
         ],
       ],
     },
@@ -640,11 +573,13 @@ function sampleRules() {
           { Unbound: 'pig' },
           { Bound: { Iri: 'https://example.com/Ability' } },
           { Bound: { Iri: 'https://example.com/Flight' } },
+          { Bound: { DefaultGraph: true } },
         ],
         [
           { Unbound: 'pig' },
           { Bound: { Iri: 'https://www.w3.org/1999/02/22-rdf-syntax-ns#type' } },
           { Bound: { Iri: 'https://example.com/Pig' } },
+          { Bound: { DefaultGraph: true } },
         ],
       ],
       then: [
@@ -659,6 +594,7 @@ function sampleRules() {
               },
             },
           },
+          { Bound: { DefaultGraph: true } },
         ],
       ],
     },

--- a/tests/unit/claimgraph.test.js
+++ b/tests/unit/claimgraph.test.js
@@ -13,11 +13,13 @@ describe('Claimgraph operations.', () => {
           },
         },
         { Blank: '_:b1' },
+        { DefaultGraph: true },
       ],
       [
         { Blank: '_:b1' },
         { Blank: '_:b3' },
         { Blank: '_:b5' },
+        { Blank: '_:b6' },
       ],
     ];
     const cg2 = [
@@ -25,6 +27,7 @@ describe('Claimgraph operations.', () => {
         { Blank: '_:b1' },
         { Blank: '_:b4' },
         { Blank: '_:b5' },
+        { Blank: '_:b6' },
       ],
     ];
     expect(merge([])).toEqual([]);
@@ -38,11 +41,13 @@ describe('Claimgraph operations.', () => {
           },
         },
         { Blank: '_:b0' },
+        { DefaultGraph: true },
       ],
       [
         { Blank: '_:b0' },
         { Blank: '_:b1' },
         { Blank: '_:b2' },
+        { Blank: '_:b3' },
       ],
     ]);
     expect(merge([cg2])).toEqual([
@@ -50,6 +55,7 @@ describe('Claimgraph operations.', () => {
         { Blank: '_:b0' },
         { Blank: '_:b1' },
         { Blank: '_:b2' },
+        { Blank: '_:b3' },
       ],
     ]);
     expect(merge([cg2, cg2])).toEqual([
@@ -57,11 +63,13 @@ describe('Claimgraph operations.', () => {
         { Blank: '_:b0' },
         { Blank: '_:b1' },
         { Blank: '_:b2' },
+        { Blank: '_:b3' },
       ],
       [
-        { Blank: '_:b3' },
         { Blank: '_:b4' },
         { Blank: '_:b5' },
+        { Blank: '_:b6' },
+        { Blank: '_:b7' },
       ],
     ]);
     expect(merge([cg1, cg2])).toEqual([
@@ -74,83 +82,19 @@ describe('Claimgraph operations.', () => {
           },
         },
         { Blank: '_:b0' },
+        { DefaultGraph: true },
       ],
       [
         { Blank: '_:b0' },
         { Blank: '_:b1' },
         { Blank: '_:b2' },
+        { Blank: '_:b3' },
       ],
       [
-        { Blank: '_:b3' },
         { Blank: '_:b4' },
         { Blank: '_:b5' },
-      ],
-    ]);
-  });
-
-  test('asEE', async () => {
-    const cg = [
-      [
-        { Iri: 'did:example:ebfeb1f712ebc6f1c276e12ec21' },
-        { Iri: 'http://schema.org/alumniOf' },
-        {
-          Literal: {
-            value: 'Example University',
-            datatype: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML',
-          },
-        },
-      ], [
-        { Iri: 'https://example.com/credentials/1872' },
-        { Iri: 'https://w3id.org/security#proof' },
-        { Blank: '_:b1' },
-      ],
-    ];
-    const eecg = asEE(cg, 'did:dock:bobert');
-    expect(eecg).toEqual([
-      [
-        { Iri: 'did:dock:bobert' },
-        { Iri: 'https://www.dock.io/rdf2020#claimsV1' },
-        { Blank: '_:b1' },
-      ],
-      [
-        { Blank: '_:b1' },
-        { Iri: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#subject' },
-        { Iri: 'did:example:ebfeb1f712ebc6f1c276e12ec21' },
-      ],
-      [
-        { Blank: '_:b1' },
-        { Iri: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate' },
-        { Iri: 'http://schema.org/alumniOf' },
-      ],
-      [
-        { Blank: '_:b1' },
-        { Iri: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#object' },
-        {
-          Literal: {
-            value: 'Example University',
-            datatype: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML',
-          },
-        },
-      ],
-      [
-        { Iri: 'did:dock:bobert' },
-        { Iri: 'https://www.dock.io/rdf2020#claimsV1' },
-        { Blank: '_:b2' },
-      ],
-      [
-        { Blank: '_:b2' },
-        { Iri: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#subject' },
-        { Iri: 'https://example.com/credentials/1872' },
-      ],
-      [
-        { Blank: '_:b2' },
-        { Iri: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate' },
-        { Iri: 'https://w3id.org/security#proof' },
-      ],
-      [
-        { Blank: '_:b2' },
-        { Iri: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#object' },
-        { Blank: '_:b0' },
+        { Blank: '_:b6' },
+        { Blank: '_:b7' },
       ],
     ]);
   });
@@ -187,10 +131,12 @@ describe('Claimgraph operations.', () => {
             datatype: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML',
           },
         },
+        { Blank: '_:b0' },
       ], [
         { Iri: 'https://example.com/credentials/1872' },
         { Iri: 'https://w3id.org/security#proof' },
         { Blank: '_:b1' },
+        { Blank: '_:b0' },
       ],
     ]);
   });
@@ -205,6 +151,7 @@ describe('Claimgraph operations.', () => {
         { Iri: 'https://example.com/a' },
         { Iri: 'https://example.com/parent' },
         { Blank: '_:b0' },
+        { DefaultGraph: true },
       ],
     ];
     const cg2 = [
@@ -212,6 +159,7 @@ describe('Claimgraph operations.', () => {
         { Blank: '_:b0' },
         { Iri: 'https://example.com/parent' },
         { Iri: 'https://example.com/b' },
+        { DefaultGraph: true },
       ],
     ];
     const merged = merge([cg1, cg2]);
@@ -225,11 +173,13 @@ describe('Claimgraph operations.', () => {
           { Iri: 'https://example.com/a' },
           { Iri: 'https://example.com/parent' },
           { Blank: '_:b0' },
+          { DefaultGraph: true },
         ],
         [
           { Blank: '_:b1' },
           { Iri: 'https://example.com/parent' },
           { Iri: 'https://example.com/b' },
+          { DefaultGraph: true },
         ],
       ],
     );
@@ -257,7 +207,8 @@ describe('Claimgraph operations.', () => {
             datatype: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#langString',
             language: 'en'
           }
-        }
+        },
+        { DefaultGraph: true },
       ],
       [
         { Blank: '_:b0' },
@@ -268,7 +219,8 @@ describe('Claimgraph operations.', () => {
             datatype: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#langString',
             language: 'cy'
           }
-        }
+        },
+        { DefaultGraph: true },
       ]
     ]);
   });

--- a/tutorials/src/concepts_claim_deduction.md
+++ b/tutorials/src/concepts_claim_deduction.md
@@ -2,13 +2,13 @@
 
 The [verifiable credentials data model](https://www.w3.org/TR/vc-data-model/) is based on a machine comprehensible language called [RDF](https://www.w3.org/TR/rdf-primer/). RDF represents arbitrary semantic knowledge as [graph](https://en.wikipedia.org/wiki/Graph_(discrete_mathematics))s. Computers can perform automatic deductive reasoning over RDF; given assumptions (represented as an RDF graph) and axioms (represented as logical rules), a computer can infer new conclusions and even prove them to other computers using deductive derivations (proofs).
 
-Every VCDM credential is representable as an RDF graph so computers can reason about them, deriving new conclusions that weren't explicitly stated by the issuer.
+Every VCDM credential is representable as an RDF graph. So computers can reason about them, deriving new conclusions that weren't explicitly stated by the issuer.
 
 The Dock SDK exposes utilities for primitive deductive reasoning over verified credentials. The Verifier has a choice to perform deduction themself (expensive), or offload that responsibility to the Presenter of the credential[s] by accepting deductive proofs of composite claims.
 
 In RDF, if graph A is true and graph B is true, then the [union](https://en.wikipedia.org/wiki/Union_(set_theory)) of those graphs, is also true `A∧B->A∪B` [^1]. Using this property we can combine multiple credentials and reason over their union.
 
-## Explicit Ethos using [RDF Reification](https://en.wikipedia.org/wiki/Modes_of_persuasion#Ethos)
+## Explicit Ethos
 
 Imagine a signed credential issued by **Alice** claiming that **Joe** is a **Member**.
 
@@ -39,13 +39,13 @@ Proven:
 <Joe> <type> <Member> <Alice> .
 ```
 
-The fourth and final element of the proven *quad* is used here to indicate the source of the information, Alice in this case. The final element of a quad is its [graph name](https://www.w3.org/TR/rdf11-concepts/#dfn-graph-name).
+The fourth and final element of the proven *quad* is used here to indicate the source of the information, Alice. The final element of a quad is its [graph name](https://www.w3.org/TR/rdf11-concepts/#dfn-graph-name).
 
-Signed credentials are [ethos](https://en.wikipedia.org/wiki/Modes_of_persuasion#Ethos) arguments. A credential may be converted to a list of quads (a claimgraph). We call this representation "Explicit Ethos" form. If a credential is *verified*, then it's explicit ethos form is *true*.
+A signed credentials are [ethos](https://en.wikipedia.org/wiki/Modes_of_persuasion#Ethos) arguments and a credential may be converted to a list of quads (a claimgraph). We call this representation "Explicit Ethos" form. If a credential is *verified*, then its explicit ethos form is *true*.
 
 ## Rule Format
 
-To perform reasoning and to accept proofs, the Verifier must select the list of logical rules which they will allow. Rules (or axioms if you prefer), are modeled as if-then relationships.
+To perform reasoning and to accept proofs, the Verifier must select the list of logical rules wish to accept. Rules (or axioms if you prefer), are modeled as if-then relationships.
 
 ```js
 const rules = [
@@ -58,21 +58,27 @@ const rules = [
 
 During reasoning, when an `if_all` pattern is matched, its corresponding `then` pattern will be implied. In logic terms, each "rule" is the conditional premise of a [modus ponens](https://en.wikipedia.org/wiki/Modus_ponens).
 
-```js
-{ if_all: [A, B, C], then: [D, E] }
-```
-
-means `if (A and B and C) then (D and E)`.
+`{ if_all: [A, B, C], then: [D, E] }` means that `if (A and B and C) then (D and E)`.
 
 Rules can contain Bound or Unbound entities. Unbound entities are named variables. Each rule has it's own unique scope, so Unbound entities introduced in the `if_all` pattern can be used in the `then` pattern.
 
 ```js
 {
   if_all: [
-    [{ Bound: alice }, { Bound: likes }, { Unbound: 'thing' }, { Bound: defaultGraph }],
+    [
+      { Bound: alice },
+      { Bound: likes },
+      { Unbound: 'thing' },
+      { Bound: defaultGraph },
+    ],
   ],
   then: [
-    [{ Bound: bob }, { Bound: likes }, { Unbound: 'thing' }, { Bound: defaultGraph }]
+    [
+      { Bound: bob },
+      { Bound: likes },
+      { Unbound: 'thing' },
+      { Bound: defaultGraph },
+    ],
   ],
 }
 ```
@@ -86,6 +92,8 @@ For any ?thing:
 ```
 
 in other words: `∀ thing: [alice likes thing] -> [bob likes thing]`
+
+If an unbound variable appears in the `then` pattern but does not appear in the `if_all` pattern the rule is considered invalid and will be rejected by the reasoner.
 
 Bound entities are constants of type RdfTerm. RDF nodes may be one of four things, an IRI, a blank node, a literal, or the default graph. For those familiar with algebraic datatypes:
 
@@ -116,7 +124,7 @@ const blank = { Blank: '_:b0' };
 const defaultGraph = { DefaultGraph: true };
 ```
 
-Example of a complete rule definition:
+Here is an example of a complete rule definition:
 
 ```js
 {

--- a/tutorials/src/tutorial_claim_deduction.md
+++ b/tutorials/src/tutorial_claim_deduction.md
@@ -4,7 +4,7 @@
 
 A Verifier has complete and low level control over the logical rules they deem valid. Rules may vary from use-case to use-case and from verifier to verifier.
 
-Unwrapping of Explicit Ethos statements is expected to be a common first step when writing a ruleset. This tutorial will give some examples of that.
+A common first step when writing a ruleset will be to unwrap of Explicit Ethos statements.
 
 ### Simple Unwrapping of Explicit Ethos
 
@@ -33,7 +33,7 @@ const rules = [
 ];
 ```
 
-That single rule is enough for some use-cases but it's not scalable. What if we want to allow more than one issuer? Instead of copying the same rule for each issuer we trust, let's define "trustworthiness":
+That single rule is enough for some use-cases but it's not scalable. What if we want to allow more than one issuer? Instead of copying the same rule for each issuer we trust, let's define "trustworthiness".
 
 ### Unwrapping Explicit Ethos by Defining Trustworthiness
 
@@ -63,11 +63,11 @@ const rules = [
 
 You may ask "So what's the difference? There is still only one issuer."
 
-By the primitive definition of "trustworthiness" written above, any claim made by a trustworthy issuer is true. did:example:issuer can claim whatever they want by issuing verifiable credentials. They can even claim that some other issuer is trustworthy. Together, the two rules defined in the above example implement a system analogous to TLS certificate chains with did:example:issuer as the single root authority.
+By the primitive definition of "trustworthiness" written above, any claim made by a trustworthy issuer is true. `did:example:issuer` can claim whatever they want by issuing verifiable credentials. They can even claim that some other issuer is trustworthy. Together, the two rules defined in the above example implement a system analogous to TLS certificate chains with `did:example:issuer` as the single root authority.
 
 ## Proving Composite Claims
 
-As a Holder of verifiable credentials, you'll want to prove specific claims to a Verifier. If those claims are composite, you'll sometimes need to provide a deductive proof in your verifiable credentials presentation. This should be done after the presentation has been assembled. If the presentation is going to be signed, sign it *after* including the deductive proof.
+As a Holder of verifiable credentials, you'll want to prove specific claims to a Verifier. If those claims are composite, you'll sometimes need to bundle a deductive proof in your verifiable credentials presentation. This should be done after the presentation has been assembled. If the presentation is going to be signed, sign it *after* including the deductive proof.
 
 ```js
 import { proveCompositeClaims } from '@docknetwork/sdk/utils/cd';

--- a/tutorials/src/tutorial_claim_deduction.md
+++ b/tutorials/src/tutorial_claim_deduction.md
@@ -8,35 +8,26 @@ Unwrapping of Explicit Ethos statements is expected to be a common first step wh
 
 ### Simple Unwrapping of Explicit Ethos
 
-This ruleset names a specific issuer and states that any claims that issuer makes are true.
+This ruleset names a specific issuer and states that any claims made by that issuer are true.
 
 ```js
 const rules = [
   {
     if_all: [
       [
-        { Bound: { Iri: 'did:example:issuer' } },
-        { Bound: { Iri: 'https://www.dock.io/rdf2020#claimsV1' } },
-        { Unbound: 'claim' },
-      ],
-      [
-        { Unbound: 'claim' },
-        { Bound: { Iri: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#subject' } },
         { Unbound: 'subject' },
-      ],
-      [
-        { Unbound: 'claim' },
-        { Bound: { Iri: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate' } },
         { Unbound: 'predicate' },
-      ],
-      [
-        { Unbound: 'claim' },
-        { Bound: { Iri: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#object' } },
         { Unbound: 'object' },
+        { Bound: { Iri: 'did:example:issuer' } },
       ],
     ],
     then: [
-      [ { Unbound: 'subject' }, { Unbound: 'predicate' }, { Unbound: 'object' } ],
+      [
+        { Unbound: 'subject' },
+        { Unbound: 'predicate' },
+        { Unbound: 'object' },
+        { Bound: { DefaultGraph: true } },
+      ],
     ],
   }
 ];
@@ -47,56 +38,24 @@ That single rule is enough for some use-cases but it's not scalable. What if we 
 ### Unwrapping Explicit Ethos by Defining Trustworthiness
 
 ```js
-const trustworthy =
-  { Bound: { Iri: 'https://www.dock.io/rdf2020#Trustworthy' } };
-const type =
-  { Bound: { Iri: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type' } };
-const claims =
-  { Bound: { Iri: 'https://www.dock.io/rdf2020#claimsV1' } };
-const subject =
-  { Bound: { Iri: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#subject' } };
-const predicate =
-  { Bound: { Iri: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate' } };
-const object =
-  { Bound: { Iri: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#object' } };
+const trustworthy = { Bound: { Iri: 'https://www.dock.io/rdf2020#Trustworthy' } };
+const type = { Bound: { Iri: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type' } };
+const defaultGraph = { Bound: { DefaultGraph: true } };
 
 const rules = [
   {
     if_all: [
-      [
-        { Unbound: 'issuer' },
-        type,
-        trustworthy,
-      ],
-      [
-        { Unbound: 'issuer' },
-        claims,
-        { Unbound: 'claim' },
-      ],
-      [
-        { Unbound: 'claim' },
-        subject,
-        { Unbound: 'subject' },
-      ],
-      [
-        { Unbound: 'claim' },
-        predicate,
-        { Unbound: 'predicate' },
-      ],
-      [
-        { Unbound: 'claim' },
-        object,
-        { Unbound: 'object' },
-      ],
+      [{ Unbound: 'issuer' }, type, trustworthy, defaultGraph],
+      [{ Unbound: 's' }, { Unbound: 'p' }, { Unbound: 'o' }, { Unbound: 'issuer' }],
     ],
     then: [
-      [ { Unbound: 'subject' }, { Unbound: 'predicate' }, { Unbound: 'object' } ],
+      [{ Unbound: 's' }, { Unbound: 'p' }, { Unbound: 'o' }, defaultGraph],
     ],
   },
   {
     if_all: [],
     then: [
-      [ { Bound: { Iri: 'did:example:issuer' } }, type, trustworthy ]
+      [{ Bound: { Iri: 'did:example:issuer' } }, type, trustworthy, defaultGraph]
     ],
   }
 ];
@@ -108,7 +67,7 @@ By the primitive definition of "trustworthiness" written above, any claim made b
 
 ## Proving Composite Claims
 
-As a Holder of verifiable credentials, you'll want to prove specific claims to a Verifier. If those claims are composite, you'll need to provide a deductive proof in your verifiable credentials presentation. This should be done after the presentation has been assembled. If the presentation is going to be signed, sign it *after* including the deductive proof.
+As a Holder of verifiable credentials, you'll want to prove specific claims to a Verifier. If those claims are composite, you'll sometimes need to provide a deductive proof in your verifiable credentials presentation. This should be done after the presentation has been assembled. If the presentation is going to be signed, sign it *after* including the deductive proof.
 
 ```js
 import { proveCompositeClaims } from '@docknetwork/sdk/utils/cd';
@@ -122,7 +81,8 @@ const presentation = { ... };
 const compositeClaim = [
   { Iri: 'uuid:19e91192-210b-4b03-8e9c-8ded0a48d5bf' },
   { Iri: 'http://dbpedia.org/ontology/owner' },
-  { Iri: 'did:example:bob' }
+  { Iri: 'did:example:bob' },
+  { DefaultGraph: true },
 ];
 
 // SDK reasoning utilities take presentations in expanded form

--- a/yarn.lock
+++ b/yarn.lock
@@ -5605,10 +5605,10 @@ ret@~0.1.10:
   resolved "https://registry.yarnpkg.com/ret/-/ret-0.1.15.tgz#b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc"
   integrity sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==
 
-rify@^0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/rify/-/rify-0.4.0.tgz#aa6c0e009c86cd75d27f3c3a6ff8da20d53b07d5"
-  integrity sha512-c9nQbttYCwIcyr5950YRy6JHXK/iBpO3AH1iZXp3cKYGVt2btAva2xL9o26mA0fWtvtMasIdrFexbtBnAqrMjQ==
+rify@^0.6.0-rc.1:
+  version "0.6.0-rc.1"
+  resolved "https://registry.yarnpkg.com/rify/-/rify-0.6.0-rc.1.tgz#7130b89bb971c0fdc8dfb502c819b2316fe0db24"
+  integrity sha512-jjYWE3i9L00vd+Ny4pCu6vmEnVbZLRlbTZxewD9uEFu27vH4o+sJXM+3YYh3X/ndYM+DxqikKuJKs4tdesT+Ew==
 
 rimraf@2.6.3:
   version "2.6.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5605,10 +5605,10 @@ ret@~0.1.10:
   resolved "https://registry.yarnpkg.com/ret/-/ret-0.1.15.tgz#b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc"
   integrity sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==
 
-rify@^0.6.0-rc.1:
-  version "0.6.0-rc.1"
-  resolved "https://registry.yarnpkg.com/rify/-/rify-0.6.0-rc.1.tgz#7130b89bb971c0fdc8dfb502c819b2316fe0db24"
-  integrity sha512-jjYWE3i9L00vd+Ny4pCu6vmEnVbZLRlbTZxewD9uEFu27vH4o+sJXM+3YYh3X/ndYM+DxqikKuJKs4tdesT+Ew==
+rify@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/rify/-/rify-0.6.0.tgz#57886f9e3c0566f453d207ac9f51253a42e7f753"
+  integrity sha512-DX7TcUIyi7zLnxOR+QgvwyNQVqPGcz8I8h2aabPW5+CeSafXMfxxYCSfgnHmMy2VptX9ynAfzQvKQdzsmBxsWQ==
 
 rimraf@2.6.3:
   version "2.6.3"


### PR DESCRIPTION
The PR modifies sdk to use the latest version of rify, which can reason over RDF quads.

- [x] Refactor cg and claimgraph modules to operate on quads.
- [x] Remove Explicit Ethos reification
- [x] Modify unit test rulesets to express attestation logic as quads instead of in reified EE
- [x] refactor unit tests
- [x] refactor affected examples
- [x] refactor affected tutorials
- [x] rebase on master after #229 is merged
- [x] use the latest non-release-candidate version of rify after https://github.com/docknetwork/rify/pull/10 is merged (using 0.6.0-rc.1 right now)
- [x] proofread claim deduction concepts doc again before submitting for review