### PR TITLE
refactor jsonld-signatures import to prevent compile errors downstream

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@docknetwork/sdk",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "main": "index.js",
   "license": "MIT",
   "repository": {

--- a/src/utils/vc/crypto/custom-linkeddatasignature.js
+++ b/src/utils/vc/crypto/custom-linkeddatasignature.js
@@ -1,4 +1,4 @@
-import { suites } from 'jsonld-signatures';
+import jsigs from 'jsonld-signatures';
 import { encode, decode } from 'base58-universal';
 import base64url from 'base64url';
 
@@ -21,7 +21,7 @@ function decodeBase64UrlToString(string) {
   return base64url.decode(string);
 }
 
-export default class CustomLinkedDataSignature extends suites.LinkedDataSignature {
+export default class CustomLinkedDataSignature extends jsigs.suites.LinkedDataSignature {
   /**
    * Creates a new CustomLinkedDataSignature instance
    * @constructor


### PR DESCRIPTION
experienced nextjs compile errors with default config due to how we import jsonld-signatures, as theres an issue with that lib:

```
error - SyntaxError: Named export 'suites' not found. The requested module 'jsonld-signatures' is a CommonJS module, which may not support all module.exports as named exports.
CommonJS modules can always be imported via the default export, for example using:

```