### PR TITLE
Fix BBS+ verify with schema

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@docknetwork/sdk",
-  "version": "2.6.2",
+  "version": "2.6.3",
   "main": "index.js",
   "license": "MIT",
   "repository": {

--- a/src/utils/vc/credentials.js
+++ b/src/utils/vc/credentials.js
@@ -187,7 +187,7 @@ export async function verifyCredential(credential, {
 
   // Validate schema
   if (schemaApi) {
-    await getAndValidateSchemaIfPresent(expandedCredential, schemaApi, credential[credentialContextField]);
+    await getAndValidateSchemaIfPresent(expandedCredential, schemaApi, credential[credentialContextField], docLoader);
   }
 
   // Verify with jsonld-signatures

--- a/src/utils/vc/schema.js
+++ b/src/utils/vc/schema.js
@@ -28,7 +28,7 @@ export async function validateCredentialSchema(credential, schema, context, docu
       delete subject[credentialIDField];
     }
 
-    const compacted = await jsonld.compact(subject, context, { documentLoader }); // eslint-disable-line
+    const compacted = await jsonld.compact(subject, context, documentLoader && { documentLoader }); // eslint-disable-line
     delete compacted[credentialContextField];
 
     if (Object.keys(compacted).length === 0) {

--- a/src/utils/vc/schema.js
+++ b/src/utils/vc/schema.js
@@ -1,6 +1,7 @@
 import jsonld from 'jsonld';
 import { validate } from 'jsonschema';
 import Schema from '../../modules/schema';
+import defaultDocumentLoader from './document-loader';
 
 import {
   expandedSubjectProperty,
@@ -28,7 +29,7 @@ export async function validateCredentialSchema(credential, schema, context, docu
       delete subject[credentialIDField];
     }
 
-    const compacted = await jsonld.compact(subject, context, documentLoader && { documentLoader }); // eslint-disable-line
+    const compacted = await jsonld.compact(subject, context, { documentLoader: documentLoader || defaultDocumentLoader() }); // eslint-disable-line
     delete compacted[credentialContextField];
 
     if (Object.keys(compacted).length === 0) {

--- a/src/utils/vc/schema.js
+++ b/src/utils/vc/schema.js
@@ -17,7 +17,7 @@ import {
  * @param context
  * @returns {Promise<Boolean>} - Returns promise to a boolean or throws error
  */
-export async function validateCredentialSchema(credential, schema, context) {
+export async function validateCredentialSchema(credential, schema, context, documentLoader) {
   const requiresID = schema.required && schema.required.indexOf('id') > -1;
   const credentialSubject = credential[expandedSubjectProperty] || [];
   const subjects = credentialSubject.length ? credentialSubject : [credentialSubject];
@@ -28,7 +28,7 @@ export async function validateCredentialSchema(credential, schema, context) {
       delete subject[credentialIDField];
     }
 
-    const compacted = await jsonld.compact(subject, context); // eslint-disable-line
+    const compacted = await jsonld.compact(subject, context, { documentLoader }); // eslint-disable-line
     delete compacted[credentialContextField];
 
     if (Object.keys(compacted).length === 0) {
@@ -49,19 +49,34 @@ export async function validateCredentialSchema(credential, schema, context) {
  * a schema doc. For now, the object specifies the type as key and the value as the API, but the structure can change
  * as we support more APIs there are more details associated with each API. Only Dock is supported as of now.
  * @param {object} context - the context
+ * @param {object} documentLoader - the document loader
  * @returns {Promise<void>}
  */
-export async function getAndValidateSchemaIfPresent(credential, schemaApi, context) {
+// eslint-disable-next-line sonarjs/cognitive-complexity
+export async function getAndValidateSchemaIfPresent(credential, schemaApi, context, documentLoader) {
   const schemaList = credential[expandedSchemaProperty];
   if (schemaList) {
     const schema = schemaList[0];
     if (credential[expandedSubjectProperty] && schema) {
-      if (!schemaApi.dock) {
-        throw new Error('Only Dock schemas are supported as of now.');
+      let schemaObj;
+      const schemaUri = schema[credentialIDField];
+
+      if (schemaUri.startsWith('blob:dock')) {
+        if (!schemaApi.dock) {
+          throw new Error('Only Dock schemas are supported as of now.');
+        }
+        schemaObj = await Schema.get(schemaUri, schemaApi.dock);
+      } else {
+        const { document } = await documentLoader(schemaUri);
+        schemaObj = document;
       }
+
+      if (!schemaObj) {
+        throw new Error(`Could not load schema URI: ${schemaUri}`);
+      }
+
       try {
-        const schemaObj = await Schema.get(schema[credentialIDField], schemaApi.dock);
-        await validateCredentialSchema(credential, schemaObj, context);
+        await validateCredentialSchema(credential, schemaObj, context, documentLoader);
       } catch (e) {
         throw new Error(`Schema validation failed: ${e}`);
       }

--- a/tests/integration/anoncreds/issuing.test.js
+++ b/tests/integration/anoncreds/issuing.test.js
@@ -128,6 +128,14 @@ describe('BBS+ Module', () => {
         getProofMatcherDoc(),
       ),
     );
+
+    // Ensure embedding the schema doesnt conflict with the other schema resolutions
+    const resultWithSchema = await verifyCredential(credential, { resolver, schemaApi: { dock }, });
+    expect(resultWithSchema).toMatchObject(
+      expect.objectContaining(
+        getProofMatcherDoc(),
+      ),
+    );
   }, 30000);
 
   test('Can issue+verify a BBS+ credential with default schema', async () => {


### PR DESCRIPTION
BBS+ credential verification was failing if schema resolution was enabled, have updated schema resolution to use the document loader which now supports embedded JSON