### PR TITLE
Allow to derive BBS+ W3C credentials for presenting

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@docknetwork/sdk",
-  "version": "2.9.0",
+  "version": "2.9.1",
   "main": "index.js",
   "license": "MIT",
   "repository": {
@@ -85,7 +85,7 @@
     "type-check": "tsc --allowJs --checkJs --noEmit --moduleResolution node --resolveJsonModule --target ES6 --skipLibCheck true --allowSyntheticDefaultImports true"
   },
   "dependencies": {
-    "@docknetwork/crypto-wasm-ts": "0.31.0",
+    "@docknetwork/crypto-wasm-ts": "0.31.1",
     "@docknetwork/node-types": "^0.13.0",
     "@juanelas/base64": "^1.0.5",
     "@polkadot/api": "9.7.1",

--- a/src/bbs-plus-presentation.js
+++ b/src/bbs-plus-presentation.js
@@ -8,10 +8,9 @@ import {
 import { ensureArray } from './utils/type-helpers';
 
 import Bls12381BBSSignatureDock2022 from './utils/vc/crypto/Bls12381BBSSignatureDock2022';
+import { Bls12381BBSSigProofDockSigName } from './utils/vc/crypto/constants';
 import CustomLinkedDataSignature from './utils/vc/crypto/custom-linkeddatasignature';
 import defaultDocumentLoader from './utils/vc/document-loader';
-
-const BBS_SIG_PROOF_TYPE = 'Bls12381BBS+SignatureProofDock2022';
 
 export default class BbsPlusPresentation {
   /**
@@ -122,7 +121,7 @@ export default class BbsPlusPresentation {
           proofPurpose: 'assertionMethod',
           created: date,
           ...credential.revealedAttributes.proof,
-          type: BBS_SIG_PROOF_TYPE,
+          type: Bls12381BBSSigProofDockSigName,
           proofValue: presentation.proof,
           nonce: presentation.nonce,
           context: presentation.context,

--- a/src/bbs-plus-presentation.js
+++ b/src/bbs-plus-presentation.js
@@ -5,13 +5,14 @@ import {
   PresentationBuilder,
   Credential,
 } from '@docknetwork/crypto-wasm-ts/lib/anonymous-credentials';
-import { ensureArray, ensureURI, isObject } from './utils/type-helpers';
+import { ensureArray } from './utils/type-helpers';
 
 import Bls12381BBSSignatureDock2022 from './utils/vc/crypto/Bls12381BBSSignatureDock2022';
 import CustomLinkedDataSignature from './utils/vc/crypto/custom-linkeddatasignature';
 import defaultDocumentLoader from './utils/vc/document-loader';
 
-const DEFAULT_CONTEXT = 'https://ld.dock.io/security/bbs/v1';
+const BBS_SIG_PROOF_TYPE = 'Bls12381BBS+SignatureProofDock2022';
+
 export default class BbsPlusPresentation {
   /**
    * Create a new BbsPlusPresentation instance.
@@ -19,7 +20,6 @@ export default class BbsPlusPresentation {
    */
   constructor() {
     this.presBuilder = new PresentationBuilder();
-    this.setPresentationContext([DEFAULT_CONTEXT]);
   }
 
   /**
@@ -43,7 +43,7 @@ export default class BbsPlusPresentation {
       this.presBuilder.nonce = stringToU8a(nonce);
     }
     if (context) {
-      this.setPresentationContext(context);
+      this.presBuilder.context = context;
     }
     const pres = this.presBuilder.finalize();
     return pres.toJSON();
@@ -83,22 +83,54 @@ export default class BbsPlusPresentation {
       document: json,
     });
 
-    const idx = await this.presBuilder.addCredential(Credential.fromJSON(credential, CustomLinkedDataSignature.fromJsigProofValue(credentialLD.proof.proofValue)), pk);
+    const convertedCredential = Credential.fromJSON(credential, CustomLinkedDataSignature.fromJsigProofValue(credentialLD.proof.proofValue));
+    console.log('convertedCredential', convertedCredential.toJSON());
+    const idx = await this.presBuilder.addCredential(convertedCredential, pk);
 
     // Enforce revealing of verificationMethod and type
     this.addAttributeToReveal(idx, ['proof.type']);
     this.addAttributeToReveal(idx, ['proof.verificationMethod']);
+
+    // We also require context and type for JSON-LD
+    this.addAttributeToReveal(idx, ['@context']);
+    this.addAttributeToReveal(idx, ['type']);
     return idx;
   }
 
-  /**
-   *
-   * @param context
-   */
-  setPresentationContext(context) {
-    if (!isObject(context) && !Array.isArray(context)) {
-      ensureURI(context);
+  deriveCredentials(options) {
+    const presentation = this.createPresentation(options);
+    const { credentials } = presentation.spec;
+    if (credentials.length > 1) {
+      throw new Error('Cannot derive from multiple credentials in a presentation');
     }
-    this.presBuilder.context = context;
+
+    return credentials.map((credential) => {
+      if (!credential.revealedAttributes.proof) {
+        throw new Error('Credential proof is not revealed, it should be');
+      }
+
+      const date = new Date().toISOString();
+
+      return {
+        ...credential.revealedAttributes,
+        '@context': JSON.parse(credential.revealedAttributes['@context']),
+        type: JSON.parse(credential.revealedAttributes.type),
+        credentialSchema: JSON.parse(credential.schema),
+        issuer: credential.revealedAttributes.issuer || credential.revealedAttributes.proof.verificationMethod.split('#')[0],
+        issuanceDate: credential.revealedAttributes.issuanceDate || date,
+        proof: {
+          proofPurpose: 'assertionMethod',
+          created: date,
+          ...credential.revealedAttributes.proof,
+          type: BBS_SIG_PROOF_TYPE,
+          proofValue: presentation.proof,
+          nonce: presentation.nonce,
+          context: presentation.context,
+          attributeCiphertexts: presentation.attributeCiphertexts,
+          attributeEqualities: presentation.spec.attributeEqualities,
+          version: credential.version,
+        },
+      };
+    });
   }
 }

--- a/src/utils/vc/contexts/dock-bbs-v1.json
+++ b/src/utils/vc/contexts/dock-bbs-v1.json
@@ -3,6 +3,78 @@
     "@version": 1.1,
     "id": "@id",
     "type": "@type",
+
+    "dockBBS": "https://ld.dock.io/dock-bbs",
+    "parsingOptions": {
+      "@id": "dockBBS:parsingOptions",
+      "@type": "@id",
+      "@container": "@graph"
+    },
+    "defaultDecimalPlaces": {
+      "@id": "dockBBS:defaultDecimalPlaces",
+      "@type": "@id",
+      "@container": "@graph"
+    },
+    "defaultMinimumInteger": {
+      "@id": "dockBBS:defaultMinimumInteger",
+      "@type": "@id",
+      "@container": "@graph"
+    },
+    "useDefaults": {
+      "@id": "dockBBS:useDefaults",
+      "@type": "@id",
+      "@container": "@graph"
+    },
+    "version": {
+      "@id": "dockBBS:useDefaults",
+      "@type": "@id",
+      "@container": "@graph"
+    },
+
+    "Bls12381BBS+SignatureProofDock2022": {
+      "@id": "https://ld.dock.io/security#Bls12381BBS+SignatureDock2022",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+        "id": "@id",
+        "type": "@type",
+        "challenge": "https://ld.dock.io/security#challenge",
+        "created": {
+          "@id": "http://purl.org/dc/terms/created",
+          "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+        },
+        "domain": "https://ld.dock.io/security#domain",
+        "context": "https://ld.dock.io/security#context",
+        "attributeCiphertexts": "https://ld.dock.io/security#attributeCiphertexts",
+        "attributeEqualities": "https://ld.dock.io/security#attributeEqualities",
+        "proofValue": "https://ld.dock.io/security#proofValue",
+        "nonce": "https://ld.dock.io/security#nonce",
+        "proofPurpose": {
+          "@id": "https://ld.dock.io/security#proofPurpose",
+          "@type": "@vocab",
+          "@context": {
+            "@version": 1.1,
+            "@protected": true,
+            "id": "@id",
+            "type": "@type",
+            "assertionMethod": {
+              "@id": "https://ld.dock.io/security#assertionMethod",
+              "@type": "@id",
+              "@container": "@set"
+            },
+            "authentication": {
+              "@id": "https://ld.dock.io/security#authenticationMethod",
+              "@type": "@id",
+              "@container": "@set"
+            }
+          }
+        },
+        "verificationMethod": {
+          "@id": "https://ld.dock.io/security#verificationMethod",
+          "@type": "@id"
+        }
+      }
+    },
     "Bls12381BBS+SignatureDock2022": {
       "@id": "https://ld.dock.io/security#Bls12381BBS+SignatureDock2022",
       "@context": {

--- a/src/utils/vc/contexts/dock-bbs-v1.json
+++ b/src/utils/vc/contexts/dock-bbs-v1.json
@@ -3,7 +3,6 @@
     "@version": 1.1,
     "id": "@id",
     "type": "@type",
-
     "dockBBS": "https://ld.dock.io/dock-bbs",
     "parsingOptions": {
       "@id": "dockBBS:parsingOptions",
@@ -30,7 +29,6 @@
       "@type": "@id",
       "@container": "@graph"
     },
-
     "Bls12381BBS+SignatureProofDock2022": {
       "@id": "https://ld.dock.io/security#Bls12381BBS+SignatureDock2022",
       "@context": {

--- a/src/utils/vc/credentials.js
+++ b/src/utils/vc/credentials.js
@@ -11,7 +11,8 @@ import { DEFAULT_CONTEXT_V1_URL, credentialContextField } from './constants';
 import { ensureValidDatetime } from '../type-helpers';
 
 import {
-  EcdsaSepc256k1Signature2019, Ed25519Signature2018, Sr25519Signature2020, Bls12381BBSSignatureDock2022,
+  EcdsaSepc256k1Signature2019, Ed25519Signature2018, Sr25519Signature2020,
+  Bls12381BBSSignatureDock2022, Bls12381BBSSignatureProofDock2022,
 } from './custom_crypto';
 
 /**
@@ -218,7 +219,7 @@ export async function verifyCredential(credential, {
       controller,
     }),
     // TODO: support more key types, see digitalbazaar github
-    suite: [new Ed25519Signature2018(), new EcdsaSepc256k1Signature2019(), new Sr25519Signature2020(), new Bls12381BBSSignatureDock2022(), ...suite],
+    suite: [new Ed25519Signature2018(), new EcdsaSepc256k1Signature2019(), new Sr25519Signature2020(), new Bls12381BBSSignatureDock2022(), new Bls12381BBSSignatureProofDock2022(), ...suite],
     documentLoader: docLoader,
     compactProof,
   });

--- a/src/utils/vc/crypto/Bls12381BBSSignatureDock2022.js
+++ b/src/utils/vc/crypto/Bls12381BBSSignatureDock2022.js
@@ -140,6 +140,9 @@ export default class Bls12381BBSSignatureDock2022 extends CustomLinkedDataSignat
       credBuilder.setTopLevelField(k, custom[k]);
     });
 
+    credBuilder.setTopLevelField('@context', JSON.stringify(document['@context']));
+    credBuilder.setTopLevelField('type', JSON.stringify(document.type));
+
     const retval = credBuilder.updateSchemaIfNeeded(signingOptions);
     return [retval, credBuilder.schema];
   }

--- a/src/utils/vc/crypto/Bls12381BBSSignatureProofDock2022.js
+++ b/src/utils/vc/crypto/Bls12381BBSSignatureProofDock2022.js
@@ -1,0 +1,141 @@
+import {
+  BBSPlusPublicKeyG2,
+} from '@docknetwork/crypto-wasm-ts';
+import { Presentation } from '@docknetwork/crypto-wasm-ts/lib/anonymous-credentials/presentation';
+import b58 from 'bs58';
+
+import Bls12381BBSSignatureDock2022 from './Bls12381BBSSignatureDock2022';
+import { Bls12381BBSSigDockSigName, Bls12381BBSSigProofDockSigName } from './constants';
+
+import Bls12381G2KeyPairDock2022 from './Bls12381G2KeyPairDock2022';
+import CustomLinkedDataSignature from './custom-linkeddatasignature';
+
+const SUITE_CONTEXT_URL = 'https://www.w3.org/2018/credentials/v1';
+
+/*
+ * Converts a derived BBS+ proof credential to the native presentation format
+ */
+export function convertToPresentation(document) {
+  const {
+    '@context': context,
+    type,
+    credentialSchema,
+    issuer,
+    issuanceDate,
+    proof,
+    ...revealedAttributes
+  } = document;
+
+  return {
+    version: '0.0.1',
+    nonce: proof.nonce,
+    context: proof.context,
+    spec: {
+      credentials: [
+        {
+          version: proof.version,
+          schema: JSON.stringify(credentialSchema),
+          revealedAttributes: {
+            proof: {
+              type: Bls12381BBSSigDockSigName,
+              verificationMethod: proof.verificationMethod,
+            },
+            '@context': JSON.stringify(context),
+            type: JSON.stringify(type),
+            ...revealedAttributes,
+          },
+        },
+      ],
+      attributeEqualities: proof.attributeEqualities,
+    },
+    attributeCiphertexts: proof.attributeCiphertexts,
+    proof: proof.proofValue,
+  };
+}
+
+/**
+ * A BBS+ signature suite for use with derived BBS+ credentials aka BBS+ presentations
+ */
+export default class Bls12381BBSSignatureProofDock2022 extends CustomLinkedDataSignature {
+  /**
+   * Default constructor
+   * @param options {SignatureSuiteOptions} options for constructing the signature suite
+   */
+  constructor(options = {}) {
+    const {
+      verificationMethod,
+    } = options;
+
+    super({
+      type: Bls12381BBSSigProofDockSigName,
+      LDKeyClass: Bls12381G2KeyPairDock2022,
+      contextUrl: SUITE_CONTEXT_URL,
+      alg: Bls12381BBSSigProofDockSigName,
+    });
+
+    this.proof = {
+      '@context': [
+        {
+          sec: 'https://w3id.org/security#',
+          proof: {
+            '@id': 'sec:proof',
+            '@type': '@id',
+            '@container': '@graph',
+          },
+        },
+        'https://ld.dock.io/security/bbs/v1',
+      ],
+      type: Bls12381BBSSigProofDockSigName,
+    };
+
+    this.verificationMethod = verificationMethod;
+  }
+
+  async verifyProof({
+    proof, document, documentLoader, expansionMap,
+  }) {
+    try {
+      const verificationMethod = await this.getVerificationMethod(
+        {
+          proof, document, documentLoader, expansionMap,
+        },
+      );
+
+      const presentationJSON = convertToPresentation({ ...document, proof });
+      const recreatedPres = Presentation.fromJSON(presentationJSON);
+
+      const pks = [verificationMethod].map((keyDocument) => {
+        const pkRaw = b58.decode(keyDocument.publicKeyBase58);
+        return new BBSPlusPublicKeyG2(pkRaw);
+      });
+
+      if (!recreatedPres.verify(pks)) {
+        throw new Error('Invalid signature');
+      }
+
+      return { verified: true, verificationMethod };
+    } catch (error) {
+      return { verified: false, error };
+    }
+  }
+
+  /**
+   * @param document {object} to be signed.
+   * @param proof {object}
+   * @param documentLoader {function}
+   * @param expansionMap {function}
+   */
+  async getVerificationMethod({ proof, documentLoader }) {
+    return Bls12381BBSSignatureDock2022.getVerificationMethod({ proof, documentLoader });
+  }
+
+  ensureSuiteContext() {
+    // no-op
+  }
+}
+
+Bls12381BBSSignatureProofDock2022.proofType = [
+  Bls12381BBSSigProofDockSigName,
+  `sec:${Bls12381BBSSigProofDockSigName}`,
+  `https://w3id.org/security#${Bls12381BBSSigProofDockSigName}`,
+];

--- a/src/utils/vc/crypto/constants.js
+++ b/src/utils/vc/crypto/constants.js
@@ -5,4 +5,5 @@ export const Ed25519SigName = 'Ed25519Signature2018';
 export const Sr25519VerKeyName = 'Sr25519VerificationKey2020';
 export const Sr25519SigName = 'Sr25519Signature2020';
 export const Bls12381BBSSigDockSigName = 'Bls12381BBS+SignatureDock2022';
+export const Bls12381BBSSigProofDockSigName = 'Bls12381BBS+SignatureProofDock2022';
 export const Bls12381BBSDockVerKeyName = 'Bls12381G2VerificationKeyDock2022';

--- a/src/utils/vc/crypto/custom-linkeddatasignature.js
+++ b/src/utils/vc/crypto/custom-linkeddatasignature.js
@@ -115,8 +115,12 @@ export default class CustomLinkedDataSignature extends jsigs.suites.LinkedDataSi
 
     return {
       ...proof,
-      proofValue: MULTIBASE_BASE58BTC_HEADER + base58btc.encode(signatureBytes),
+      proofValue: CustomLinkedDataSignature.encodeProofValue(signatureBytes),
     };
+  }
+
+  static encodeProofValue(signatureBytes) {
+    return MULTIBASE_BASE58BTC_HEADER + base58btc.encode(signatureBytes);
   }
 
   /**

--- a/src/utils/vc/custom_crypto.js
+++ b/src/utils/vc/custom_crypto.js
@@ -7,6 +7,7 @@ import {
   Sr25519SigName,
   Bls12381BBSDockVerKeyName,
   Bls12381BBSSigDockSigName,
+  Bls12381BBSSigProofDockSigName,
 } from './crypto/constants';
 
 import EcdsaSecp256k1VerificationKey2019 from './crypto/EcdsaSecp256k1VerificationKey2019';
@@ -16,6 +17,7 @@ import Ed25519Signature2018 from './crypto/Ed25519Signature2018';
 import Sr25519VerificationKey2020 from './crypto/Sr25519VerificationKey2020';
 import Sr25519Signature2020 from './crypto/Sr25519Signature2020';
 import Bls12381BBSSignatureDock2022 from './crypto/Bls12381BBSSignatureDock2022';
+import Bls12381BBSSignatureProofDock2022 from './crypto/Bls12381BBSSignatureProofDock2022';
 
 export {
   EcdsaSecp256k1VerKeyName,
@@ -31,6 +33,8 @@ export {
   Sr25519VerificationKey2020,
   Sr25519Signature2020,
   Bls12381BBSSignatureDock2022,
+  Bls12381BBSSignatureProofDock2022,
   Bls12381BBSDockVerKeyName,
   Bls12381BBSSigDockSigName,
+  Bls12381BBSSigProofDockSigName,
 };

--- a/src/utils/vc/presentations.js
+++ b/src/utils/vc/presentations.js
@@ -209,13 +209,13 @@ export async function signPresentation(presentation, keyDoc, challenge, domain, 
   });
 }
 
-function isBBSPlusPresentation(presentation) {
+export function isBBSPlusPresentation(presentation) {
   // Since there is no type parameter present we have to guess by checking field types
   // these wont exist in a standard VP
   return typeof presentation.version === 'string' && typeof presentation.proof === 'string' && typeof presentation.spec !== 'undefined' && typeof presentation.spec.credentials !== 'undefined';
 }
 
-async function verifyBBSPlusPresentation(presentation, options = {}) {
+export async function verifyBBSPlusPresentation(presentation, options = {}) {
   const documentLoader = options.documentLoader || defaultDocumentLoader(options.resolver);
 
   const keyDocuments = await Promise.all(presentation.spec.credentials.map((c, idx) => {

--- a/tests/integration/anoncreds/bbs-derived-credentials.test.js
+++ b/tests/integration/anoncreds/bbs-derived-credentials.test.js
@@ -9,7 +9,9 @@ import BbsPlusPresentation from '../../../src/bbs-plus-presentation';
 import BBSPlusModule from '../../../src/modules/bbs-plus';
 import { registerNewDIDUsingPair } from '../helpers';
 import getKeyDoc from '../../../src/utils/vc/helpers';
-import { issueCredential, signPresentation, verifyPresentation, verifyCredential } from '../../../src/utils/vc';
+import {
+  issueCredential, signPresentation, verifyPresentation, verifyCredential,
+} from '../../../src/utils/vc';
 import { DockResolver } from '../../../src/resolver';
 import { convertToPresentation } from '../../../src/utils/vc/crypto/Bls12381BBSSignatureProofDock2022';
 import { createPresentation } from '../../create-presentation';
@@ -120,60 +122,59 @@ describe('BBS+ Derived Credentials', () => {
   async function createAndVerifyPresentation(credentials) {
     const holderKey = getKeyDoc(holder3DID, dock.keyring.addFromUri(holder3KeySeed, null, 'sr25519'), 'Sr25519VerificationKey2020');
 
-      const presId = randomAsHex(32);
-      const chal = randomAsHex(32);
-      const domain = 'test domain';
-      const presentation = createPresentation(
-        credentials,
-        presId,
-      );
+    const presId = randomAsHex(32);
+    const chal = randomAsHex(32);
+    const domain = 'test domain';
+    const presentation = createPresentation(
+      credentials,
+      presId,
+    );
 
-      expect(presentation).toMatchObject(
-        expect.objectContaining(
-          {
-            type: ['VerifiablePresentation'],
-            verifiableCredential: credentials,
-            id: presId,
-          },
-        ),
-      );
+    expect(presentation).toMatchObject(
+      expect.objectContaining(
+        {
+          type: ['VerifiablePresentation'],
+          verifiableCredential: credentials,
+          id: presId,
+        },
+      ),
+    );
 
-      const signedPres = await signPresentation(
-        presentation,
-        holderKey,
-        chal,
-        domain,
-        resolver,
-      );
+    const signedPres = await signPresentation(
+      presentation,
+      holderKey,
+      chal,
+      domain,
+      resolver,
+    );
 
-      expect(signedPres).toMatchObject(
-        expect.objectContaining(
-          {
-            type: ['VerifiablePresentation'],
-            verifiableCredential: credentials,
-            id: presId,
-            proof: expect.objectContaining({
-              type: 'Sr25519Signature2020',
-              challenge: chal,
-              domain,
-              proofPurpose: 'authentication',
-            }),
-          },
-        ),
-      );
+    expect(signedPres).toMatchObject(
+      expect.objectContaining(
+        {
+          type: ['VerifiablePresentation'],
+          verifiableCredential: credentials,
+          id: presId,
+          proof: expect.objectContaining({
+            type: 'Sr25519Signature2020',
+            challenge: chal,
+            domain,
+            proofPurpose: 'authentication',
+          }),
+        },
+      ),
+    );
 
-      const result = await verifyPresentation(signedPres, {
-        challenge: chal,
-        domain,
-        resolver,
-      });
+    const result = await verifyPresentation(signedPres, {
+      challenge: chal,
+      domain,
+      resolver,
+    });
 
-      expect(result.verified).toBe(true);
-      expect(result.presentationResult.verified).toBe(true);
-      expect(result.credentialResults.length).toBe(1);
-      expect(result.credentialResults[0].verified).toBe(true);
+    expect(result.verified).toBe(true);
+    expect(result.presentationResult.verified).toBe(true);
+    expect(result.credentialResults.length).toBe(1);
+    expect(result.credentialResults[0].verified).toBe(true);
   }
-
 
   test('Holder creates a derived BBS+ verifiable credential from a BBS+ credential with selective disclosure', async () => {
     const issuerKey = getKeyDoc(did1, keypair, keypair.type, keypair.id);

--- a/tests/integration/anoncreds/bbs-derived-credentials.test.js
+++ b/tests/integration/anoncreds/bbs-derived-credentials.test.js
@@ -1,0 +1,233 @@
+import { randomAsHex } from '@polkadot/util-crypto';
+import { stringToU8a, u8aToHex } from '@polkadot/util';
+import { initializeWasm } from '@docknetwork/crypto-wasm-ts';
+import { DockAPI } from '../../../src';
+import { FullNodeEndpoint, TestAccountURI, TestKeyringOpts } from '../../test-constants';
+import { createNewDockDID } from '../../../src/utils/did';
+import Bls12381G2KeyPairDock2022 from '../../../src/utils/vc/crypto/Bls12381G2KeyPairDock2022';
+import BbsPlusPresentation from '../../../src/bbs-plus-presentation';
+import BBSPlusModule from '../../../src/modules/bbs-plus';
+import { registerNewDIDUsingPair } from '../helpers';
+import getKeyDoc from '../../../src/utils/vc/helpers';
+import { issueCredential, signPresentation, verifyPresentation, verifyCredential } from '../../../src/utils/vc';
+import { DockResolver } from '../../../src/resolver';
+import { convertToPresentation } from '../../../src/utils/vc/crypto/Bls12381BBSSignatureProofDock2022';
+import { createPresentation } from '../../create-presentation';
+
+// TODO: move to fixtures
+const residentCardSchema = {
+  $schema: 'http://json-schema.org/draft-07/schema#',
+  $id: 'https://ld.dock.io/examples/resident-card-schema.json',
+  title: 'Resident Card Example',
+  type: 'object',
+  properties: {
+    credentialSubject: {
+      type: 'object',
+      properties: {
+        givenName: {
+          title: 'Given Name',
+          type: 'string',
+        },
+        familyName: {
+          title: 'Family Name',
+          type: 'string',
+        },
+        lprNumber: {
+          title: 'LPR Number',
+          type: 'integer',
+          minimum: 0,
+        },
+      },
+      required: [],
+    },
+  },
+};
+
+const embeddedSchema = {
+  id: `data:application/json;charset=utf-8,${encodeURIComponent(JSON.stringify(residentCardSchema))}`,
+  type: 'JsonSchemaValidator2018',
+};
+
+// TODO: move to fixtures
+const credentialJSON = {
+  '@context': [
+    'https://www.w3.org/2018/credentials/v1',
+    'https://w3id.org/citizenship/v1',
+    'https://ld.dock.io/security/bbs/v1',
+  ],
+  id: 'https://issuer.oidp.uscis.gov/credentials/83627465',
+  type: ['VerifiableCredential', 'PermanentResidentCard'],
+  credentialSchema: embeddedSchema,
+  identifier: '83627465',
+  name: 'Permanent Resident Card',
+  description: 'Government of Example Permanent Resident Card.',
+  issuanceDate: '2019-12-03T12:19:52Z',
+  expirationDate: '2029-12-03T12:19:52Z',
+  credentialSubject: {
+    id: 'did:example:b34ca6cd37bbf23',
+    type: ['PermanentResident', 'Person'],
+    givenName: 'JOHN',
+    familyName: 'SMITH',
+    lprNumber: 1234,
+  },
+};
+
+const holder3DID = createNewDockDID();
+// seed used for 3rd holder keys
+const holder3KeySeed = randomAsHex(32);
+
+describe('BBS+ Derived Credentials', () => {
+  const dock = new DockAPI();
+  const resolver = new DockResolver(dock);
+  let account;
+  let did1;
+  let pair1;
+  let chainModule;
+  let keypair;
+  let didDocument;
+
+  beforeAll(async () => {
+    await initializeWasm();
+    await dock.init({
+      keyring: TestKeyringOpts,
+      address: FullNodeEndpoint,
+    });
+    chainModule = dock.bbsPlusModule;
+    account = dock.keyring.addFromUri(TestAccountURI);
+
+    dock.setAccount(account);
+    pair1 = dock.keyring.addFromUri(randomAsHex(32));
+    did1 = createNewDockDID();
+    await registerNewDIDUsingPair(dock, did1, pair1);
+
+    keypair = Bls12381G2KeyPairDock2022.generate({
+      controller: did1,
+    });
+
+    const pk1 = BBSPlusModule.prepareAddPublicKey(u8aToHex(keypair.publicKeyBuffer));
+    await chainModule.addPublicKey(pk1, did1, did1, pair1, 1, { didModule: dock.did }, false);
+
+    didDocument = await dock.did.getDocument(did1);
+    const { publicKey } = didDocument;
+    expect(publicKey.length).toEqual(2);
+    expect(publicKey[1].type).toEqual('Bls12381G2VerificationKeyDock2022');
+    keypair.id = publicKey[1].id;
+
+    // Register holder DID with sr25519 key
+    await registerNewDIDUsingPair(dock, holder3DID, dock.keyring.addFromUri(holder3KeySeed, null, 'sr25519'));
+  }, 30000);
+
+  async function createAndVerifyPresentation(credentials) {
+    const holderKey = getKeyDoc(holder3DID, dock.keyring.addFromUri(holder3KeySeed, null, 'sr25519'), 'Sr25519VerificationKey2020');
+
+      const presId = randomAsHex(32);
+      const chal = randomAsHex(32);
+      const domain = 'test domain';
+      const presentation = createPresentation(
+        credentials,
+        presId,
+      );
+
+      expect(presentation).toMatchObject(
+        expect.objectContaining(
+          {
+            type: ['VerifiablePresentation'],
+            verifiableCredential: credentials,
+            id: presId,
+          },
+        ),
+      );
+
+      const signedPres = await signPresentation(
+        presentation,
+        holderKey,
+        chal,
+        domain,
+        resolver,
+      );
+
+      expect(signedPres).toMatchObject(
+        expect.objectContaining(
+          {
+            type: ['VerifiablePresentation'],
+            verifiableCredential: credentials,
+            id: presId,
+            proof: expect.objectContaining({
+              type: 'Sr25519Signature2020',
+              challenge: chal,
+              domain,
+              proofPurpose: 'authentication',
+            }),
+          },
+        ),
+      );
+
+      const result = await verifyPresentation(signedPres, {
+        challenge: chal,
+        domain,
+        resolver,
+      });
+
+      expect(result.verified).toBe(true);
+      expect(result.presentationResult.verified).toBe(true);
+      expect(result.credentialResults.length).toBe(1);
+      expect(result.credentialResults[0].verified).toBe(true);
+  }
+
+
+  test('Holder creates a derived BBS+ verifiable credential from a BBS+ credential with selective disclosure', async () => {
+    const issuerKey = getKeyDoc(did1, keypair, keypair.type, keypair.id);
+    const unsignedCred = {
+      ...credentialJSON,
+      issuer: did1,
+    };
+
+    const presentationOptions = { nonce: stringToU8a('noncetest'), context: 'my context' };
+
+    // Create W3C BBS+ credential
+    const credential = await issueCredential(issuerKey, unsignedCred);
+
+    // Begin to derive a credential from the above issued one
+    const bbsPlusPresentation = new BbsPlusPresentation();
+    const idx = await bbsPlusPresentation.addCredentialToPresent(credential, { resolver });
+
+    // Reveal subject attributes
+    await bbsPlusPresentation.addAttributeToReveal(idx, ['credentialSubject.lprNumber']);
+
+    // NOTE: revealing subject type because of JSON-LD processing for this certain credential
+    // you may not always need to do this depending on your JSON-LD contexts
+    await bbsPlusPresentation.addAttributeToReveal(idx, ['credentialSubject.type.0']);
+    await bbsPlusPresentation.addAttributeToReveal(idx, ['credentialSubject.type.1']);
+
+    // Derive a W3C Verifiable Credential JSON from the above presentation
+    const credentials = await bbsPlusPresentation.deriveCredentials(presentationOptions);
+    expect(credentials.length).toEqual(1);
+    expect(credentials[0].proof).toBeDefined();
+    expect(credentials[0]).toHaveProperty('credentialSubject');
+    expect(credentials[0].credentialSubject).toMatchObject(expect.objectContaining({
+      type: unsignedCred.credentialSubject.type,
+      lprNumber: 1234,
+    }));
+
+    // Ensure reconstructing presentation from credential matches
+    // NOTE: ignoring proof here as itll differ when signed twice as above
+    const presentation = await bbsPlusPresentation.createPresentation(presentationOptions);
+    const reconstructedBBSPres = convertToPresentation(credentials[0]);
+    expect(reconstructedBBSPres.proof).toBeDefined();
+    expect({
+      ...reconstructedBBSPres,
+      proof: '',
+    }).toMatchObject({ ...presentation, proof: '' });
+
+    // Try to verify the derived credential alone
+    const credentialResult = await verifyCredential(credentials[0], { resolver });
+    expect(credentialResult.verified).toEqual(true);
+
+    // Create a VP and verify it from this credential
+    await createAndVerifyPresentation(credentials);
+  }, 30000);
+
+  afterAll(async () => {
+    await dock.disconnect();
+  }, 10000);
+});

--- a/tests/integration/anoncreds/bbs-plus-presentation.test.js
+++ b/tests/integration/anoncreds/bbs-plus-presentation.test.js
@@ -20,44 +20,9 @@ const residentCardSchema = {
   title: 'Resident Card Example',
   type: 'object',
   properties: {
-    '@context': {
-      title: 'Context',
-      type: 'array',
-      items: [{ type: 'string' }, { type: 'string' }, { type: 'string' }],
-    },
-    id: {
-      title: 'Id',
-      type: 'string',
-    },
-    type: {
-      title: 'Type',
-      type: 'array',
-      items: [{ type: 'string' }, { type: 'string' }],
-    },
-    identifier: {
-      title: 'identifier',
-      type: 'string',
-    },
-    name: {
-      title: 'Name',
-      type: 'string',
-    },
-    description: {
-      title: 'Desc',
-      type: 'string',
-    },
     credentialSubject: {
       type: 'object',
       properties: {
-        id: {
-          title: 'Id',
-          type: 'string',
-        },
-        type: {
-          title: 'Type',
-          type: 'array',
-          items: [{ type: 'string' }, { type: 'string' }],
-        },
         givenName: {
           title: 'Given Name',
           type: 'string',
@@ -73,18 +38,6 @@ const residentCardSchema = {
         },
       },
       required: [],
-    },
-    expirationDate: {
-      title: 'Expiration Date',
-      type: 'string',
-    },
-    issuanceDate: {
-      title: 'Issuance Date',
-      type: 'string',
-    },
-    issuer: {
-      title: 'Issuer DID',
-      type: 'string',
     },
   },
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2348,10 +2348,10 @@
     ky "^0.25.1"
     ky-universal "^0.8.2"
 
-"@docknetwork/crypto-wasm-ts@0.31.0":
-  version "0.31.0"
-  resolved "https://registry.yarnpkg.com/@docknetwork/crypto-wasm-ts/-/crypto-wasm-ts-0.31.0.tgz#822b1ab113e62a60f5d00843c5984c6242b89b91"
-  integrity sha512-YXpEikOl54SKLXud69UqRAwZSbCPjJB7M5IG+VUMgCfmsUaxHYgRGsV6BQjFzvdKL4WrZre6VUrXxLDjaXLSbg==
+"@docknetwork/crypto-wasm-ts@0.31.1":
+  version "0.31.1"
+  resolved "https://registry.yarnpkg.com/@docknetwork/crypto-wasm-ts/-/crypto-wasm-ts-0.31.1.tgz#400540b2777445bd525daac917f37ec819f3e71e"
+  integrity sha512-wxuIsc0cW2ZJibagr0CluwHzV6JvZ4RLsjvUf7UKHiACXWFylf0pBP1X5xOE5tWBSO5YDi5xqz2PtxYZNyG4tA==
   dependencies:
     "@docknetwork/crypto-wasm" "0.16.0"
     "@types/flat" "^5.0.2"


### PR DESCRIPTION
Since Dock BBS+ presentations are not compatible with W3C verifiable presentations and the specs that rely on it (such as dif pres exchange etc), it makes sense to have a way of deriving a "BBS+ proof" credential that acts the same way. The caveat is that multiple BBS+ credentials derived are not supported this way, but you can always derive from multiple presentations to pack into one W3C Verifiable Presentation.

This is primarily for interop with other libs/systems, and should be the preferable way to use BBS+ credentials and their features within presentations. The basic flow is:

- Use BBS+ presentation builder to select attributes to disclose etc
- Finalize, create BBS+ presentation JSON then convert that to a W3C verifiable credential with BBS+ proof type
- This credential can be verified/wrapped in a VP and communicated
- On verification for that BBS+ proof type, convert the credential back into a Dock BBS+ presentation for verification

This has only been tested with selective disclosure for now, we should add more cases as we grow SDK BBS+ features