### PR TITLE
JWT VCs and JsonWebKey2020 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@docknetwork/sdk",
-  "version": "3.0.1",
+  "version": "4.0.0",
   "main": "index.js",
   "license": "MIT",
   "repository": {
@@ -97,6 +97,7 @@
     "@polkadot/types-known": "9.7.1",
     "@polkadot/util": "10.1.11",
     "@polkadot/util-crypto": "10.1.11",
+    "@transmute/json-web-signature": "^0.7.0-unstable.80",
     "axios": "0.27.2",
     "base64url": "3.0.1",
     "blake2b": "2.1.4",

--- a/src/utils/vc/contexts.js
+++ b/src/utils/vc/contexts.js
@@ -10,6 +10,7 @@ import odrl from './contexts/odrl.json';
 import bbsV1Context from './contexts/bbs-v1.json';
 import dockBBSV1Context from './contexts/dock-bbs-v1.json';
 import dockPrettyVCContext from './contexts/prettyvc.json';
+import jws2020V1Context from './contexts/jws-2020-v1.json';
 
 // Lookup of following URLs will lead to loading data from the context directory, this is done as the Sr25519 keys are not
 // supported in any W3C standard and vc-js has them stored locally. This is a temporary solution.
@@ -73,5 +74,9 @@ export default new Map([
   [
     'https://w3id.org/security/suites/ed25519-2020/v1',
     ed25519V1Context,
+  ],
+  [
+    'https://w3id.org/security/suites/jws-2020/v1',
+    jws2020V1Context,
   ],
 ]);

--- a/src/utils/vc/contexts/jws-2020-v1.json
+++ b/src/utils/vc/contexts/jws-2020-v1.json
@@ -1,0 +1,82 @@
+{
+  "@context": {
+    "privateKeyJwk": {
+      "@id": "https://w3id.org/security#privateKeyJwk",
+      "@type": "@json"
+    },
+    "JsonWebKey2020": {
+      "@id": "https://w3id.org/security#JsonWebKey2020",
+      "@context": {
+        "@protected": true,
+        "id": "@id",
+        "type": "@type",
+        "publicKeyJwk": {
+          "@id": "https://w3id.org/security#publicKeyJwk",
+          "@type": "@json"
+        }
+      }
+    },
+    "JsonWebSignature2020": {
+      "@id": "https://w3id.org/security#JsonWebSignature2020",
+      "@context": {
+        "@protected": true,
+
+        "id": "@id",
+        "type": "@type",
+
+        "challenge": "https://w3id.org/security#challenge",
+        "created": {
+          "@id": "http://purl.org/dc/terms/created",
+          "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+        },
+        "domain": "https://w3id.org/security#domain",
+        "expires": {
+          "@id": "https://w3id.org/security#expiration",
+          "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+        },
+        "jws": "https://w3id.org/security#jws",
+        "nonce": "https://w3id.org/security#nonce",
+        "proofPurpose": {
+          "@id": "https://w3id.org/security#proofPurpose",
+          "@type": "@vocab",
+          "@context": {
+            "@protected": true,
+
+            "id": "@id",
+            "type": "@type",
+
+            "assertionMethod": {
+              "@id": "https://w3id.org/security#assertionMethod",
+              "@type": "@id",
+              "@container": "@set"
+            },
+            "authentication": {
+              "@id": "https://w3id.org/security#authenticationMethod",
+              "@type": "@id",
+              "@container": "@set"
+            },
+            "capabilityInvocation": {
+              "@id": "https://w3id.org/security#capabilityInvocationMethod",
+              "@type": "@id",
+              "@container": "@set"
+            },
+            "capabilityDelegation": {
+              "@id": "https://w3id.org/security#capabilityDelegationMethod",
+              "@type": "@id",
+              "@container": "@set"
+            },
+            "keyAgreement": {
+              "@id": "https://w3id.org/security#keyAgreementMethod",
+              "@type": "@id",
+              "@container": "@set"
+            }
+          }
+        },
+        "verificationMethod": {
+          "@id": "https://w3id.org/security#verificationMethod",
+          "@type": "@id"
+        }
+      }
+    }
+  }
+}

--- a/src/utils/vc/credentials.js
+++ b/src/utils/vc/credentials.js
@@ -46,10 +46,13 @@ export function formatToJWTPayload(keyDoc, cred) {
   const kid = keyDoc.id;
   const credentialIssuer = cred.issuer;
   const subject = cred.credentialSubject.id;
-  const validFrom = cred.validFrom || cred.issuanceDate;
   const { issuanceDate, expirationDate } = cred;
 
-  // Reference: https://www.w3.org/TR/vc-data-model/#jwt-encoding
+  // NOTE: Expecting validFrom here for future spec support
+  const validFrom = cred.validFrom || issuanceDate;
+
+  // References: https://www.w3.org/TR/vc-data-model/#jwt-encoding
+  // https://www.rfc-editor.org/rfc/rfc7519#section-4.1.6
   const vcJwtPayload = {
     jti: cred.id,
     sub: subject || '',

--- a/src/utils/vc/crypto/JsonWebSignature2020.js
+++ b/src/utils/vc/crypto/JsonWebSignature2020.js
@@ -1,0 +1,101 @@
+import { JsonWebKey } from '@transmute/json-web-signature';
+import CustomLinkedDataSignature from './custom-linkeddatasignature';
+// import JsonWebKey from './JsonWebKey';
+
+const SUITE_CONTEXT_URL = 'https://w3id.org/security/suites/jws-2020/v1';
+
+export default class JsonWebSignature2020 extends CustomLinkedDataSignature {
+// export default class JsonWebSignature2020 extends JsonWebSignature {
+  /**
+   * Creates a new JsonWebSignature2020 instance
+   * @constructor
+   * @param {object} config - Configuration options
+   */
+  constructor(options = {}) {
+    const {
+      keypair, verifier, signer, useProofValue, verificationMethod,
+    } = options;
+
+    super({
+      type: 'JsonWebSignature2020',
+      LDKeyClass: JsonWebKey,
+      contextUrl: SUITE_CONTEXT_URL,
+      signer: signer || (keypair && keypair.privateKey && keypair.signer()),
+      // alg: keypair && keypair.publicKey && keypair.publicKey.algorithm.name,
+      verifier: verifier || (keypair && keypair.verifier()),
+      useProofValue,
+    });
+
+    this.requiredKeyType = 'JsonWebKey2020';
+    this.verificationMethod = verificationMethod || (keypair && keypair.id);
+  }
+
+  /**
+   * Adds a signature (proofValue) field to the proof object. Called by
+   * LinkedDataSignature.createProof().
+   *
+   * @param {object} options - The options to use.
+   * @param {Uint8Array} options.verifyData - Data to be signed (extracted
+   *   from document, according to the suite's spec).
+   * @param {object} options.proof - Proof object (containing the proofPurpose,
+   *   verificationMethod, etc).
+   *
+   * @returns {Promise<object>} Resolves with the proof containing the signature
+   *   value.
+   */
+  async sign({ verifyData, proof }) {
+    const finalProof = { ...proof };
+    finalProof.jws = await this.signer.sign({ data: verifyData, detached: true });
+    return finalProof;
+  }
+
+  /**
+   * Verifies the proof signature against the given data.
+   *
+   * @param {object} options - The options to use.
+   * @param {Uint8Array} options.verifyData - Canonicalized hashed data.
+   * @param {object} options.verificationMethod - Key object.
+   * @param {object} options.proof - The proof to be verified.
+   *
+   * @returns {Promise<boolean>} Resolves with the verification result.
+   */
+  async verifySignature({ verifyData, verificationMethod, proof }) {
+    const data = verifyData;
+    let { verifier } = this;
+    if (!verifier) {
+      const key = await this.LDKeyClass.from(verificationMethod);
+      verifier = key.verifier();
+    }
+    return verifier.verify({ data, signature: proof.jws });
+  }
+
+  /**
+   * @param document {object} to be signed.
+   * @param proof {object}
+   * @param documentLoader {function}
+   */
+  async getVerificationMethod({ proof, documentLoader }) {
+    let { verificationMethod } = proof;
+
+    if (typeof verificationMethod === 'object') {
+      verificationMethod = verificationMethod.id;
+    }
+
+    if (!verificationMethod) {
+      throw new Error('No "verificationMethod" found in proof.');
+    }
+
+    const { document } = await documentLoader(verificationMethod);
+
+    if (!document) {
+      throw new Error(`Verification method ${verificationMethod} not found.`);
+    }
+
+    // ensure verification method has not been revoked
+    if (document.revoked !== undefined) {
+      throw new Error('The verification method has been revoked.');
+    }
+
+    return document;
+  }
+}

--- a/src/utils/vc/crypto/JsonWebSignature2020.js
+++ b/src/utils/vc/crypto/JsonWebSignature2020.js
@@ -1,11 +1,9 @@
 import { JsonWebKey } from '@transmute/json-web-signature';
 import CustomLinkedDataSignature from './custom-linkeddatasignature';
-// import JsonWebKey from './JsonWebKey';
 
 const SUITE_CONTEXT_URL = 'https://w3id.org/security/suites/jws-2020/v1';
 
 export default class JsonWebSignature2020 extends CustomLinkedDataSignature {
-// export default class JsonWebSignature2020 extends JsonWebSignature {
   /**
    * Creates a new JsonWebSignature2020 instance
    * @constructor

--- a/src/utils/vc/crypto/custom-linkeddatasignature.js
+++ b/src/utils/vc/crypto/custom-linkeddatasignature.js
@@ -111,12 +111,6 @@ export default class CustomLinkedDataSignature extends jsigs.suites.LinkedDataSi
         throw new Error('Invalid JWS header.');
       }
 
-      // if (header.alg !== this.alg) {
-      //   throw new Error(
-      //     `Invalid JWS header alg, expected ${this.alg}.`,
-      //   );
-      // }
-
       signatureBytes = decodeBase64Url(encodedSignature);
       data = createJws({ encodedHeader, verifyData });
     }

--- a/src/utils/vc/custom_crypto.js
+++ b/src/utils/vc/custom_crypto.js
@@ -18,6 +18,7 @@ import Sr25519VerificationKey2020 from './crypto/Sr25519VerificationKey2020';
 import Sr25519Signature2020 from './crypto/Sr25519Signature2020';
 import Bls12381BBSSignatureDock2022 from './crypto/Bls12381BBSSignatureDock2022';
 import Bls12381BBSSignatureProofDock2022 from './crypto/Bls12381BBSSignatureProofDock2022';
+import JsonWebSignature2020 from './crypto/JsonWebSignature2020';
 
 export {
   EcdsaSecp256k1VerKeyName,
@@ -37,4 +38,5 @@ export {
   Bls12381BBSDockVerKeyName,
   Bls12381BBSSigDockSigName,
   Bls12381BBSSigProofDockSigName,
+  JsonWebSignature2020,
 };

--- a/src/utils/vc/jws.js
+++ b/src/utils/vc/jws.js
@@ -1,0 +1,52 @@
+import base64url from 'base64url';
+
+const detachedHeaderParams = {
+  b64: false,
+  crit: ['b64'],
+};
+
+// Taken from https://github.com/transmute-industries/verifiable-data/blob/main/packages/jose-ld/src/JWS/createSigner.ts
+export async function signJWS(signer, type, options, data) {
+  if (!type) {
+    return signer.sign({ data });
+  }
+
+  const header = {
+    alg: type,
+    ...options.header,
+    ...(options.detached ? detachedHeaderParams : undefined),
+  };
+  const encodedHeader = base64url.encode(JSON.stringify(header));
+  const encodedPayload = base64url.encode(
+    data instanceof Uint8Array
+      ? Buffer.from(data).toString('utf-8')
+      : JSON.stringify(data),
+  );
+
+  const toBeSigned = options.detached
+    ? new Uint8Array(
+      Buffer.concat([
+        Buffer.from(encodedHeader, 'utf8'),
+        Buffer.from('.', 'utf-8'),
+        data,
+      ]),
+    )
+    : new Uint8Array(Buffer.from(`${encodedHeader}.${encodedPayload}`));
+
+  const signature = await signer.sign({ data: toBeSigned });
+
+  // If not, encode it ourselves
+  return options.detached
+    ? `${encodedHeader}..${base64url.encode(Buffer.from(signature))}`
+    : `${encodedHeader}.${encodedPayload}.${base64url.encode(
+      Buffer.from(signature),
+    )}`;
+}
+
+export function createJws({ encodedHeader, verifyData }) {
+  const buffer = Buffer.concat([
+    Buffer.from(`${encodedHeader}.`, 'utf8'),
+    Buffer.from(verifyData.buffer, verifyData.byteOffset, verifyData.length),
+  ]);
+  return new Uint8Array(buffer.buffer, buffer.byteOffset, buffer.length);
+}

--- a/src/utils/vc/presentations.js
+++ b/src/utils/vc/presentations.js
@@ -14,7 +14,7 @@ import {
 } from './constants';
 
 import {
-  EcdsaSepc256k1Signature2019, Ed25519Signature2018, Sr25519Signature2020,
+  EcdsaSepc256k1Signature2019, Ed25519Signature2018, JsonWebSignature2020, Sr25519Signature2020,
 } from './custom_crypto';
 
 import Bls12381BBSSignatureDock2022 from './crypto/Bls12381BBSSignatureDock2022';
@@ -139,7 +139,13 @@ export async function verifyPresentation(presentation, options = {}) {
     documentLoader: options.documentLoader || defaultDocumentLoader(resolver),
     ...options,
     resolver: null,
-    suite: [new Ed25519Signature2018(), new EcdsaSepc256k1Signature2019(), new Sr25519Signature2020(), ...suite],
+    suite: [
+      new Ed25519Signature2018(),
+      new EcdsaSepc256k1Signature2019(),
+      new Sr25519Signature2020(),
+      new JsonWebSignature2020(),
+      ...suite,
+    ],
   };
 
   // TODO: verify proof then credentials
@@ -196,8 +202,8 @@ export async function verifyPresentation(presentation, options = {}) {
  * @param {object} [presentationPurpose] - Optional presentation purpose to override default AuthenticationProofPurpose
  * @return {Promise<VerifiablePresentation>} A VerifiablePresentation with a proof.
  */
-export async function signPresentation(presentation, keyDoc, challenge, domain, resolver = null, compactProof = true, presentationPurpose = null) {
-  const suite = getSuiteFromKeyDoc(keyDoc);
+export async function signPresentation(presentation, keyDoc, challenge, domain, resolver = null, compactProof = true, presentationPurpose = null, addSuiteContext = true) {
+  const suite = await getSuiteFromKeyDoc(keyDoc);
   const purpose = presentationPurpose || new AuthenticationProofPurpose({
     domain,
     challenge,
@@ -205,7 +211,7 @@ export async function signPresentation(presentation, keyDoc, challenge, domain, 
 
   const documentLoader = defaultDocumentLoader(resolver);
   return jsigs.sign(presentation, {
-    purpose, documentLoader, domain, challenge, compactProof, suite,
+    purpose, documentLoader, domain, challenge, compactProof, suite, addSuiteContext,
   });
 }
 

--- a/src/verifiable-credential.js
+++ b/src/verifiable-credential.js
@@ -235,7 +235,7 @@ class VerifiableCredential {
    *   `@context` (if it is not present, it's added to the context list).
    * @returns {Promise<VerifiableCredential>}
    */
-  async sign(keyDoc, compactProof = true, issuerObject = null, addSuiteContext = false, useProofValue = false) {
+  async sign(keyDoc, compactProof = true, issuerObject = null, addSuiteContext = true, format = null) {
     const signedVC = await issueCredential(
       keyDoc,
       this.toJSON(),
@@ -243,10 +243,11 @@ class VerifiableCredential {
       null, null, null,
       issuerObject,
       addSuiteContext,
-      useProofValue,
+      format,
     );
     this.setProof(signedVC.proof);
     this.issuer = signedVC.issuer;
+    this.context = signedVC['@context'];
     return this;
   }
 

--- a/src/verifiable-credential.js
+++ b/src/verifiable-credential.js
@@ -233,9 +233,10 @@ class VerifiableCredential {
    * @param {Boolean} [addSuiteContext] - Toggles the default
    *   behavior of each signature suite enforcing the presence of its own
    *   `@context` (if it is not present, it's added to the context list).
+   * @param {(jsonld|jwt|proofValue)} [type] - Optional format/type of the credential (JSON-LD, JWT, proofValue)
    * @returns {Promise<VerifiableCredential>}
    */
-  async sign(keyDoc, compactProof = true, issuerObject = null, addSuiteContext = true, format = null) {
+  async sign(keyDoc, compactProof = true, issuerObject = null, addSuiteContext = true, type = null) {
     const signedVC = await issueCredential(
       keyDoc,
       this.toJSON(),
@@ -243,7 +244,7 @@ class VerifiableCredential {
       null, null, null,
       issuerObject,
       addSuiteContext,
-      format,
+      type,
     );
     this.setProof(signedVC.proof);
     this.issuer = signedVC.issuer;

--- a/src/verifiable-presentation.js
+++ b/src/verifiable-presentation.js
@@ -180,6 +180,7 @@ class VerifiablePresentation {
       compactProof,
     );
     this.proof = signedVP.proof.pop();
+    this.context = signedVP['@context'];
     return this;
   }
 

--- a/tests/cached-document-loader.js
+++ b/tests/cached-document-loader.js
@@ -19,7 +19,7 @@ export async function documentLoader(url) {
     }
     documentRegistry[url] = (await axios.get(url)).data;
     console.warn(
-      'Unit test is making web requests. This is slow. Please update ./test/network-cache.json',
+      'Unit test is making web requests. This is slow. Please update ./test/network-cache.js',
       'with: ',
       JSON.stringify({ [url]: documentRegistry[url] }, null, 2),
     );

--- a/tests/network-cache.js
+++ b/tests/network-cache.js
@@ -1,78 +1,4 @@
 export default {
-  'https://w3id.org/security/v1': {
-    '@context': {
-      id: '@id',
-      type: '@type',
-      dc: 'http://purl.org/dc/terms/',
-      sec: 'https://w3id.org/security#',
-      xsd: 'http://www.w3.org/2001/XMLSchema#',
-      EcdsaKoblitzSignature2016: 'sec:EcdsaKoblitzSignature2016',
-      Ed25519Signature2018: 'sec:Ed25519Signature2018',
-      EncryptedMessage: 'sec:EncryptedMessage',
-      GraphSignature2012: 'sec:GraphSignature2012',
-      LinkedDataSignature2015: 'sec:LinkedDataSignature2015',
-      LinkedDataSignature2016: 'sec:LinkedDataSignature2016',
-      CryptographicKey: 'sec:Key',
-      authenticationTag: 'sec:authenticationTag',
-      canonicalizationAlgorithm: 'sec:canonicalizationAlgorithm',
-      cipherAlgorithm: 'sec:cipherAlgorithm',
-      cipherData: 'sec:cipherData',
-      cipherKey: 'sec:cipherKey',
-      created: {
-        '@id': 'dc:created',
-        '@type': 'xsd:dateTime',
-      },
-      creator: {
-        '@id': 'dc:creator',
-        '@type': '@id',
-      },
-      digestAlgorithm: 'sec:digestAlgorithm',
-      digestValue: 'sec:digestValue',
-      domain: 'sec:domain',
-      encryptionKey: 'sec:encryptionKey',
-      expiration: {
-        '@id': 'sec:expiration',
-        '@type': 'xsd:dateTime',
-      },
-      expires: {
-        '@id': 'sec:expiration',
-        '@type': 'xsd:dateTime',
-      },
-      initializationVector: 'sec:initializationVector',
-      iterationCount: 'sec:iterationCount',
-      nonce: 'sec:nonce',
-      normalizationAlgorithm: 'sec:normalizationAlgorithm',
-      owner: {
-        '@id': 'sec:owner',
-        '@type': '@id',
-      },
-      password: 'sec:password',
-      privateKey: {
-        '@id': 'sec:privateKey',
-        '@type': '@id',
-      },
-      privateKeyPem: 'sec:privateKeyPem',
-      publicKey: {
-        '@id': 'sec:publicKey',
-        '@type': '@id',
-      },
-      publicKeyBase58: 'sec:publicKeyBase58',
-      publicKeyPem: 'sec:publicKeyPem',
-      publicKeyWif: 'sec:publicKeyWif',
-      publicKeyService: {
-        '@id': 'sec:publicKeyService',
-        '@type': '@id',
-      },
-      revoked: {
-        '@id': 'sec:revoked',
-        '@type': 'xsd:dateTime',
-      },
-      salt: 'sec:salt',
-      signature: 'sec:signature',
-      signatureAlgorithm: 'sec:signingAlgorithm',
-      signatureValue: 'sec:signatureValue',
-    },
-  },
   'https://gist.githubusercontent.com/lovesh/67bdfd354cfaf4fb853df4d6713f4610/raw': {
     id: 'https://gist.githubusercontent.com/lovesh/67bdfd354cfaf4fb853df4d6713f4610/raw',
     type: 'EcdsaSecp256k1VerificationKey2019',
@@ -89,5 +15,46 @@ export default {
     authentication: [
       'https://gist.githubusercontent.com/lovesh/67bdfd354cfaf4fb853df4d6713f4610/raw',
     ],
+  },
+
+  'urn:EcdsaSecp256k1VerificationKey2019#keys-1': {
+    id: 'urn:EcdsaSecp256k1VerificationKey2019#keys-1',
+    type: 'EcdsaSecp256k1VerificationKey2019',
+    publicKeyBase58: '222iuczftmixHLkW6wszwyeAfYCZA7bzQMhkEXpeNVJrk',
+    '@context': 'https://w3id.org/security/v2',
+    controller: 'urn:EcdsaSecp256k1VerificationKey2019',
+  },
+  'urn:EcdsaSecp256k1VerificationKey2019': {
+    '@context': 'https://w3id.org/security/v2',
+    id: 'urn:EcdsaSecp256k1VerificationKey2019',
+    assertionMethod: [
+      'urn:EcdsaSecp256k1VerificationKey2019#keys-1',
+    ],
+    authentication: [
+      'urn:EcdsaSecp256k1VerificationKey2019#keys-1',
+    ],
+  },
+
+  'urn:JsonWebKey2020': {
+    '@context': 'https://w3id.org/security/v2',
+    id: 'urn:JsonWebKey2020',
+    assertionMethod: [
+      'urn:JsonWebKey2020#keys-1',
+    ],
+    authentication: [
+      'urn:JsonWebKey2020#keys-1',
+    ],
+  },
+  'urn:JsonWebKey2020#keys-1': {
+    '@context': 'https://w3id.org/security/suites/jws-2020/v1',
+    id: 'urn:JsonWebKey2020#keys-1',
+    controller: 'urn:JsonWebKey2020',
+    type: 'JsonWebKey2020',
+    publicKeyJwk: {
+      kty: 'EC',
+      crv: 'P-384',
+      x: 'dMtj6RjwQK4G5HP3iwOD94RwbzPhS4wTZHO1luk_0Wz89chqV6uJyb51KaZzK0tk',
+      y: 'viPKF7Zbc4FxKegoupyVRcBr8TZHFxUrKQq4huOAyMuhTYJbFpAwMhIrWppql02E'
+    },
   },
 };

--- a/tests/test-keys.js
+++ b/tests/test-keys.js
@@ -1,0 +1,36 @@
+import { generateEcdsaSecp256k1Keypair, getPublicKeyFromKeyringPair } from '../src/utils/misc';
+
+const keypairEcdsaSecp256k1 = generateEcdsaSecp256k1Keypair('ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff');
+
+// TODO: add more testing keys (ed25519 etc)
+export default [{
+  sigType: 'JsonWebSignature2020',
+  keyDocument: {
+    '@context': 'https://w3id.org/security/suites/jws-2020/v1',
+    id: 'urn:JsonWebKey2020#keys-1',
+    controller: 'urn:JsonWebKey2020',
+    type: 'JsonWebKey2020',
+    publicKeyJwk: {
+      kty: "EC",
+      crv: "P-384",
+      x: "dMtj6RjwQK4G5HP3iwOD94RwbzPhS4wTZHO1luk_0Wz89chqV6uJyb51KaZzK0tk",
+      y: "viPKF7Zbc4FxKegoupyVRcBr8TZHFxUrKQq4huOAyMuhTYJbFpAwMhIrWppql02E"
+    },
+    privateKeyJwk: {
+      kty: "EC",
+      crv: "P-384",
+      x: "dMtj6RjwQK4G5HP3iwOD94RwbzPhS4wTZHO1luk_0Wz89chqV6uJyb51KaZzK0tk",
+      y: "viPKF7Zbc4FxKegoupyVRcBr8TZHFxUrKQq4huOAyMuhTYJbFpAwMhIrWppql02E",
+      d: "Wq5_KgqjvYh_EGvBDYtSs_0ufJJP0y0tkAXl6GqxHMkY0QP8vmD76mniXD-BWhd_"
+    }
+  },
+}, {
+  sigType: 'EcdsaSecp256k1Signature2019',
+  keyDocument: {
+    id: 'urn:EcdsaSecp256k1VerificationKey2019#keys-1',
+    controller: 'urn:EcdsaSecp256k1VerificationKey2019',
+    type: 'EcdsaSecp256k1VerificationKey2019',
+    keypair: keypairEcdsaSecp256k1,
+    publicKey: getPublicKeyFromKeyringPair(keypairEcdsaSecp256k1),
+  },
+}];

--- a/tests/unit/issuing.test.js
+++ b/tests/unit/issuing.test.js
@@ -10,14 +10,12 @@ import {
 import { createPresentation } from '../create-presentation';
 import VerifiableCredential from '../../src/verifiable-credential';
 import VerifiablePresentation from '../../src/verifiable-presentation';
-import { generateEcdsaSecp256k1Keypair, getPublicKeyFromKeyringPair } from '../../src/utils/misc';
+import testingKeys from '../test-keys';
 
 mockAxios();
 
 // Test constants
 const issuanceDate = '2020-04-15T09:05:35Z';
-
-const keypairEcdsaSecp256k1 = generateEcdsaSecp256k1Keypair('ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff');
 
 const vpId = 'https://example.com/credentials/12345';
 const vpHolder = 'https://example.com/credentials/1234567890';
@@ -55,39 +53,6 @@ function getSamplePres(presentationCredentials) {
     holder: vpHolder,
   };
 }
-
-// TODO: loop all tests for multiple testingKeys (ed25519 etc)
-const testingKeys = [{
-  sigType: 'JsonWebSignature2020',
-  keyDocument: {
-    '@context': 'https://w3id.org/security/suites/jws-2020/v1',
-    id: 'urn:JsonWebKey2020#keys-1',
-    controller: 'urn:JsonWebKey2020',
-    type: 'JsonWebKey2020',
-    publicKeyJwk: {
-      kty: "EC",
-      crv: "P-384",
-      x: "dMtj6RjwQK4G5HP3iwOD94RwbzPhS4wTZHO1luk_0Wz89chqV6uJyb51KaZzK0tk",
-      y: "viPKF7Zbc4FxKegoupyVRcBr8TZHFxUrKQq4huOAyMuhTYJbFpAwMhIrWppql02E"
-    },
-    privateKeyJwk: {
-      kty: "EC",
-      crv: "P-384",
-      x: "dMtj6RjwQK4G5HP3iwOD94RwbzPhS4wTZHO1luk_0Wz89chqV6uJyb51KaZzK0tk",
-      y: "viPKF7Zbc4FxKegoupyVRcBr8TZHFxUrKQq4huOAyMuhTYJbFpAwMhIrWppql02E",
-      d: "Wq5_KgqjvYh_EGvBDYtSs_0ufJJP0y0tkAXl6GqxHMkY0QP8vmD76mniXD-BWhd_"
-    }
-  },
-}, {
-  sigType: 'EcdsaSecp256k1Signature2019',
-  keyDocument: {
-    id: 'urn:EcdsaSecp256k1VerificationKey2019#keys-1',
-    controller: 'urn:EcdsaSecp256k1VerificationKey2019',
-    type: 'EcdsaSecp256k1VerificationKey2019',
-    keypair: keypairEcdsaSecp256k1,
-    publicKey: getPublicKeyFromKeyringPair(keypairEcdsaSecp256k1),
-  },
-}];
 
 testingKeys.forEach((testKey) => {
   const { sigType, keyDocument } = testKey;

--- a/tests/unit/issuing.test.js
+++ b/tests/unit/issuing.test.js
@@ -15,12 +15,23 @@ import { generateEcdsaSecp256k1Keypair, getPublicKeyFromKeyringPair } from '../.
 mockAxios();
 
 // Test constants
-const controllerUrl = 'https://gist.githubusercontent.com/lovesh/312d407e3a16be0e7d5e43169e824958/raw';
-const keyUrl = 'https://gist.githubusercontent.com/lovesh/67bdfd354cfaf4fb853df4d6713f4610/raw';
 const issuanceDate = '2020-04-15T09:05:35Z';
 
-function getSampleCredential(signed = false) {
-  let cred = {
+const keypairEcdsaSecp256k1 = generateEcdsaSecp256k1Keypair('ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff');
+
+const vpId = 'https://example.com/credentials/12345';
+const vpHolder = 'https://example.com/credentials/1234567890';
+const sampleId = 'http://example.edu/credentials/2803';
+const fakeContext = {
+  '@context': {
+    '@protected': true,
+    id: '@id',
+    type: '@type',
+  },
+};
+
+function getSampleCredential() {
+  return {
     '@context': [
       'https://www.w3.org/2018/credentials/v1',
       'https://www.w3.org/2018/credentials/examples/v1',
@@ -33,471 +44,471 @@ function getSampleCredential(signed = false) {
       alumniOf: 'Example University',
     },
   };
-  if (signed) {
-    cred = {
-      ...cred,
-      issuer: controllerUrl,
-      proof: {
-        type: 'EcdsaSecp256k1Signature2019',
-        created: '2021-11-24T21:47:28Z',
-        proofValue: 'zAN1rKvtBajWcQS61LU4wX8hB4tUNFze44pHKwkVYoZaGMRxXquAaKcnUiwarZyWmMQzB4ttFLCEFXQq6F9dnq5pWJSC1WZgga',
-        proofPurpose: 'assertionMethod',
-        verificationMethod: keyUrl,
-      },
-    };
-  }
-  return cred;
 }
 
-function getSamplePres(signed = false) {
-  let vp = {
+function getSamplePres(presentationCredentials) {
+  return {
     '@context': ['https://www.w3.org/2018/credentials/v1'],
     type: ['VerifiablePresentation'],
     verifiableCredential: presentationCredentials,
     id: vpId,
     holder: vpHolder,
   };
-  if (signed) {
-    vp = {
-      ...vp,
-      '@context': expect.anything(),
-      proof: {
-        type: 'EcdsaSecp256k1Signature2019',
-        challenge: 'some_challenge',
-        domain: 'some_domain',
-        jws: expect.anything(),
-        proofPurpose: 'authentication',
-        verificationMethod: keyUrl,
-      },
-    };
-  }
-  return vp;
 }
 
-const keypair = generateEcdsaSecp256k1Keypair('ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff');
-
-function getSampleKey() {
-  return {
-    id: keyUrl,
-    controller: controllerUrl,
-    type: 'EcdsaSecp256k1VerificationKey2019',
-    keypair,
-    publicKey: getPublicKeyFromKeyringPair(keypair),
-  };
-}
-const vpId = 'https://example.com/credentials/12345';
-const vpHolder = 'https://example.com/credentials/1234567890';
-const presentationCredentials = [getSampleCredential(true), getSampleCredential(true)];
-const sampleId = 'http://example.edu/credentials/2803';
-const fakeContext = {
-  '@context': {
-    '@protected': true,
-    id: '@id',
-    type: '@type',
+// TODO: loop all tests for multiple testingKeys (ed25519 etc)
+const testingKeys = [{
+  sigType: 'JsonWebSignature2020',
+  keyDocument: {
+    '@context': 'https://w3id.org/security/suites/jws-2020/v1',
+    id: 'urn:JsonWebKey2020#keys-1',
+    controller: 'urn:JsonWebKey2020',
+    type: 'JsonWebKey2020',
+    publicKeyJwk: {
+      kty: "EC",
+      crv: "P-384",
+      x: "dMtj6RjwQK4G5HP3iwOD94RwbzPhS4wTZHO1luk_0Wz89chqV6uJyb51KaZzK0tk",
+      y: "viPKF7Zbc4FxKegoupyVRcBr8TZHFxUrKQq4huOAyMuhTYJbFpAwMhIrWppql02E"
+    },
+    privateKeyJwk: {
+      kty: "EC",
+      crv: "P-384",
+      x: "dMtj6RjwQK4G5HP3iwOD94RwbzPhS4wTZHO1luk_0Wz89chqV6uJyb51KaZzK0tk",
+      y: "viPKF7Zbc4FxKegoupyVRcBr8TZHFxUrKQq4huOAyMuhTYJbFpAwMhIrWppql02E",
+      d: "Wq5_KgqjvYh_EGvBDYtSs_0ufJJP0y0tkAXl6GqxHMkY0QP8vmD76mniXD-BWhd_"
+    }
   },
-};
+}, {
+  sigType: 'EcdsaSecp256k1Signature2019',
+  keyDocument: {
+    id: 'urn:EcdsaSecp256k1VerificationKey2019#keys-1',
+    controller: 'urn:EcdsaSecp256k1VerificationKey2019',
+    type: 'EcdsaSecp256k1VerificationKey2019',
+    keypair: keypairEcdsaSecp256k1,
+    publicKey: getPublicKeyFromKeyringPair(keypairEcdsaSecp256k1),
+  },
+}];
 
-describe('Verifiable Credential Issuing', () => {
-  test('Issuing should return an object with a proof, and it must pass validation.', async () => {
-    const credential = await issueCredential(getSampleKey(), getSampleCredential());
-    expect(credential.id).toBe('https://example.com/credentials/1872');
-    expect(credential.type).toContain('VerifiableCredential');
-    expect(credential.type).toContain('AlumniCredential');
-    expect(credential.issuanceDate).toBe(issuanceDate);
-    expect(credential.credentialSubject.id).toBe('did:example:ebfeb1f712ebc6f1c276e12ec21');
-    expect(credential.credentialSubject.alumniOf).toBe('Example University');
-    expect(credential.issuer).toBe(controllerUrl);
-    expect(credential.proof.type).toBe('EcdsaSecp256k1Signature2019');
-    expect(credential.proof.created).toBeDefined();
-    expect(credential.proof.proofPurpose).toBe('assertionMethod');
-    expect(credential.proof.verificationMethod).toBe(keyUrl);
+testingKeys.forEach((testKey) => {
+  const { sigType, keyDocument } = testKey;
+  const keyUrl = keyDocument.id;
+  const controllerUrl = keyDocument.controller;
 
-    const result = await verifyCredential(credential);
-    expect(result.verified).toBe(true);
-    expect(result.results[0].proof).toBeDefined();
-    expect(result.results[0].verified).toBe(true);
-  }, 30000);
+  describe(`Verifiable Credential Issuing [${keyDocument.type}]`, () => {
+    test('Issuing should return an object with a proof, and it must pass validation.', async () => {
+      const credential = await issueCredential(testKey.keyDocument, getSampleCredential());
+      expect(credential.id).toBe('https://example.com/credentials/1872');
+      expect(credential.type).toContain('VerifiableCredential');
+      expect(credential.type).toContain('AlumniCredential');
+      expect(credential.issuanceDate).toBe(issuanceDate);
+      expect(credential.credentialSubject.id).toBe('did:example:ebfeb1f712ebc6f1c276e12ec21');
+      expect(credential.credentialSubject.alumniOf).toBe('Example University');
+      expect(credential.issuer).toBe(controllerUrl);
+      expect(credential.proof.type).toBe(sigType);
+      expect(credential.proof.created).toBeDefined();
+      expect(credential.proof.proofPurpose).toBe('assertionMethod');
+      expect(credential.proof.verificationMethod).toBe(keyUrl);
 
-  test('Issuing should return an object with a proof, and it must pass validation (using proofValue).', async () => {
-    const credential = await issueCredential(getSampleKey(), getSampleCredential(), true, null, null, null, null, false, true);
-    expect(credential.proof.proofValue).toBeDefined();
-    const result = await verifyCredential(credential);
-    expect(result.verified).toBe(true);
-  }, 30000);
+      const result = await verifyCredential(credential);
+      expect(result.verified).toBe(true);
+      expect(result.results[0].proof).toBeDefined();
+      expect(result.results[0].proof.proofPurpose).toBe('assertionMethod');
+      expect(result.results[0].proof.type).toBe(sigType);
+      expect(result.results[0].proof.verificationMethod).toBe(keyUrl);
+      expect(result.results[0].verified).toBe(true);
+    }, 30000);
 
-  test('Tampered Credential should not pass validation.', async () => {
-    const credential = await issueCredential(getSampleKey(), getSampleCredential());
-    credential.issuanceDate = '9020-04-15T09:05:35Z';
-    const result = await verifyCredential(credential);
-    expect(result.verified).toBe(false);
-  }, 30000);
+    // JsonWebKey signatures cant use proofValue
+    if (keyDocument.type !== 'JsonWebKey2020') {
+      test('Issuing should return an object with a proof, and it must pass validation (using proofValue).', async () => {
+        const credential = await issueCredential(testKey.keyDocument, getSampleCredential(), true, null, null, null, null, false, 'proofValue');
+        expect(credential.proof.proofValue).toBeDefined();
+        const result = await verifyCredential(credential);
+        expect(result.verified).toBe(true);
+      }, 30000);
+    }
 
-  test('Expired Credential should not pass validation with verifyDates as true', async () => {
-    const credential = await issueCredential(getSampleKey(), {
-      ...getSampleCredential(),
-      expirationDate: new Date('2000-01-01T09:05:35Z').toISOString(),
+    test('Issuing should return a valid JWT, and it must pass validation', async () => {
+      const credential = await issueCredential(testKey.keyDocument, getSampleCredential(), true, null, null, null, null, false, 'jwt');
+      expect(typeof credential).toEqual('string');
+      const result = await verifyCredential(credential);
+      expect(result.verified).toBe(true);
+    }, 30000);
+
+    test('Tampered Credential should not pass validation.', async () => {
+      const credential = await issueCredential(testKey.keyDocument, getSampleCredential());
+      credential.issuanceDate = '9020-04-15T09:05:35Z';
+      const result = await verifyCredential(credential);
+      expect(result.verified).toBe(false);
+    }, 30000);
+
+    test('Expired Credential should not pass validation with verifyDates as true', async () => {
+      const credential = await issueCredential(testKey.keyDocument, {
+        ...getSampleCredential(),
+        expirationDate: new Date('2000-01-01T09:05:35Z').toISOString(),
+      });
+      const result = await verifyCredential(credential);
+      expect(result.verified).toBe(false);
+      expect(result.error.message).toEqual('Credential has expired');
+    }, 30000);
+
+    test('Expired Credential should pass validation with verifyDates as false', async () => {
+      const credential = await issueCredential(testKey.keyDocument, {
+        ...getSampleCredential(),
+        expirationDate: new Date('2000-01-01T09:05:35Z').toISOString(),
+      });
+      const result = await verifyCredential(credential, { verifyDates: false });
+      expect(result.verified).toBe(true);
+    }, 30000);
+
+    test('Credential With incorrect issuer should not pass validation.', async () => {
+      const keydoc = { ...testKey.keyDocument };
+      keydoc.controller = 'did:rando:id';
+      const credential = await issueCredential(keydoc, getSampleCredential());
+      const result = await verifyCredential(credential);
+      expect(result.verified).toBe(false);
+    }, 30000);
+  });
+
+  describe(`Verifiable Presentation creation [${keyDocument.type}]`, () => {
+    let presentationCredentials;
+    beforeAll(async () => {
+      const sampleIssuedCredential = await issueCredential(testKey.keyDocument, getSampleCredential());
+      presentationCredentials = [sampleIssuedCredential, sampleIssuedCredential];
     });
-    const result = await verifyCredential(credential);
-    expect(result.verified).toBe(false);
-    expect(result.error.message).toEqual('Credential has expired');
-  }, 30000);
 
-  test('Expired Credential should pass validation with verifyDates as false', async () => {
-    const credential = await issueCredential(getSampleKey(), {
-      ...getSampleCredential(),
-      expirationDate: new Date('2000-01-01T09:05:35Z').toISOString(),
+    test('A proper verifiable presentation should be created from two valid sample credentials.', async () => {
+      const presentation = createPresentation(
+        presentationCredentials,
+        vpId,
+        vpHolder,
+      );
+      expect(presentation).toMatchObject(getSamplePres(presentationCredentials));
+    }, 30000);
+
+    test('A verifiable presentation should contain a proof once signed, and it should pass verification.', async () => {
+      const signedVp = await signPresentation(
+        getSamplePres(presentationCredentials),
+        testKey.keyDocument,
+        'some_challenge',
+        'some_domain',
+      );
+
+      const results = await verifyPresentation(
+        signedVp,
+        {
+          challenge: 'some_challenge',
+          domain: 'some_domain',
+        },
+      );
+
+      expect(results.verified).toBe(true);
+      expect(results.error).toBe(undefined);
+      expect(results.presentationResult.verified).toBe(true);
+      // expect(results.presentationResult.results[0].proof['@context']).toBe('https://w3id.org/security/v2');
+      expect(results.presentationResult.results[0].proof.type).toBe(sigType);
+      expect(results.presentationResult.results[0].proof.challenge).toBe('some_challenge');
+      expect(results.presentationResult.results[0].proof.domain).toBe('some_domain');
+      expect(results.presentationResult.results[0].proof.proofPurpose).toBe('authentication');
+      expect(results.presentationResult.results[0].proof.verificationMethod).toBe(keyUrl);
+      expect(results.presentationResult.results[0].verified).toBe(true);
+      expect(results.credentialResults[0].verified).toBe(true);
+      expect(results.credentialResults[0].results).toBeDefined();
+      expect(results.credentialResults[1].verified).toBe(true);
+      expect(results.credentialResults[1].results).toBeDefined();
+    }, 30000);
+  });
+
+  describe(`Verifiable Credential incremental creation [${keyDocument.type}]`, () => {
+    test('VC creation with only id should be possible, yet bring default values', async () => {
+      const credential = new VerifiableCredential(sampleId);
+      expect(credential.id).toBe(sampleId);
+      expect(credential.context).toEqual(['https://www.w3.org/2018/credentials/v1']);
+      expect(credential.type).toEqual(['VerifiableCredential']);
+      expect(credential.issuanceDate).toEqual(expect.anything());
     });
-    const result = await verifyCredential(credential, { verifyDates: false });
-    expect(result.verified).toBe(true);
-  }, 30000);
 
-  test('Credential With incorrect issuer should not pass validation.', async () => {
-    const keydoc = getSampleKey();
-    keydoc.controller = 'did:rando:id';
-    const credential = await issueCredential(keydoc, getSampleCredential());
-    const result = await verifyCredential(credential);
-    expect(result.verified).toBe(false);
-  }, 30000);
-});
+    test('VC creation with an object context should be possible', async () => {
+      const credential = new VerifiableCredential(sampleId);
+      credential.addContext(fakeContext);
+      expect(credential.context).toEqual(['https://www.w3.org/2018/credentials/v1', fakeContext]);
+    });
 
-describe('Verifiable Credential Verification', () => {
-  test('The sample signed credential should pass verification.', async () => {
-    const signedCred = getSampleCredential(true);
-    const result = await verifyCredential(signedCred);
-    expect(result.verified).toBe(true);
-    expect(result.results[0].proof.proofPurpose).toBe('assertionMethod');
-    expect(result.results[0].proof.type).toBe('EcdsaSecp256k1Signature2019');
-    expect(result.results[0].proof.verificationMethod).toBe(keyUrl);
-    expect(result.results[0].verified).toBe(true);
-  }, 30000);
-});
+    test('JSON representation of a VC should bring the proper keys', async () => {
+      const credential = new VerifiableCredential(sampleId);
+      const credentialJSON = credential.toJSON();
+      expect(credentialJSON['@context']).toContain('https://www.w3.org/2018/credentials/v1');
+      expect(credentialJSON.id).toBe(sampleId);
+      expect(credentialJSON.credentialSubject).toEqual([]);
+      expect(credentialJSON.type).toEqual(['VerifiableCredential']);
+      expect(credentialJSON.issuanceDate).toBeDefined();
+    });
 
-describe('Verifiable Presentation creation', () => {
-  test('A proper verifiable presentation should be created from two valid sample credentials.', async () => {
-    const presentation = createPresentation(
-      presentationCredentials,
-      vpId,
-      vpHolder,
-    );
-    expect(presentation).toMatchObject(getSamplePres());
-  }, 30000);
+    test('Incremental VC creation should be possible', async () => {
+      const credential = new VerifiableCredential(sampleId);
+      expect(credential.id).toBe(sampleId);
 
-  test('A verifiable presentation should contain a proof once signed, and it should pass verification.', async () => {
-    const signedVp = await signPresentation(
-      getSamplePres(),
-      getSampleKey(),
-      'some_challenge',
-      'some_domain',
-    );
-    expect(signedVp).toMatchObject(getSamplePres(true));
-    const results = await verifyPresentation(
-      signedVp,
-      {
+      credential.addContext('https://www.w3.org/2018/credentials/examples/v1');
+      expect(credential.context).toEqual([
+        'https://www.w3.org/2018/credentials/v1',
+        'https://www.w3.org/2018/credentials/examples/v1',
+      ]);
+      credential.addType('some_type');
+      expect(credential.type).toEqual([
+        'VerifiableCredential',
+        'some_type',
+      ]);
+      credential.addSubject({ id: 'some_subject_id' });
+      expect(credential.credentialSubject).toEqual([{ id: 'some_subject_id' }]);
+      credential.setStatus({ id: 'some_status_id', type: 'CredentialStatusList2017' });
+      expect(credential.status).toEqual({ id: 'some_status_id', type: 'CredentialStatusList2017' });
+      credential.setIssuanceDate('2020-03-18T19:23:24Z');
+      expect(credential.issuanceDate).toEqual('2020-03-18T19:23:24Z');
+      credential.setExpirationDate('2021-03-18T19:23:24Z');
+      expect(credential.expirationDate).toEqual('2021-03-18T19:23:24Z');
+    });
+
+    test('Duplicates in context, types and subjects are omitted.', async () => {
+      const credential = new VerifiableCredential(sampleId);
+
+      credential.addContext('https://www.w3.org/2018/credentials/examples/v1');
+      expect(credential.context).toEqual([
+        'https://www.w3.org/2018/credentials/v1',
+        'https://www.w3.org/2018/credentials/examples/v1',
+      ]);
+      credential.addContext('https://www.w3.org/2018/credentials/examples/v1');
+      expect(credential.context).toEqual([
+        'https://www.w3.org/2018/credentials/v1',
+        'https://www.w3.org/2018/credentials/examples/v1',
+      ]);
+      credential.addContext({ '@context': 'https://www.google.com' });
+      expect(credential.context).toEqual([
+        'https://www.w3.org/2018/credentials/v1',
+        'https://www.w3.org/2018/credentials/examples/v1',
+        { '@context': 'https://www.google.com' },
+      ]);
+      credential.addContext({ '@context': 'https://www.google.com' });
+      expect(credential.context).toEqual([
+        'https://www.w3.org/2018/credentials/v1',
+        'https://www.w3.org/2018/credentials/examples/v1',
+        { '@context': 'https://www.google.com' },
+      ]);
+
+      credential.addType('some_type');
+      expect(credential.type).toEqual([
+        'VerifiableCredential',
+        'some_type',
+      ]);
+      credential.addType('some_type');
+      expect(credential.type).toEqual([
+        'VerifiableCredential',
+        'some_type',
+      ]);
+
+      credential.addSubject({
+        id: 'did:example:ebfeb1f712ebc6f1c276e12ec21',
+        alumniOf: 'Example University',
+      });
+      expect(credential.credentialSubject).toEqual([{
+        id: 'did:example:ebfeb1f712ebc6f1c276e12ec21',
+        alumniOf: 'Example University',
+      }]);
+      credential.addSubject({
+        id: 'did:example:ebfeb1f712ebc6f1c276e12ec21',
+        alumniOf: 'Example University',
+      });
+      expect(credential.credentialSubject).toEqual([{
+        id: 'did:example:ebfeb1f712ebc6f1c276e12ec21',
+        alumniOf: 'Example University',
+      }]);
+    });
+
+    test('Incremental VC creations runs basic validation', async () => {
+      const credential = new VerifiableCredential(sampleId);
+      expect(() => {
+        credential.addContext(123);
+      }).toThrowError('needs to be a string.');
+
+      expect(() => {
+        credential.setStatus({ some: 'value', type: 'something' });
+      }).toThrowError('"credentialStatus" must include the \'id\' property.');
+      expect(() => {
+        credential.setStatus({ id: 'value', some: 'value' });
+      }).toThrowError('"credentialStatus" must include a type.');
+
+      expect(() => {
+        credential.setIssuanceDate('2020');
+      }).toThrowError('needs to be a valid datetime.');
+
+      expect(() => {
+        credential.setExpirationDate('2020');
+      }).toThrowError('needs to be a valid datetime.');
+
+      await expect(credential.verify()).rejects.toThrowError('The current Verifiable Credential has no proof.');
+    });
+
+    test('Issuing an incrementally-created VC should return an object with a proof, and it must pass validation.', async () => {
+      const unsignedCredential = new VerifiableCredential('https://example.com/credentials/1872');
+      unsignedCredential.addContext('https://www.w3.org/2018/credentials/examples/v1');
+      const signedCredential = await unsignedCredential.sign(testKey.keyDocument);
+      expect(signedCredential.proof).toBeDefined();
+      const result = await signedCredential.verify();
+      expect(result.verified).toBe(true);
+      expect(result.results[0].proof).toBeDefined();
+      expect(result.results[0].verified).toBe(true);
+    }, 30000);
+  });
+
+  describe(`Verifiable Presentation incremental creation [${keyDocument.type}]`, () => {
+    let presentationCredentials;
+    beforeAll(async () => {
+      const sampleIssuedCredential = await issueCredential(testKey.keyDocument, getSampleCredential());
+      presentationCredentials = [sampleIssuedCredential, sampleIssuedCredential];
+    });
+    
+    test('VP creation with only id should be possible, yet bring default values', async () => {
+      const vp = new VerifiablePresentation(sampleId);
+      expect(vp.id).toBe(sampleId);
+      expect(vp.context).toEqual(['https://www.w3.org/2018/credentials/v1']);
+      expect(vp.type).toEqual(['VerifiablePresentation']);
+      expect(vp.credentials).toEqual([]);
+    });
+
+    test('VP creation with an object context should be possible', async () => {
+      const vp = new VerifiablePresentation(sampleId);
+      vp.addContext(fakeContext);
+      expect(vp.context).toEqual(['https://www.w3.org/2018/credentials/v1', fakeContext]);
+    });
+
+    test('The JSON representation of a VP should bring the proper keys', async () => {
+      const vp = new VerifiablePresentation(sampleId);
+      const vpJSON = vp.toJSON();
+      expect(vpJSON['@context']).toContain('https://www.w3.org/2018/credentials/v1');
+      expect(vpJSON.id).toBe(sampleId);
+      expect(vpJSON.type).toEqual(['VerifiablePresentation']);
+      expect(vpJSON.verifiableCredential).toEqual([]);
+    });
+
+    test('Incremental VP creation should be possible', async () => {
+      const vp = new VerifiablePresentation(sampleId);
+      expect(vp.id).toBe(sampleId);
+
+      vp.addContext('https://www.w3.org/2018/credentials/examples/v1');
+      expect(vp.context).toEqual([
+        'https://www.w3.org/2018/credentials/v1',
+        'https://www.w3.org/2018/credentials/examples/v1',
+      ]);
+      vp.addType('some_type');
+      expect(vp.type).toEqual([
+        'VerifiablePresentation',
+        'some_type',
+      ]);
+      vp.addCredential({ id: 'some_credential_id' });
+      expect(vp.credentials).toEqual([{ id: 'some_credential_id' }]);
+    });
+
+    test('Incremental VP creations runs basic validation', async () => {
+      const vp = new VerifiablePresentation(sampleId);
+      expect(() => {
+        vp.addContext(123);
+      }).toThrowError('needs to be a string.');
+      expect(() => {
+        vp.addContext('123');
+      }).toThrowError('needs to be a valid URI.');
+
+      expect(() => {
+        vp.addCredential({ some: 'value' });
+      }).toThrowError('"credential" must include the \'id\' property.');
+
+      await expect(vp.verify({
         challenge: 'some_challenge',
         domain: 'some_domain',
-      },
-    );
-
-    expect(results.verified).toBe(true);
-    expect(results.error).toBe(undefined);
-    expect(results.presentationResult.verified).toBe(true);
-    // expect(results.presentationResult.results[0].proof['@context']).toBe('https://w3id.org/security/v2');
-    expect(results.presentationResult.results[0].proof.type).toBe('EcdsaSecp256k1Signature2019');
-    expect(results.presentationResult.results[0].proof.challenge).toBe('some_challenge');
-    expect(results.presentationResult.results[0].proof.domain).toBe('some_domain');
-    expect(results.presentationResult.results[0].proof.proofPurpose).toBe('authentication');
-    expect(results.presentationResult.results[0].proof.verificationMethod).toBe(keyUrl);
-    expect(results.presentationResult.results[0].verified).toBe(true);
-    expect(results.credentialResults[0].verified).toBe(true);
-    expect(results.credentialResults[0].results).toBeDefined();
-    expect(results.credentialResults[1].verified).toBe(true);
-    expect(results.credentialResults[1].results).toBeDefined();
-  }, 30000);
-});
-
-describe('Verifiable Credential incremental creation', () => {
-  test('VC creation with only id should be possible, yet bring default values', async () => {
-    const credential = new VerifiableCredential(sampleId);
-    expect(credential.id).toBe(sampleId);
-    expect(credential.context).toEqual(['https://www.w3.org/2018/credentials/v1']);
-    expect(credential.type).toEqual(['VerifiableCredential']);
-    expect(credential.issuanceDate).toEqual(expect.anything());
-  });
-
-  test('VC creation with an object context should be possible', async () => {
-    const credential = new VerifiableCredential(sampleId);
-    credential.addContext(fakeContext);
-    expect(credential.context).toEqual(['https://www.w3.org/2018/credentials/v1', fakeContext]);
-  });
-
-  test('JSON representation of a VC should bring the proper keys', async () => {
-    const credential = new VerifiableCredential(sampleId);
-    const credentialJSON = credential.toJSON();
-    expect(credentialJSON['@context']).toContain('https://www.w3.org/2018/credentials/v1');
-    expect(credentialJSON.id).toBe(sampleId);
-    expect(credentialJSON.credentialSubject).toEqual([]);
-    expect(credentialJSON.type).toEqual(['VerifiableCredential']);
-    expect(credentialJSON.issuanceDate).toBeDefined();
-  });
-
-  test('Incremental VC creation should be possible', async () => {
-    const credential = new VerifiableCredential(sampleId);
-    expect(credential.id).toBe(sampleId);
-
-    credential.addContext('https://www.w3.org/2018/credentials/examples/v1');
-    expect(credential.context).toEqual([
-      'https://www.w3.org/2018/credentials/v1',
-      'https://www.w3.org/2018/credentials/examples/v1',
-    ]);
-    credential.addType('some_type');
-    expect(credential.type).toEqual([
-      'VerifiableCredential',
-      'some_type',
-    ]);
-    credential.addSubject({ id: 'some_subject_id' });
-    expect(credential.credentialSubject).toEqual([{ id: 'some_subject_id' }]);
-    credential.setStatus({ id: 'some_status_id', type: 'CredentialStatusList2017' });
-    expect(credential.status).toEqual({ id: 'some_status_id', type: 'CredentialStatusList2017' });
-    credential.setIssuanceDate('2020-03-18T19:23:24Z');
-    expect(credential.issuanceDate).toEqual('2020-03-18T19:23:24Z');
-    credential.setExpirationDate('2021-03-18T19:23:24Z');
-    expect(credential.expirationDate).toEqual('2021-03-18T19:23:24Z');
-  });
-
-  test('Duplicates in context, types and subjects are omitted.', async () => {
-    const credential = new VerifiableCredential(sampleId);
-
-    credential.addContext('https://www.w3.org/2018/credentials/examples/v1');
-    expect(credential.context).toEqual([
-      'https://www.w3.org/2018/credentials/v1',
-      'https://www.w3.org/2018/credentials/examples/v1',
-    ]);
-    credential.addContext('https://www.w3.org/2018/credentials/examples/v1');
-    expect(credential.context).toEqual([
-      'https://www.w3.org/2018/credentials/v1',
-      'https://www.w3.org/2018/credentials/examples/v1',
-    ]);
-    credential.addContext({ '@context': 'https://www.google.com' });
-    expect(credential.context).toEqual([
-      'https://www.w3.org/2018/credentials/v1',
-      'https://www.w3.org/2018/credentials/examples/v1',
-      { '@context': 'https://www.google.com' },
-    ]);
-    credential.addContext({ '@context': 'https://www.google.com' });
-    expect(credential.context).toEqual([
-      'https://www.w3.org/2018/credentials/v1',
-      'https://www.w3.org/2018/credentials/examples/v1',
-      { '@context': 'https://www.google.com' },
-    ]);
-
-    credential.addType('some_type');
-    expect(credential.type).toEqual([
-      'VerifiableCredential',
-      'some_type',
-    ]);
-    credential.addType('some_type');
-    expect(credential.type).toEqual([
-      'VerifiableCredential',
-      'some_type',
-    ]);
-
-    credential.addSubject({
-      id: 'did:example:ebfeb1f712ebc6f1c276e12ec21',
-      alumniOf: 'Example University',
-    });
-    expect(credential.credentialSubject).toEqual([{
-      id: 'did:example:ebfeb1f712ebc6f1c276e12ec21',
-      alumniOf: 'Example University',
-    }]);
-    credential.addSubject({
-      id: 'did:example:ebfeb1f712ebc6f1c276e12ec21',
-      alumniOf: 'Example University',
-    });
-    expect(credential.credentialSubject).toEqual([{
-      id: 'did:example:ebfeb1f712ebc6f1c276e12ec21',
-      alumniOf: 'Example University',
-    }]);
-  });
-
-  test('Incremental VC creations runs basic validation', async () => {
-    const credential = new VerifiableCredential(sampleId);
-    expect(() => {
-      credential.addContext(123);
-    }).toThrowError('needs to be a string.');
-
-    expect(() => {
-      credential.setStatus({ some: 'value', type: 'something' });
-    }).toThrowError('"credentialStatus" must include the \'id\' property.');
-    expect(() => {
-      credential.setStatus({ id: 'value', some: 'value' });
-    }).toThrowError('"credentialStatus" must include a type.');
-
-    expect(() => {
-      credential.setIssuanceDate('2020');
-    }).toThrowError('needs to be a valid datetime.');
-
-    expect(() => {
-      credential.setExpirationDate('2020');
-    }).toThrowError('needs to be a valid datetime.');
-
-    await expect(credential.verify()).rejects.toThrowError('The current Verifiable Credential has no proof.');
-  });
-
-  test('Issuing an incrementally-created VC should return an object with a proof, and it must pass validation.', async () => {
-    const unsignedCredential = new VerifiableCredential('https://example.com/credentials/1872');
-    unsignedCredential.addContext('https://www.w3.org/2018/credentials/examples/v1');
-    const signedCredential = await unsignedCredential.sign(getSampleKey());
-    expect(signedCredential.proof).toBeDefined();
-    const result = await signedCredential.verify();
-    expect(result.verified).toBe(true);
-    expect(result.results[0].proof).toBeDefined();
-    expect(result.results[0].verified).toBe(true);
-  }, 30000);
-});
-
-describe('Verifiable Presentation incremental creation', () => {
-  test('VP creation with only id should be possible, yet bring default values', async () => {
-    const vp = new VerifiablePresentation(sampleId);
-    expect(vp.id).toBe(sampleId);
-    expect(vp.context).toEqual(['https://www.w3.org/2018/credentials/v1']);
-    expect(vp.type).toEqual(['VerifiablePresentation']);
-    expect(vp.credentials).toEqual([]);
-  });
-
-  test('VP creation with an object context should be possible', async () => {
-    const vp = new VerifiablePresentation(sampleId);
-    vp.addContext(fakeContext);
-    expect(vp.context).toEqual(['https://www.w3.org/2018/credentials/v1', fakeContext]);
-  });
-
-  test('The JSON representation of a VP should bring the proper keys', async () => {
-    const vp = new VerifiablePresentation(sampleId);
-    const vpJSON = vp.toJSON();
-    expect(vpJSON['@context']).toContain('https://www.w3.org/2018/credentials/v1');
-    expect(vpJSON.id).toBe(sampleId);
-    expect(vpJSON.type).toEqual(['VerifiablePresentation']);
-    expect(vpJSON.verifiableCredential).toEqual([]);
-  });
-
-  test('Incremental VP creation should be possible', async () => {
-    const vp = new VerifiablePresentation(sampleId);
-    expect(vp.id).toBe(sampleId);
-
-    vp.addContext('https://www.w3.org/2018/credentials/examples/v1');
-    expect(vp.context).toEqual([
-      'https://www.w3.org/2018/credentials/v1',
-      'https://www.w3.org/2018/credentials/examples/v1',
-    ]);
-    vp.addType('some_type');
-    expect(vp.type).toEqual([
-      'VerifiablePresentation',
-      'some_type',
-    ]);
-    vp.addCredential({ id: 'some_credential_id' });
-    expect(vp.credentials).toEqual([{ id: 'some_credential_id' }]);
-  });
-
-  test('Incremental VP creations runs basic validation', async () => {
-    const vp = new VerifiablePresentation(sampleId);
-    expect(() => {
-      vp.addContext(123);
-    }).toThrowError('needs to be a string.');
-    expect(() => {
-      vp.addContext('123');
-    }).toThrowError('needs to be a valid URI.');
-
-    expect(() => {
-      vp.addCredential({ some: 'value' });
-    }).toThrowError('"credential" must include the \'id\' property.');
-
-    await expect(vp.verify({
-      challenge: 'some_challenge',
-      domain: 'some_domain',
-    })).rejects.toThrowError('The current VerifiablePresentation has no proof.');
-  });
-
-  test('Incremental VP creation from external VCs should be possible', async () => {
-    const vp = new VerifiablePresentation(vpId);
-    vp.addCredential(getSampleCredential(true));
-    expect(vp.credentials).toEqual([getSampleCredential(true)]);
-    await vp.sign(
-      getSampleKey(),
-      'some_challenge',
-      'some_domain',
-    );
-    expect(vp.proof).toMatchObject({ type: 'EcdsaSecp256k1Signature2019' });
-    expect(vp.proof).toMatchObject({ created: expect.anything() });
-    expect(vp.proof).toMatchObject({ challenge: 'some_challenge' });
-    expect(vp.proof).toMatchObject({ domain: 'some_domain' });
-    expect(vp.proof).toMatchObject({ jws: expect.anything() });
-    expect(vp.proof).toMatchObject({ proofPurpose: 'authentication' });
-    expect(vp.proof).toMatchObject({ verificationMethod: expect.anything() });
-
-    const results = await vp.verify({
-      challenge: 'some_challenge',
-      domain: 'some_domain',
+      })).rejects.toThrowError('The current VerifiablePresentation has no proof.');
     });
 
-    expect(results.presentationResult).toMatchObject({ verified: true });
-    expect(results.presentationResult.results[0]).toMatchObject({ verified: true });
-    expect(results.presentationResult.results[0]).toMatchObject({ proof: expect.anything() });
-    expect(results.credentialResults[0]).toMatchObject({ verified: true });
-    expect(results.credentialResults[0]).toMatchObject({ results: expect.anything() });
-  }, 20000);
+    test('Incremental VP creation from external VCs should be possible', async () => {
+      const vp = new VerifiablePresentation(vpId);
+      vp.addCredential(presentationCredentials[0]);
+      expect(vp.credentials).toEqual([presentationCredentials[0]]);
+      await vp.sign(
+        testKey.keyDocument,
+        'some_challenge',
+        'some_domain',
+      );
+      expect(vp.proof).toMatchObject({ type: sigType });
+      expect(vp.proof).toMatchObject({ created: expect.anything() });
+      expect(vp.proof).toMatchObject({ challenge: 'some_challenge' });
+      expect(vp.proof).toMatchObject({ domain: 'some_domain' });
+      expect(vp.proof).toMatchObject({ jws: expect.anything() });
+      expect(vp.proof).toMatchObject({ proofPurpose: 'authentication' });
+      expect(vp.proof).toMatchObject({ verificationMethod: expect.anything() });
 
-  test('Issuing an incrementally-created VP from an incrementally created VC should return an object with a proof, and it must pass validation.', async () => {
-    const vc = new VerifiableCredential('https://example.com/credentials/1872');
-    vc.addContext('https://www.w3.org/2018/credentials/examples/v1');
-    vc.addType('AlumniCredential');
-    vc.addSubject({
-      id: 'did:example:ebfeb1f712ebc6f1c276e12ec21',
-      alumniOf: 'Example University',
+      const results = await vp.verify({
+        challenge: 'some_challenge',
+        domain: 'some_domain',
+      });
+
+      expect(results.presentationResult).toMatchObject({ verified: true });
+      expect(results.presentationResult.results[0]).toMatchObject({ verified: true });
+      expect(results.presentationResult.results[0]).toMatchObject({ proof: expect.anything() });
+      expect(results.credentialResults[0]).toMatchObject({ verified: true });
+      expect(results.credentialResults[0]).toMatchObject({ results: expect.anything() });
+    }, 20000);
+
+    test('Issuing an incrementally-created VP from an incrementally created VC should return an object with a proof, and it must pass validation.', async () => {
+      const vc = new VerifiableCredential('https://example.com/credentials/1872');
+      vc.addContext('https://www.w3.org/2018/credentials/examples/v1');
+      vc.addType('AlumniCredential');
+      vc.addSubject({
+        id: 'did:example:ebfeb1f712ebc6f1c276e12ec21',
+        alumniOf: 'Example University',
+      });
+      await vc.sign(testKey.keyDocument);
+      const vcVerificationResult = await vc.verify();
+      expect(vcVerificationResult).toMatchObject({ verified: true });
+
+      const vp = new VerifiablePresentation(vpId);
+      vp.setHolder(vpHolder);
+      vp.addCredential(vc);
+      await vp.sign(
+        testKey.keyDocument,
+        'some_challenge',
+        'some_domain',
+      );
+      expect(vp.proof).toMatchObject({ type: sigType });
+      expect(vp.proof).toMatchObject({ created: expect.anything() });
+      expect(vp.proof).toMatchObject({ challenge: 'some_challenge' });
+      expect(vp.proof).toMatchObject({ domain: 'some_domain' });
+      expect(vp.proof).toMatchObject({ jws: expect.anything() });
+      expect(vp.proof).toMatchObject({ proofPurpose: 'authentication' });
+      expect(vp.proof).toMatchObject({ verificationMethod: expect.anything() });
+
+      const results = await vp.verify({
+        challenge: 'some_challenge',
+        domain: 'some_domain',
+      });
+      expect(results.presentationResult).toMatchObject({ verified: true });
+      expect(results.presentationResult.results[0]).toMatchObject({ verified: true });
+      expect(results.presentationResult.results[0]).toMatchObject({ proof: expect.anything() });
+      expect(results.credentialResults[0]).toMatchObject({ verified: true });
+      expect(results.credentialResults[0]).toMatchObject({ results: expect.anything() });
+    }, 30000);
+
+    test('Support contexts without @context key', () => {
+      const credential = new VerifiableCredential(sampleId);
+      const context = {
+        name: 'http://schema.org/name',
+        image: {
+          '@id': 'http://schema.org/image',
+          '@type': '@id',
+        },
+        homepage: {
+          '@id': 'http://schema.org/url',
+          '@type': '@id',
+        },
+      };
+      credential.setContext(context);
+      expect(credential.context).toEqual(context);
     });
-    await vc.sign(getSampleKey());
-    const vcVerificationResult = await vc.verify();
-    expect(vcVerificationResult).toMatchObject({ verified: true });
-
-    const vp = new VerifiablePresentation(vpId);
-    vp.setHolder(vpHolder);
-    vp.addCredential(vc);
-    await vp.sign(
-      getSampleKey(),
-      'some_challenge',
-      'some_domain',
-    );
-    expect(vp.proof).toMatchObject({ type: 'EcdsaSecp256k1Signature2019' });
-    expect(vp.proof).toMatchObject({ created: expect.anything() });
-    expect(vp.proof).toMatchObject({ challenge: 'some_challenge' });
-    expect(vp.proof).toMatchObject({ domain: 'some_domain' });
-    expect(vp.proof).toMatchObject({ jws: expect.anything() });
-    expect(vp.proof).toMatchObject({ proofPurpose: 'authentication' });
-    expect(vp.proof).toMatchObject({ verificationMethod: expect.anything() });
-
-    const results = await vp.verify({
-      challenge: 'some_challenge',
-      domain: 'some_domain',
-    });
-    expect(results.presentationResult).toMatchObject({ verified: true });
-    expect(results.presentationResult.results[0]).toMatchObject({ verified: true });
-    expect(results.presentationResult.results[0]).toMatchObject({ proof: expect.anything() });
-    expect(results.credentialResults[0]).toMatchObject({ verified: true });
-    expect(results.credentialResults[0]).toMatchObject({ results: expect.anything() });
-  }, 30000);
-
-  test('Support contexts without @context key', () => {
-    const credential = new VerifiableCredential(sampleId);
-    const context = {
-      name: 'http://schema.org/name',
-      image: {
-        '@id': 'http://schema.org/image',
-        '@type': '@id',
-      },
-      homepage: {
-        '@id': 'http://schema.org/url',
-        '@type': '@id',
-      },
-    };
-    credential.setContext(context);
-    expect(credential.context).toEqual(context);
   });
 });

--- a/tests/unit/presigned-validation.test.js
+++ b/tests/unit/presigned-validation.test.js
@@ -1,0 +1,42 @@
+// Mock axios
+import mockAxios from '../mocks/axios';
+
+import {
+  verifyCredential,
+} from '../../src/utils/vc/index';
+
+mockAxios();
+
+const controllerUrl = 'https://gist.githubusercontent.com/lovesh/312d407e3a16be0e7d5e43169e824958/raw';
+const keyUrl = 'https://gist.githubusercontent.com/lovesh/67bdfd354cfaf4fb853df4d6713f4610/raw';
+
+function getSamplePresignedCredential() {
+  return {
+    '@context': [
+      'https://www.w3.org/2018/credentials/v1',
+      'https://www.w3.org/2018/credentials/examples/v1',
+    ],
+    id: 'https://example.com/credentials/1872',
+    type: ['VerifiableCredential', 'AlumniCredential'],
+    issuanceDate: '2020-04-15T09:05:35Z',
+    credentialSubject: {
+      id: 'did:example:ebfeb1f712ebc6f1c276e12ec21',
+      alumniOf: 'Example University',
+    },
+    issuer: controllerUrl,
+    proof: {
+      type: 'EcdsaSecp256k1Signature2019',
+      created: '2021-11-24T21:47:28Z',
+      proofValue: 'zAN1rKvtBajWcQS61LU4wX8hB4tUNFze44pHKwkVYoZaGMRxXquAaKcnUiwarZyWmMQzB4ttFLCEFXQq6F9dnq5pWJSC1WZgga',
+      proofPurpose: 'assertionMethod',
+      verificationMethod: keyUrl,
+    },
+  };
+}
+
+describe('Static pre-signed credential validation', () => {
+  test('Presigned credential should verify', async () => {
+    const results = await verifyCredential(getSamplePresignedCredential());
+    expect(results.verified).toBe(true);
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -939,6 +939,11 @@
     "@babel/helper-validator-identifier" "^7.19.1"
     to-fast-properties "^2.0.0"
 
+"@bitauth/libauth@^1.18.1":
+  version "1.19.1"
+  resolved "https://registry.yarnpkg.com/@bitauth/libauth/-/libauth-1.19.1.tgz#713751bbc09815b667f8fe00a1cc5b0f3bf45dd1"
+  integrity sha512-R524tD5VwOt3QRHr7N518nqTVR/HKgfWL4LypekcGuNQN8R4PWScvuRcRzrY39A28kLztMv+TJdiKuMNbkU1ug==
+
 "@cnakazawa/watch@^1.0.3":
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/@cnakazawa/watch/-/watch-1.0.4.tgz#f864ae85004d0fcab6f50be9141c4da368d1656a"
@@ -3009,6 +3014,33 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
+"@peculiar/asn1-schema@^2.3.6":
+  version "2.3.6"
+  resolved "https://registry.yarnpkg.com/@peculiar/asn1-schema/-/asn1-schema-2.3.6.tgz#3dd3c2ade7f702a9a94dfb395c192f5fa5d6b922"
+  integrity sha512-izNRxPoaeJeg/AyH8hER6s+H7p4itk+03QCa4sbxI3lNdseQYCuxzgsuNK8bTXChtLTjpJz6NmXKA73qLa3rCA==
+  dependencies:
+    asn1js "^3.0.5"
+    pvtsutils "^1.3.2"
+    tslib "^2.4.0"
+
+"@peculiar/json-schema@^1.1.12":
+  version "1.1.12"
+  resolved "https://registry.yarnpkg.com/@peculiar/json-schema/-/json-schema-1.1.12.tgz#fe61e85259e3b5ba5ad566cb62ca75b3d3cd5339"
+  integrity sha512-coUfuoMeIB7B8/NMekxaDzLhaYmp0HZNPEjYRm9goRou8UZIC3z21s0sL9AWoCw4EG876QyO3kYrc61WNF9B/w==
+  dependencies:
+    tslib "^2.0.0"
+
+"@peculiar/webcrypto@^1.1.6":
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/@peculiar/webcrypto/-/webcrypto-1.4.2.tgz#66d70ee476608fa45ebd60af0aa3c69640d0d85a"
+  integrity sha512-dMvTarTKRx3FzlRUD7Zi2qEsnWVedb/XNRvfM/JaanhTPm+ug9wPsvLXfPHDdl4mjbGdD+Lo/DXRd9sJRuQV3w==
+  dependencies:
+    "@peculiar/asn1-schema" "^2.3.6"
+    "@peculiar/json-schema" "^1.1.12"
+    pvtsutils "^1.3.2"
+    tslib "^2.5.0"
+    webcrypto-core "^1.7.7"
+
 "@polkadot/api-augment@9.7.1":
   version "9.7.1"
   resolved "https://registry.yarnpkg.com/@polkadot/api-augment/-/api-augment-9.7.1.tgz#4c42ca16fe7849279b00719f2b239dfd7b78f7a2"
@@ -3450,6 +3482,31 @@
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-4.6.0.tgz#3c7c9c46e678feefe7a2e5bb609d3dbd665ffb3f"
   integrity sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==
 
+"@stablelib/aead@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@stablelib/aead/-/aead-1.0.1.tgz#c4b1106df9c23d1b867eb9b276d8f42d5fc4c0c3"
+  integrity sha512-q39ik6sxGHewqtO0nP4BuSe3db5G1fEJE8ukvngS2gLkBXyy6E7pLubhbYgnkDFv6V8cWaxcE4Xn0t6LWcJkyg==
+
+"@stablelib/aes-kw@^1.0.0":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@stablelib/aes-kw/-/aes-kw-1.0.1.tgz#43f25517f719d69bb995909a5b69a2d9172c2a93"
+  integrity sha512-KrOkiRex1tQTbWk+hFB5fFw4vqKhNnTUtlCRf1bhUEOFp7hadWe49/sLa/P4X4FBQVoh3Z9Lj0zS1OWu/AHA1w==
+  dependencies:
+    "@stablelib/aes" "^1.0.1"
+    "@stablelib/binary" "^1.0.1"
+    "@stablelib/blockcipher" "^1.0.1"
+    "@stablelib/constant-time" "^1.0.1"
+    "@stablelib/wipe" "^1.0.1"
+
+"@stablelib/aes@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@stablelib/aes/-/aes-1.0.1.tgz#f2a8aec2cebaf0e69be2b49c7c57b4267867ffa5"
+  integrity sha512-bMiezJDeFONDHbMEa+Kic26962+bwkZfsHPAmcqTjLaHCAhEQuK3i1H0POPOkcHCdj75oVRIqFCraCA0cyHPvw==
+  dependencies:
+    "@stablelib/binary" "^1.0.1"
+    "@stablelib/blockcipher" "^1.0.1"
+    "@stablelib/wipe" "^1.0.1"
+
 "@stablelib/binary@^1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@stablelib/binary/-/binary-1.0.1.tgz#c5900b94368baf00f811da5bdb1610963dfddf7f"
@@ -3457,7 +3514,42 @@
   dependencies:
     "@stablelib/int" "^1.0.1"
 
-"@stablelib/ed25519@^1.0.2":
+"@stablelib/blockcipher@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@stablelib/blockcipher/-/blockcipher-1.0.1.tgz#535f067d147ecdc9625ccd2b0d129f6d53d563d2"
+  integrity sha512-4bkpV8HUAv0CgI1fUqkPUEEvv3RXQ3qBkuZaSWhshXGAz1JCpriesgiO9Qs4f0KzBJkCtvcho5n7d/RKvnHbew==
+
+"@stablelib/bytes@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@stablelib/bytes/-/bytes-1.0.1.tgz#0f4aa7b03df3080b878c7dea927d01f42d6a20d8"
+  integrity sha512-Kre4Y4kdwuqL8BR2E9hV/R5sOrUj6NanZaZis0V6lX5yzqC3hBuVSDXUIBqQv/sCpmuWRiHLwqiT1pqqjuBXoQ==
+
+"@stablelib/chacha20poly1305@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@stablelib/chacha20poly1305/-/chacha20poly1305-1.0.1.tgz#de6b18e283a9cb9b7530d8767f99cde1fec4c2ee"
+  integrity sha512-MmViqnqHd1ymwjOQfghRKw2R/jMIGT3wySN7cthjXCBdO+qErNPUBnRzqNpnvIwg7JBCg3LdeCZZO4de/yEhVA==
+  dependencies:
+    "@stablelib/aead" "^1.0.1"
+    "@stablelib/binary" "^1.0.1"
+    "@stablelib/chacha" "^1.0.1"
+    "@stablelib/constant-time" "^1.0.1"
+    "@stablelib/poly1305" "^1.0.1"
+    "@stablelib/wipe" "^1.0.1"
+
+"@stablelib/chacha@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@stablelib/chacha/-/chacha-1.0.1.tgz#deccfac95083e30600c3f92803a3a1a4fa761371"
+  integrity sha512-Pmlrswzr0pBzDofdFuVe1q7KdsHKhhU24e8gkEwnTGOmlC7PADzLVxGdn2PoNVBBabdg0l/IfLKg6sHAbTQugg==
+  dependencies:
+    "@stablelib/binary" "^1.0.1"
+    "@stablelib/wipe" "^1.0.1"
+
+"@stablelib/constant-time@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@stablelib/constant-time/-/constant-time-1.0.1.tgz#bde361465e1cf7b9753061b77e376b0ca4c77e35"
+  integrity sha512-tNOs3uD0vSJcK6z1fvef4Y+buN7DXhzHDPqRLSXUel1UfqMB1PWNsnnAezrKfEwTLpN0cGH2p9NNjs6IqeD0eg==
+
+"@stablelib/ed25519@^1.0.1", "@stablelib/ed25519@^1.0.2":
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/@stablelib/ed25519/-/ed25519-1.0.3.tgz#f8fdeb6f77114897c887bb6a3138d659d3f35996"
   integrity sha512-puIMWaX9QlRsbhxfDc5i+mNPMY+0TmQEskunY1rZEBPi1acBCVQAhnsk/1Hk50DGPtVsZtAWQg4NHGlVaO9Hqg==
@@ -3475,6 +3567,21 @@
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@stablelib/int/-/int-1.0.1.tgz#75928cc25d59d73d75ae361f02128588c15fd008"
   integrity sha512-byr69X/sDtDiIjIV6m4roLVWnNNlRGzsvxw+agj8CIEazqWGOQp2dTYgQhtyVXV9wpO6WyXRQUzLV/JRNumT2w==
+
+"@stablelib/keyagreement@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@stablelib/keyagreement/-/keyagreement-1.0.1.tgz#4612efb0a30989deb437cd352cee637ca41fc50f"
+  integrity sha512-VKL6xBwgJnI6l1jKrBAfn265cspaWBPAPEc62VBQrWHLqVgNRE09gQ/AnOEyKUWrrqfD+xSQ3u42gJjLDdMDQg==
+  dependencies:
+    "@stablelib/bytes" "^1.0.1"
+
+"@stablelib/poly1305@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@stablelib/poly1305/-/poly1305-1.0.1.tgz#93bfb836c9384685d33d70080718deae4ddef1dc"
+  integrity sha512-1HlG3oTSuQDOhSnLwJRKeTRSAdFNVB/1djy2ZbS35rBSJ/PFqx9cf9qatinWghC2UbfOYD8AcrtbUQl8WoxabA==
+  dependencies:
+    "@stablelib/constant-time" "^1.0.1"
+    "@stablelib/wipe" "^1.0.1"
 
 "@stablelib/random@^1.0.2":
   version "1.0.2"
@@ -3497,6 +3604,35 @@
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@stablelib/wipe/-/wipe-1.0.1.tgz#d21401f1d59ade56a62e139462a97f104ed19a36"
   integrity sha512-WfqfX/eXGiAd3RJe4VU2snh/ZPwtSjLG4ynQ/vYzvghTh7dHFcI1wl+nrkWG6lGhukOxOsUHfv8dUXr58D0ayg==
+
+"@stablelib/x25519@^1.0.0":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@stablelib/x25519/-/x25519-1.0.3.tgz#13c8174f774ea9f3e5e42213cbf9fc68a3c7b7fd"
+  integrity sha512-KnTbKmUhPhHavzobclVJQG5kuivH+qDLpe84iRqX3CLrKp881cF160JvXJ+hjn1aMyCwYOKeIZefIH/P5cJoRw==
+  dependencies:
+    "@stablelib/keyagreement" "^1.0.1"
+    "@stablelib/random" "^1.0.2"
+    "@stablelib/wipe" "^1.0.1"
+
+"@stablelib/xchacha20@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@stablelib/xchacha20/-/xchacha20-1.0.1.tgz#e98808d1f7d8b20e3ff37c71a3062a2a955d9a8c"
+  integrity sha512-1YkiZnFF4veUwBVhDnDYwo6EHeKzQK4FnLiO7ezCl/zu64uG0bCCAUROJaBkaLH+5BEsO3W7BTXTguMbSLlWSw==
+  dependencies:
+    "@stablelib/binary" "^1.0.1"
+    "@stablelib/chacha" "^1.0.1"
+    "@stablelib/wipe" "^1.0.1"
+
+"@stablelib/xchacha20poly1305@^1.0.0":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@stablelib/xchacha20poly1305/-/xchacha20poly1305-1.0.1.tgz#addcaf30b92dd956f76b3357888e2f91b92e7a61"
+  integrity sha512-B1Abj0sMJ8h3HNmGnJ7vHBrAvxuNka6cJJoZ1ILN7iuacXp7sUYcgOVEOTLWj+rtQMpspY9tXSCRLPmN1mQNWg==
+  dependencies:
+    "@stablelib/aead" "^1.0.1"
+    "@stablelib/chacha20poly1305" "^1.0.1"
+    "@stablelib/constant-time" "^1.0.1"
+    "@stablelib/wipe" "^1.0.1"
+    "@stablelib/xchacha20" "^1.0.1"
 
 "@substrate/connect-extension-protocol@^1.0.1":
   version "1.0.1"
@@ -3538,6 +3674,83 @@
   integrity sha512-+PmQX0PiAYPMeVYe237LJAYvOMYW1j2rH5YROyS3b4CTVJum34HfRvKvAzozHAQG0TnHNdUfY9nCeUyRAs//cw==
   dependencies:
     defer-to-connect "^2.0.1"
+
+"@transmute/ed25519-key-pair@^0.7.0-unstable.80":
+  version "0.7.0-unstable.80"
+  resolved "https://registry.yarnpkg.com/@transmute/ed25519-key-pair/-/ed25519-key-pair-0.7.0-unstable.80.tgz#c2c2f775bc932c9c8fdcfa1ad6d1095c76b61832"
+  integrity sha512-Rl9mdLkUrn299hUEeVlcx4JYg5S0zdK8M4GhuLGpcQozkqPApbDuuotzyNIp4ok3tDwyM0v62H1gZRxWEYcvMg==
+  dependencies:
+    "@stablelib/ed25519" "^1.0.1"
+    "@transmute/ld-key-pair" "^0.7.0-unstable.80"
+    "@transmute/x25519-key-pair" "^0.7.0-unstable.80"
+
+"@transmute/jose-ld@^0.7.0-unstable.80":
+  version "0.7.0-unstable.80"
+  resolved "https://registry.yarnpkg.com/@transmute/jose-ld/-/jose-ld-0.7.0-unstable.80.tgz#59c1d4dca48cd7c22c1730fca039b138e934b4c5"
+  integrity sha512-Bdb/+wd/SDaRpAlGmkDrXL6nsHdBO/7Zr+zNEYC7cQTtiTnKQsjAKbQa+AF470PEgNwJIbNK2YjWIwnsv5q69A==
+  dependencies:
+    "@peculiar/webcrypto" "^1.1.6"
+    "@stablelib/aes-kw" "^1.0.0"
+    "@stablelib/xchacha20poly1305" "^1.0.0"
+    base64url "^3.0.1"
+    jose "^4.3.8"
+    web-streams-polyfill "^3.0.3"
+
+"@transmute/json-web-signature@^0.7.0-unstable.80":
+  version "0.7.0-unstable.80"
+  resolved "https://registry.yarnpkg.com/@transmute/json-web-signature/-/json-web-signature-0.7.0-unstable.80.tgz#53c45b1c817f691d1014a0b7cc36ff5ce33a511d"
+  integrity sha512-vlLgCkn/1onskP/VWa6t3JBtVrvo1yz6NRpJ5b4abwav0/t6E+AGS64mpYiC6ZMQV32ZGXSFHDs6FAoeCrX57A==
+  dependencies:
+    "@transmute/ed25519-key-pair" "^0.7.0-unstable.80"
+    "@transmute/jose-ld" "^0.7.0-unstable.80"
+    "@transmute/jsonld" "0.0.4"
+    "@transmute/secp256k1-key-pair" "^0.7.0-unstable.80"
+    "@transmute/security-context" "^0.7.0-unstable.80"
+    "@transmute/web-crypto-key-pair" "^0.7.0-unstable.80"
+
+"@transmute/jsonld@0.0.4":
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/@transmute/jsonld/-/jsonld-0.0.4.tgz#09a7737edd1f827d65353c7207136c96e5875224"
+  integrity sha512-6G++8imMYW9dtTvATPHNfrV3lLeX5E57DOmlgIDfO0A0yjkBCss1usB80NfONS26ynyveb8vTbp4nQDW9Ki4Rw==
+  dependencies:
+    json-pointer "^0.6.2"
+    jsonld "5.2.0"
+
+"@transmute/ld-key-pair@^0.7.0-unstable.80":
+  version "0.7.0-unstable.80"
+  resolved "https://registry.yarnpkg.com/@transmute/ld-key-pair/-/ld-key-pair-0.7.0-unstable.80.tgz#1baafda865c3989d71590259de1552744f4e548c"
+  integrity sha512-oI6xJDT116+xViJKFxbjs8wX/k6O6e5kPKjmLfApYZKF63Tf01m+nflh7iAhgecSWl7W9SRo560SEtkyOVl7fQ==
+
+"@transmute/secp256k1-key-pair@^0.7.0-unstable.80":
+  version "0.7.0-unstable.80"
+  resolved "https://registry.yarnpkg.com/@transmute/secp256k1-key-pair/-/secp256k1-key-pair-0.7.0-unstable.80.tgz#38fe581a178219b9be544976ad5d600c989927f3"
+  integrity sha512-tPq00bzqfMKgk6YYEqtSU1p+702j7VV37XLFlwMSSDK18JgVoQlp3ULZddEeFajbXQgX8N6yq6jlDUdXLW27bA==
+  dependencies:
+    "@bitauth/libauth" "^1.18.1"
+    "@transmute/ld-key-pair" "^0.7.0-unstable.80"
+    secp256k1 "^4.0.2"
+
+"@transmute/security-context@^0.7.0-unstable.80":
+  version "0.7.0-unstable.80"
+  resolved "https://registry.yarnpkg.com/@transmute/security-context/-/security-context-0.7.0-unstable.80.tgz#0a10cc6fc740258dc2d7ec24115ed4823e290911"
+  integrity sha512-8Q1Q37QP1HNdemVNAi35Uaww1trPm7ybl8+vam90+MyI5kV4nLhOZab378vNYShUMgAccUkFXHlZSsuqD7HlCw==
+
+"@transmute/web-crypto-key-pair@^0.7.0-unstable.80":
+  version "0.7.0-unstable.80"
+  resolved "https://registry.yarnpkg.com/@transmute/web-crypto-key-pair/-/web-crypto-key-pair-0.7.0-unstable.80.tgz#23aa4d08f378dad421c6c4c894513f230ed84268"
+  integrity sha512-k7kV3DPZoIoLSItnU9qHOBebMhem2y6Qay8JSgS+QTsEf4sGMNl3Unm560I9aocvdlurMTwQmgCfwPJ8WFQYaQ==
+  dependencies:
+    "@peculiar/webcrypto" "^1.1.6"
+    "@transmute/ld-key-pair" "^0.7.0-unstable.80"
+    big-integer "^1.6.48"
+
+"@transmute/x25519-key-pair@^0.7.0-unstable.80":
+  version "0.7.0-unstable.80"
+  resolved "https://registry.yarnpkg.com/@transmute/x25519-key-pair/-/x25519-key-pair-0.7.0-unstable.80.tgz#749badbfe16e2c7b324e7b0ddf111b5ed28dc221"
+  integrity sha512-6YxaWl3E9pTIsfuOCwoQFWYGH/bLoUkH4S7hhVORaNAS8r/XPNRP9IMcbemfHsP7f67GHVHXbOghVZd9nPLlQg==
+  dependencies:
+    "@stablelib/x25519" "^1.0.0"
+    "@transmute/ld-key-pair" "^0.7.0-unstable.80"
 
 "@types/babel__core@^7.1.0":
   version "7.1.19"
@@ -4153,6 +4366,15 @@ asn1@~0.2.3:
   dependencies:
     safer-buffer "~2.1.0"
 
+asn1js@^3.0.1, asn1js@^3.0.5:
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/asn1js/-/asn1js-3.0.5.tgz#5ea36820443dbefb51cc7f88a2ebb5b462114f38"
+  integrity sha512-FVnvrKJwpt9LP2lAMl8qZswRNm3T4q9CON+bxldk2iwk3FFpuwhx2FfinyitizWHsVYyaY+y5JzDR0rCMV5yTQ==
+  dependencies:
+    pvtsutils "^1.3.2"
+    pvutils "^1.1.3"
+    tslib "^2.4.0"
+
 assert-plus@1.0.0, assert-plus@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/assert-plus/-/assert-plus-1.0.0.tgz#f12e0f3c5d77b0b1cdd9146942e4e96c1e4dd525"
@@ -4349,7 +4571,7 @@ base64-js@^1.0.2, base64-js@^1.3.1:
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
   integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
 
-base64url@3.0.1:
+base64url@3.0.1, base64url@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/base64url/-/base64url-3.0.1.tgz#6399d572e2bc3f90a9a8b22d5dbb0a32d33f788d"
   integrity sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A==
@@ -4378,6 +4600,11 @@ bech32@1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/bech32/-/bech32-1.1.4.tgz#e38c9f37bf179b8eb16ae3a772b40c356d4832e9"
   integrity sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ==
+
+big-integer@^1.6.48:
+  version "1.6.51"
+  resolved "https://registry.yarnpkg.com/big-integer/-/big-integer-1.6.51.tgz#0df92a5d9880560d3ff2d5fd20245c889d130686"
+  integrity sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg==
 
 bignumber.js@^9.0.0:
   version "9.1.0"
@@ -8164,6 +8391,11 @@ jmespath@0.16.0:
   resolved "https://registry.yarnpkg.com/jmespath/-/jmespath-0.16.0.tgz#b15b0a85dfd4d930d43e69ed605943c802785076"
   integrity sha512-9FzQjJ7MATs1tSpnco1K6ayiYE3figslrXA72G2HQ/n76RzvYlofyi5QM+iX4YRs/pu3yzxlVQSST23+dMDknw==
 
+jose@^4.3.8:
+  version "4.13.1"
+  resolved "https://registry.yarnpkg.com/jose/-/jose-4.13.1.tgz#449111bb5ab171db85c03f1bd2cb1647ca06db1c"
+  integrity sha512-MSJQC5vXco5Br38mzaQKiq9mwt7lwj2eXpgpRyQYNHYt2lq1PjkWa7DLXX0WVcQLE9HhMh3jPiufS7fhJf+CLQ==
+
 js-sha256@0.9.0:
   version "0.9.0"
   resolved "https://registry.yarnpkg.com/js-sha256/-/js-sha256-0.9.0.tgz#0b89ac166583e91ef9123644bd3c5334ce9d0966"
@@ -8375,7 +8607,7 @@ jsonld-streaming-serializer@^1.3.0:
     "@rdfjs/types" "*"
     jsonld-context-parser "^2.0.0"
 
-jsonld@^5.0.0:
+jsonld@5.2.0, jsonld@^5.0.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/jsonld/-/jsonld-5.2.0.tgz#d1e8af38a334cb95edf0f2ae4e2b58baf8d2b5a9"
   integrity sha512-JymgT6Xzk5CHEmHuEyvoTNviEPxv6ihLWSPu1gFdtjSAyM6cFqNrv02yS/SIur3BBIkCf0HjizRc24d8/FfQKw==
@@ -9650,6 +9882,18 @@ punycode@^2.1.0, punycode@^2.1.1:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
 
+pvtsutils@^1.3.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/pvtsutils/-/pvtsutils-1.3.2.tgz#9f8570d132cdd3c27ab7d51a2799239bf8d8d5de"
+  integrity sha512-+Ipe2iNUyrZz+8K/2IOo+kKikdtfhRKzNpQbruF2URmqPtoqAs8g3xS7TJvFF2GcPXjh7DkqMnpVveRFq4PgEQ==
+  dependencies:
+    tslib "^2.4.0"
+
+pvutils@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/pvutils/-/pvutils-1.1.3.tgz#f35fc1d27e7cd3dfbd39c0826d173e806a03f5a3"
+  integrity sha512-pMpnA0qRdFp32b1sJl1wOJNxZLQ2cbQx+k6tjNtZ8CpvVhNqEPRgivZ2WOUev2YMajecdH7ctUPDvEe87nariQ==
+
 qs@6.11.0:
   version "6.11.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.11.0.tgz#fd0d963446f7a65e1367e01abd85429453f0c37a"
@@ -10372,7 +10616,7 @@ scrypt-js@3.0.1, scrypt-js@^3.0.0, scrypt-js@^3.0.1:
   resolved "https://registry.yarnpkg.com/scrypt-js/-/scrypt-js-3.0.1.tgz#d314a57c2aef69d1ad98a138a21fe9eafa9ee312"
   integrity sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA==
 
-secp256k1@^4.0.1:
+secp256k1@^4.0.1, secp256k1@^4.0.2:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/secp256k1/-/secp256k1-4.0.3.tgz#c4559ecd1b8d3c1827ed2d1b94190d69ce267303"
   integrity sha512-NLZVf+ROMxwtEj3Xa562qgv2BK5e2WNmXPiOdVIPLgs6lyTzMvBq0aWTYMI5XCP9jZMVKOcqZLw/Wc4vDkuxhA==
@@ -11153,6 +11397,11 @@ tslib@^1.8.1, tslib@^1.9.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
+tslib@^2.0.0, tslib@^2.4.0, tslib@^2.5.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.5.0.tgz#42bfed86f5787aeb41d031866c8f402429e0fddf"
+  integrity sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==
+
 tslib@^2.1.0:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.1.tgz#0d0bfbaac2880b91e22df0768e55be9753a5b17e"
@@ -11759,6 +12008,17 @@ web3@^1.7.5:
     web3-net "1.8.0"
     web3-shh "1.8.0"
     web3-utils "1.8.0"
+
+webcrypto-core@^1.7.7:
+  version "1.7.7"
+  resolved "https://registry.yarnpkg.com/webcrypto-core/-/webcrypto-core-1.7.7.tgz#06f24b3498463e570fed64d7cab149e5437b162c"
+  integrity sha512-7FjigXNsBfopEj+5DV2nhNpfic2vumtjjgPmeDKk45z+MJwXKKfhPB7118Pfzrmh4jqOMST6Ch37iPAHoImg5g==
+  dependencies:
+    "@peculiar/asn1-schema" "^2.3.6"
+    "@peculiar/json-schema" "^1.1.12"
+    asn1js "^3.0.1"
+    pvtsutils "^1.3.2"
+    tslib "^2.4.0"
 
 webidl-conversions@^3.0.0:
   version "3.0.1"


### PR DESCRIPTION
- Create JWT VC
- Verify JWT VC
- JsonWebKey2020 support (JWT and non-JWT)
- Updates issuance test to cover more key types
- Added test for pre-signed credentials for robustness

JWT VPs not supported in this PR to keep changes minimal
