### PR TITLE
Misc tweaks

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@docknetwork/sdk",
-  "version": "6.3.1",
+  "version": "6.4.0",
   "main": "index.js",
   "license": "MIT",
   "repository": {

--- a/scripts/slack.js
+++ b/scripts/slack.js
@@ -1,0 +1,41 @@
+import { curry } from "ramda";
+import { envObj, notNilAnd } from "./helpers";
+import fetch from "node-fetch";
+
+const { SlackNotificationWebhookUrl } = envObj({
+  SlackNotificationWebhookUrl: notNilAnd(String),
+});
+
+export const TYPES = {
+  WARNING: "warning",
+  DANGER: "danger",
+  SUCCESS: "success",
+};
+
+/**
+ * Posts a message to Slack.
+ */
+export const postMessage = curry(async (type, header, fields) => {
+  const body = Buffer.from(
+    JSON.stringify({
+      text: header,
+      attachments: [
+        {
+          color: type,
+          fields,
+          ts: new Date().getTime() / 1e3,
+        },
+      ],
+    })
+  );
+  const headers = {
+    "Content-Type": "application/json",
+    "Content-Length": body.byteLength,
+  };
+
+  return await fetch(SlackNotificationWebhookUrl, {
+    headers,
+    method: "POST",
+    body,
+  });
+});

--- a/scripts/watch-essential-events.js
+++ b/scripts/watch-essential-events.js
@@ -714,7 +714,7 @@ const eventFilters = [
               map(String),
               map((value) =>
                 value.length > 100
-                  ? `${value.slice(0, 50)}... (truncated)`
+                  ? `${value.slice(0, 100)}... (truncated)`
                   : value
               ),
               JSON.stringify

--- a/src/modules/did/did.js
+++ b/src/modules/did/did.js
@@ -27,6 +27,8 @@ import WithParamsAndPublicKeys from '../WithParamsAndPublicKeys';
 
 export const ATTESTS_IRI = 'https://rdf.dock.io/alpha/2021#attestsDocumentContents';
 
+const valuePropOrIdentity = (val) => val.value || val;
+
 /** Class to create, update and destroy DIDs */
 class DIDModule {
   /**
@@ -798,16 +800,16 @@ class DIDModule {
           let typ;
           if (pk.isSr25519) {
             typ = 'Sr25519VerificationKey2020';
-            publicKeyRaw = pk.asSr25519.value;
+            publicKeyRaw = valuePropOrIdentity(pk.asSr25519);
           } else if (pk.isEd25519) {
             typ = 'Ed25519VerificationKey2018';
-            publicKeyRaw = pk.asEd25519.value;
+            publicKeyRaw = valuePropOrIdentity(pk.asEd25519);
           } else if (pk.isSecp256k1) {
             typ = 'EcdsaSecp256k1VerificationKey2019';
-            publicKeyRaw = pk.asSecp256k1.value;
+            publicKeyRaw = valuePropOrIdentity(pk.asSecp256k1);
           } else if (pk.isX25519) {
             typ = 'X25519KeyAgreementKey2019';
-            publicKeyRaw = pk.asX25519.value;
+            publicKeyRaw = valuePropOrIdentity(pk.asX25519);
           } else {
             throw new Error(`Cannot parse public key ${pk}`);
           }
@@ -1066,13 +1068,13 @@ class DIDModule {
 
     let publicKey;
     if (pk.isSr25519) {
-      publicKey = new PublicKeySr25519(u8aToHex(pk.asSr25519.value));
+      publicKey = new PublicKeySr25519(u8aToHex(valuePropOrIdentity(pk.asSr25519)));
     } else if (pk.isEd25519) {
-      publicKey = new PublicKeyEd25519(u8aToHex(pk.asEd25519.value));
+      publicKey = new PublicKeyEd25519(u8aToHex(valuePropOrIdentity(pk.asEd25519)));
     } else if (pk.isSecp256k1) {
-      publicKey = new PublicKeySecp256k1(u8aToHex(pk.asSecp256k1.value));
+      publicKey = new PublicKeySecp256k1(u8aToHex(valuePropOrIdentity(pk.asSecp256k1)));
     } else if (pk.isX25519) {
-      publicKey = new PublicKeyX25519(u8aToHex(pk.asX25519.value));
+      publicKey = new PublicKeyX25519(u8aToHex(valuePropOrIdentity(pk.asX25519)));
     } else {
       throw new Error(`Cannot parse public key ${pk}`);
     }

--- a/src/status-list-credential/status-list2021-credential.js
+++ b/src/status-list-credential/status-list2021-credential.js
@@ -86,6 +86,9 @@ export default class StatusList2021Credential extends VerifiableCredential {
   /**
    * Revokes indices and unsuspends other indices in the underlying status list, regenerating the proof.
    * If `statusPurpose` = `revocation`, indices can't be unsuspended.
+   * The status list revoked (suspended)/unsuspended indices will be set atomically and in case of an error,
+   * the underlying value won't be modified.
+   * Throws an error if the underlying status list can't be decoded or any of the supplied indices is out of range.
    *
    * @param {KeyDoc} keyDoc
    * @param {object} [update={}]
@@ -94,7 +97,9 @@ export default class StatusList2021Credential extends VerifiableCredential {
    * @returns {this}
    */
   async update(keyDoc, { revokeIndices = [], unsuspendIndices = [] }) {
-    const statusList = await this.decodedStatusList();
+    const statusList = new StatusList({
+      buffer: new Uint8Array((await this.decodedStatusList()).bitstring.bits),
+    });
     this.constructor.updateStatusList(
       this.credentialSubject.statusPurpose,
       statusList,


### PR DESCRIPTION
- Make `StatusList2021Credential` update atomic, and rollback all modifications made to the underlying decoded status list in case of an invalid index
- Allow the essential notification watcher to use `Slack` hooks 
- Update metadata to be compatible with the latest `dock-substrate`