### PR TITLE
Fix: dont pin all polkadot packages anymore

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,18 +95,7 @@
     "type-check": "tsc --allowJs --checkJs --noEmit --moduleResolution node --resolveJsonModule --target ES6 --skipLibCheck true --allowSyntheticDefaultImports true"
   },
   "resolutions": {
-    "@polkadot/api": "9.7.1",
-    "@polkadot/keyring": "10.1.11",
-    "@polkadot/rpc-provider": "9.7.1",
-    "@polkadot/types": "9.7.1",
-    "@polkadot/types-known": "9.7.1",
-    "@polkadot/util": "10.1.11",
-    "@polkadot/util-crypto": "10.1.11",
-    "@polkadot/x-textencoder": "10.1.11",
-    "@polkadot/x-textdecoder": "10.1.11",
-    "@polkadot/x-ws": "10.1.11",
-    "@polkadot/x-fetch": "10.1.11",
-    "@polkadot/x-randomvalues": "10.1.11"
+    "@polkadot/api": "9.7.1"
   },
   "dependencies": {
     "@digitalbazaar/vc-status-list": "^4.0.0",
@@ -114,17 +103,6 @@
     "@docknetwork/node-types": "^0.16.0",
     "@juanelas/base64": "^1.0.5",
     "@polkadot/api": "9.7.1",
-    "@polkadot/keyring": "10.1.11",
-    "@polkadot/rpc-provider": "9.7.1",
-    "@polkadot/types": "9.7.1",
-    "@polkadot/types-known": "9.7.1",
-    "@polkadot/util": "10.1.11",
-    "@polkadot/util-crypto": "10.1.11",
-    "@polkadot/x-fetch": "10.1.11",
-    "@polkadot/x-randomvalues": "10.1.11",
-    "@polkadot/x-textdecoder": "10.1.11",
-    "@polkadot/x-textencoder": "10.1.11",
-    "@polkadot/x-ws": "10.1.11",
     "@transmute/json-web-signature": "^0.7.0-unstable.80",
     "axios": "0.27.2",
     "base64url": "3.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3247,7 +3247,7 @@
     eventemitter3 "^4.0.7"
     rxjs "^7.5.7"
 
-"@polkadot/keyring@10.1.11", "@polkadot/keyring@^10.1.11":
+"@polkadot/keyring@^10.1.11":
   version "10.1.11"
   resolved "https://registry.yarnpkg.com/@polkadot/keyring/-/keyring-10.1.11.tgz#a3fed011b0c8826ea2097e04f7189e9be66fbf98"
   integrity sha512-Nv8cZaOA/KbdslDMTklJ58+y+UPpic3+oMQoozuq48Ccjv7WeW2BX47XM/RNE8nYFg6EHa6Whfm4IFaFb8s7ag==
@@ -3467,7 +3467,7 @@
     "@polkadot/util" "10.1.11"
     buffer-es6 "^4.9.3"
 
-"@polkadot/x-fetch@10.1.11", "@polkadot/x-fetch@^10.1.11":
+"@polkadot/x-fetch@^10.1.11":
   version "10.1.11"
   resolved "https://registry.yarnpkg.com/@polkadot/x-fetch/-/x-fetch-10.1.11.tgz#8f579bb166096c977acff91a40b3848fb5581900"
   integrity sha512-WtyUr9itVD9BLnxCUloJ1iwrXOY/lnlEShEYKHcSm6MIHtbJolePd3v1+o5mOX+bdDbHXhPZnH8anCCqDNDRqg==
@@ -3508,7 +3508,7 @@
     "@babel/runtime" "^7.19.4"
     "@polkadot/x-global" "10.1.11"
 
-"@polkadot/x-ws@10.1.11", "@polkadot/x-ws@^10.1.11":
+"@polkadot/x-ws@^10.1.11":
   version "10.1.11"
   resolved "https://registry.yarnpkg.com/@polkadot/x-ws/-/x-ws-10.1.11.tgz#7431ad72064d56519d4293278f03ae97b9ea9271"
   integrity sha512-EUbL/R1A/NxYf6Rnb1M7U9yeTuo5r4y2vcQllE5aBLaQ0cFnRykHzlmZlVX1E7O5uy3lYVdxWC7sNgxItIWkWA==


### PR DESCRIPTION
Used to be required, doesnt seem to be anymore