### PR TITLE
Anoncreds derived bounds check

### DIFF
--- a/.github/workflows/integrations-tests.yml
+++ b/.github/workflows/integrations-tests.yml
@@ -15,7 +15,7 @@ jobs:
           run_daemon: true
       - uses: actions/setup-node@v1
         with:
-          node-version: '16.x'
+          node-version: '18.x'
       - run: yarn install --frozen-lockfile --ignore-scripts
       - run: yarn build
       - run: yarn test-with-node
@@ -32,7 +32,7 @@ jobs:
           run_daemon: true
       - uses: actions/setup-node@v1
         with:
-          node-version: '16.x'
+          node-version: '18.x'
       - run: yarn install --frozen-lockfile --ignore-scripts
       - run: yarn build
       - run: yarn test-with-node
@@ -49,7 +49,7 @@ jobs:
           run_daemon: true
       - uses: actions/setup-node@v1
         with:
-          node-version: '16.x'
+          node-version: '18.x'
       - run: yarn install --frozen-lockfile --ignore-scripts
       - run: yarn build
       - run: yarn test-with-node

--- a/.github/workflows/integrations-tests.yml
+++ b/.github/workflows/integrations-tests.yml
@@ -15,7 +15,7 @@ jobs:
           run_daemon: true
       - uses: actions/setup-node@v1
         with:
-          node-version: '18.x'
+          node-version: '16.x'
       - run: yarn install --frozen-lockfile --ignore-scripts
       - run: yarn build
       - run: yarn test-with-node
@@ -32,7 +32,7 @@ jobs:
           run_daemon: true
       - uses: actions/setup-node@v1
         with:
-          node-version: '18.x'
+          node-version: '16.x'
       - run: yarn install --frozen-lockfile --ignore-scripts
       - run: yarn build
       - run: yarn test-with-node
@@ -49,7 +49,7 @@ jobs:
           run_daemon: true
       - uses: actions/setup-node@v1
         with:
-          node-version: '18.x'
+          node-version: '16.x'
       - run: yarn install --frozen-lockfile --ignore-scripts
       - run: yarn build
       - run: yarn test-with-node

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@docknetwork/sdk",
-  "version": "6.5.0",
+  "version": "6.5.1",
   "main": "index.js",
   "license": "MIT",
   "repository": {

--- a/src/presentation.js
+++ b/src/presentation.js
@@ -206,6 +206,7 @@ export default class Presentation {
           unboundedPseudonyms: presentation.spec.unboundedPseudonyms,
           version: credential.version,
           sigType: credential.sigType,
+          bounds: credential.bounds,
         },
       };
     });

--- a/src/utils/vc/contexts/dock-bbs-v1.json
+++ b/src/utils/vc/contexts/dock-bbs-v1.json
@@ -48,6 +48,10 @@
         },
         "domain": "https://ld.dock.io/security#domain",
         "context": "https://ld.dock.io/security#context",
+        "bounds": {
+          "@id": "https://ld.dock.io/security#bounds",
+          "@context": {"@vocab": "https://ld.dock.io/security/bounds"}
+        },
         "sigType": "https://ld.dock.io/security#sigType",
         "boundedPseudonyms": "https://ld.dock.io/security#boundedPseudonyms",
         "unboundedPseudonyms": "https://ld.dock.io/security#unboundedPseudonyms",

--- a/src/utils/vc/contexts/dock-bbs23-v1.json
+++ b/src/utils/vc/contexts/dock-bbs23-v1.json
@@ -48,6 +48,10 @@
         },
         "domain": "https://ld.dock.io/security#domain",
         "context": "https://ld.dock.io/security#context",
+        "bounds": {
+          "@id": "https://ld.dock.io/security#bounds",
+          "@context": {"@vocab": "https://ld.dock.io/security/bounds"}
+        },
         "sigType": "https://ld.dock.io/security#sigType",
         "boundedPseudonyms": "https://ld.dock.io/security#boundedPseudonyms",
         "unboundedPseudonyms": "https://ld.dock.io/security#unboundedPseudonyms",

--- a/src/utils/vc/contexts/dock-ps-v1.json
+++ b/src/utils/vc/contexts/dock-ps-v1.json
@@ -48,6 +48,10 @@
         },
         "domain": "https://ld.dock.io/security#domain",
         "context": "https://ld.dock.io/security#context",
+        "bounds": {
+          "@id": "https://ld.dock.io/security#bounds",
+          "@context": {"@vocab": "https://ld.dock.io/security/bounds"}
+        },
         "sigType": "https://ld.dock.io/security#sigType",
         "boundedPseudonyms": "https://ld.dock.io/security#boundedPseudonyms",
         "unboundedPseudonyms": "https://ld.dock.io/security#unboundedPseudonyms",

--- a/src/utils/vc/credentials.js
+++ b/src/utils/vc/credentials.js
@@ -233,6 +233,12 @@ export async function verifyCredential(
     controller = null,
     suite = [],
     verifyDates = true,
+
+    // Anoncreds params
+    predicateParams = null,
+    accumulatorPublicKeys = null,
+    circomOutputs = null,
+    blindedAttributesCircomOutputs = null,
   } = {},
 ) {
   if (documentLoader && resolver) {
@@ -321,17 +327,21 @@ export async function verifyCredential(
     return { verified };
   }
 
+  // Specify certain parameters for anoncreds
+  const anoncredsParams = {
+    accumulatorPublicKeys, predicateParams, circomOutputs, blindedAttributesCircomOutputs,
+  };
   const fullSuite = [
     new Ed25519Signature2018(),
     new EcdsaSepc256k1Signature2019(),
     new Sr25519Signature2020(),
-    new Bls12381BBSSignatureDock2022(),
-    new Bls12381BBSSignatureProofDock2022(),
-    new Bls12381BBSSignatureDock2023(),
-    new Bls12381BBSSignatureProofDock2023(),
-    new Bls12381PSSignatureDock2023(),
-    new Bls12381PSSignatureProofDock2023(),
     new JsonWebSignature2020(),
+    new Bls12381BBSSignatureDock2022(anoncredsParams),
+    new Bls12381BBSSignatureProofDock2022(anoncredsParams),
+    new Bls12381BBSSignatureDock2023(anoncredsParams),
+    new Bls12381BBSSignatureProofDock2023(anoncredsParams),
+    new Bls12381PSSignatureDock2023(anoncredsParams),
+    new Bls12381PSSignatureProofDock2023(anoncredsParams),
     ...suite,
   ];
 

--- a/src/utils/vc/crypto/common/DockCryptoSignatureProof.js
+++ b/src/utils/vc/crypto/common/DockCryptoSignatureProof.js
@@ -46,6 +46,10 @@ export default withExtendedStaticProperties(
       };
 
       this.verificationMethod = verificationMethod;
+      this.accumulatorPublicKeys = options.accumulatorPublicKeys;
+      this.predicateParams = options.predicateParams;
+      this.circomOutputs = options.circomOutputs;
+      this.blindedAttributesCircomOutputs = options.blindedAttributesCircomOutputs;
     }
 
     async verifyProof({
@@ -70,7 +74,12 @@ export default withExtendedStaticProperties(
           return new this.constructor.Signature.KeyPair.PublicKey(pkRaw);
         });
 
-        if (!recreatedPres.verify(pks)) {
+        const {
+          accumulatorPublicKeys, predicateParams,
+          circomOutputs, blindedAttributesCircomOutputs,
+        } = this;
+
+        if (!recreatedPres.verify(pks, accumulatorPublicKeys, predicateParams, circomOutputs, blindedAttributesCircomOutputs)) {
           throw new Error('Invalid signature');
         }
 
@@ -96,7 +105,7 @@ export default withExtendedStaticProperties(
       } = document;
 
       return {
-        version: '0.1.0',
+        version: '0.1.0', // TODO: should this be retrieved from the doc somehow?
         nonce: proof.nonce,
         context: proof.context,
         spec: {
@@ -104,6 +113,7 @@ export default withExtendedStaticProperties(
             {
               sigType: proof.sigType,
               version: proof.version,
+              bounds: proof.bounds,
               schema: JSON.stringify(credentialSchema),
               revealedAttributes: {
                 proof: {

--- a/src/utils/vc/presentations.js
+++ b/src/utils/vc/presentations.js
@@ -265,6 +265,10 @@ export function isAnoncreds(presentation) {
 
 export async function verifyAnoncreds(presentation, options = {}) {
   const documentLoader = options.documentLoader || defaultDocumentLoader(options.resolver);
+  const {
+    predicateParams, accumulatorPublicKeys,
+    circomOutputs, blindedAttributesCircomOutputs,
+  } = options;
 
   const keyDocuments = await Promise.all(
     presentation.spec.credentials.map((c, idx) => {
@@ -315,5 +319,5 @@ export async function verifyAnoncreds(presentation, options = {}) {
     }
   });
 
-  return recreatedPres.verify(pks);
+  return recreatedPres.verify(pks, accumulatorPublicKeys, predicateParams, circomOutputs, blindedAttributesCircomOutputs);
 }

--- a/tests/integration/anoncreds/derived-credentials.test.js
+++ b/tests/integration/anoncreds/derived-credentials.test.js
@@ -1,6 +1,5 @@
 import { randomAsHex } from '@polkadot/util-crypto';
 import { stringToU8a, u8aToHex } from '@polkadot/util';
-import { error } from 'console';
 import { initializeWasm, BoundCheckSnarkSetup } from '@docknetwork/crypto-wasm-ts';
 import { DockAPI } from '../../../src';
 import {
@@ -415,7 +414,7 @@ for (const {
 
       // Create a VP and verify it from this credential
       await createAndVerifyPresentation(credentials, { predicateParams });
-    }, 30000);
+    }, 60000);
 
     afterAll(async () => {
       await dock.disconnect();

--- a/tests/integration/anoncreds/derived-credentials.test.js
+++ b/tests/integration/anoncreds/derived-credentials.test.js
@@ -407,6 +407,9 @@ for (const {
         resolver,
         predicateParams,
       });
+      if (credentialResult.error) {
+        console.log('credentialResult.error', JSON.stringify(credentialResult.error, null, 2));
+      }
       expect(credentialResult.error).toBe(undefined);
       expect(credentialResult.verified).toBe(true);
 

--- a/tests/integration/anoncreds/presentation.test.js
+++ b/tests/integration/anoncreds/presentation.test.js
@@ -204,7 +204,7 @@ for (const {
       // Verify the presentation, note that we must pass predicateParams with the verification key
       const { verified } = await verifyPresentation(presentation, { resolver, predicateParams });
       expect(verified).toEqual(true);
-    }, 30000);
+    }, 60000);
 
     test('expect to reveal specified attributes', async () => {
       const presentationInstance = new Presentation();


### PR DESCRIPTION
Fixes "bounds" property not being in derived credentials/presentations, allows to pass anoncreds specific verification parameters (predicates etc) in verifyCredential/verifyPresentation methods