### PR TITLE
Skip schema check for anoncreds derived credentials

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@docknetwork/sdk",
-  "version": "8.1.2",
+  "version": "8.1.3",
   "main": "index.js",
   "license": "MIT",
   "repository": {

--- a/src/utils/vc/credentials.js
+++ b/src/utils/vc/credentials.js
@@ -39,9 +39,12 @@ import {
   Bls12381BBSSignatureProofDock2022,
   Bls12381BBSSignatureDock2023,
   Bls12381BBSSignatureProofDock2023,
+  Bls12381BBS23SigProofDockSigName,
+  Bls12381PSSigProofDockSigName,
   JsonWebSignature2020,
   Bls12381PSSigDockSigName,
   Bls12381BBSSigDockSigName,
+  Bls12381BBSSigProofDockSigName,
   Bls12381BBS23SigDockSigName,
   Bls12381BDDT16MacDockName,
   Bls12381BDDT16MacProofDockName,
@@ -77,6 +80,9 @@ export function isAnoncredsProofType(verifiableCredential) {
   const proofType = verifiableCredential.proof && verifiableCredential.proof.type;
   return (
     proofType === Bls12381BBSSigDockSigName
+    || proofType === Bls12381BBSSigProofDockSigName
+    || proofType === Bls12381BBS23SigProofDockSigName
+    || proofType === Bls12381PSSigProofDockSigName
     || proofType === Bls12381BBS23SigDockSigName
     || proofType === Bls12381BDDT16MacDockName
     || proofType === Bls12381BDDT16MacProofDockName

--- a/src/utils/vc/credentials.js
+++ b/src/utils/vc/credentials.js
@@ -40,6 +40,11 @@ import {
   Bls12381BBSSignatureDock2023,
   Bls12381BBSSignatureProofDock2023,
   JsonWebSignature2020,
+  Bls12381PSSigDockSigName,
+  Bls12381BBSSigDockSigName,
+  Bls12381BBS23SigDockSigName,
+  Bls12381BDDT16MacDockName,
+  Bls12381BDDT16MacProofDockName,
 } from './custom_crypto';
 import { signJWS } from './jws';
 import Bls12381BDDT16MACProofDock2024 from './crypto/Bls12381BDDT16MACProofDock2024';
@@ -66,6 +71,17 @@ function getId(obj) {
 
 function dateStringToTimestamp(dateStr) {
   return Math.floor(Date.parse(dateStr) / 1000);
+}
+
+export function isAnoncredsProofType(verifiableCredential) {
+  const proofType = verifiableCredential.proof && verifiableCredential.proof.type;
+  return (
+    proofType === Bls12381BBSSigDockSigName
+    || proofType === Bls12381BBS23SigDockSigName
+    || proofType === Bls12381BDDT16MacDockName
+    || proofType === Bls12381BDDT16MacProofDockName
+    || proofType === Bls12381PSSigDockSigName
+  );
 }
 
 export function formatToJWTPayload(keyDoc, cred) {
@@ -293,7 +309,8 @@ export async function verifyCredential(
     documentLoader: docLoader,
   });
 
-  if (!skipSchemaCheck) {
+  const isAnoncredsDerived = isAnoncredsProofType(credential);
+  if (!skipSchemaCheck && !isAnoncredsDerived) {
     await getAndValidateSchemaIfPresent(
       expandedCredential,
       credential[credentialContextField],

--- a/src/utils/vc/credentials.js
+++ b/src/utils/vc/credentials.js
@@ -309,6 +309,9 @@ export async function verifyCredential(
     documentLoader: docLoader,
   });
 
+  // Determine if we should validate the schema when verifying
+  // NOTE: derived anoncreds do not need JSON schema validation as the anoncreds library validates it
+  // and it can fail when required attributes are not revealed
   const isAnoncredsDerived = isAnoncredsProofType(credential);
   if (!skipSchemaCheck && !isAnoncredsDerived) {
     await getAndValidateSchemaIfPresent(

--- a/src/utils/vc/custom_crypto.js
+++ b/src/utils/vc/custom_crypto.js
@@ -14,6 +14,8 @@ import {
   Bls12381PSDockVerKeyName,
   Bls12381PSSigDockSigName,
   Bls12381PSSigProofDockSigName,
+  Bls12381BDDT16MacDockName,
+  Bls12381BDDT16MacProofDockName,
 } from './crypto/constants';
 
 import EcdsaSecp256k1VerificationKey2019 from './crypto/EcdsaSecp256k1VerificationKey2019';
@@ -58,5 +60,7 @@ export {
   Bls12381PSDockVerKeyName,
   Bls12381PSSigDockSigName,
   Bls12381PSSigProofDockSigName,
+  Bls12381BDDT16MacDockName,
+  Bls12381BDDT16MacProofDockName,
   JsonWebSignature2020,
 };

--- a/tests/integration/anoncreds/derived-credentials.test.js
+++ b/tests/integration/anoncreds/derived-credentials.test.js
@@ -67,7 +67,7 @@ const residentCardSchema = {
           minimum: 0,
         },
       },
-      required: [],
+      required: ['givenName', 'familyName', 'lprNumber'],
     },
   },
 };


### PR DESCRIPTION
Skip JSON schema validation when verifying derived credentials, as anoncreds will do its own schema checks. This resolves an issue whereby schema validation fails for required fields that are not revealed.