### PR TITLE
Fix verifying schema with only ID field in subject, dont expand for schema validation

### DIFF
--- a/example/standard_schemas.js
+++ b/example/standard_schemas.js
@@ -178,8 +178,7 @@ async function validateSchema(schema, credential) {
   await Schema.validateSchema(schema);
   console.log('Validating credential against schema...');
 
-  const expanded = await expandJSONLD(credential);
-  await validateCredentialSchema(expanded, schema, credential['@context']);
+  await validateCredentialSchema(credential, schema);
   console.log('Success!');
 }
 

--- a/src/utils/vc/credentials.js
+++ b/src/utils/vc/credentials.js
@@ -19,7 +19,6 @@ import {
   expandJSONLD, getKeyFromDIDDocument, getSuiteFromKeyDoc, processIfKvac,
 } from './helpers';
 import {
-  credentialContextField,
   DEFAULT_CONTEXT_V1_URL,
   DockStatusList2021Qualifier,
   PrivateStatusList2021EntryType,
@@ -323,8 +322,7 @@ export async function verifyCredential(
   const isAnoncredsDerived = isAnoncredsProofType(credential);
   if (!skipSchemaCheck && !isAnoncredsDerived) {
     await getAndValidateSchemaIfPresent(
-      expandedCredential,
-      credential[credentialContextField],
+      credential,
       docLoader,
     );
   }

--- a/src/utils/vc/schema.js
+++ b/src/utils/vc/schema.js
@@ -42,17 +42,16 @@ export async function validateCredentialSchema(
     });
     delete compacted[credentialContextField];
 
-    if (Object.keys(compacted).length === 0) {
-      throw new Error('Compacted subject is empty, likely invalid');
+    // Only validate if has non-id fields in compacted schema, otherwise its empty
+    if (Object.keys(compacted).length > 0) {
+      const schemaObj = schema.schema || schema;
+      const subjectSchema = (schemaObj.properties && schemaObj.properties.credentialSubject)
+        || schemaObj;
+
+      validate(compacted, subjectSchema, {
+        throwError: true,
+      });
     }
-
-    const schemaObj = schema.schema || schema;
-    const subjectSchema = (schemaObj.properties && schemaObj.properties.credentialSubject)
-      || schemaObj;
-
-    validate(compacted, subjectSchema, {
-      throwError: true,
-    });
   }
   return true;
 }

--- a/src/utils/vc/schema.js
+++ b/src/utils/vc/schema.js
@@ -1,7 +1,6 @@
 import { validate } from 'jsonschema';
 
 import {
-  expandedSchemaProperty,
   credentialIDField,
 } from './constants';
 
@@ -43,21 +42,19 @@ export function validateCredentialSchema(
 /**
  * Get schema and run validation on credential if it contains both a credentialSubject and credentialSchema
  * @param {object} credential - a verifiable credential JSON object
- * @param {object} context - the context
  * @param {object} documentLoader - the document loader
  * @returns {Promise<void>}
  */
 // eslint-disable-next-line sonarjs/cognitive-complexity
 export async function getAndValidateSchemaIfPresent(
   credential,
-  context,
   documentLoader,
 ) {
-  const schemaList = credential[expandedSchemaProperty];
+  const schemaList = Array.isArray(credential.credentialSchema) ? credential.credentialSchema : [credential.credentialSchema];
   if (schemaList) {
     const schema = schemaList[0];
     if (credential.credentialSubject && schema) {
-      const schemaUri = schema[credentialIDField];
+      const schemaUri = schema.id;
       let schemaObj;
 
       const { document } = await documentLoader(schemaUri);

--- a/src/verifiable-credential.js
+++ b/src/verifiable-credential.js
@@ -1,5 +1,4 @@
 import {
-  expandJSONLD,
   issueCredential,
   verifyCredential,
   DEFAULT_CONTEXT,
@@ -107,8 +106,7 @@ class VerifiableCredential {
       throw new Error('No credential subject defined');
     }
 
-    const expanded = await expandJSONLD(this.toJSON());
-    return validateCredentialSchema(expanded, schema, this.context);
+    return validateCredentialSchema(this.toJSON(), schema);
   }
 
   /**


### PR DESCRIPTION
Expanding the credential subject before verification is incorrect because if a field is not defined in the context, it will result in a potentially empty object to validate (or object with that field popped off) which may pass/fail unexpectedly. Also, it prevented verifying subjects with only the ID field since that is popped off.

Cannot see a requirement in the spec to do JSON-LD processing for schema validation. This change also allows validating of JWT-VC schemas when they dont use JSON-LD (no official support for that format yet but it lays some groundwork)