### PR TITLE
Revert anoncreds upgrade

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@docknetwork/sdk",
-  "version": "9.2.0",
+  "version": "9.0.0",
   "main": "index.js",
   "license": "MIT",
   "repository": {
@@ -104,7 +104,7 @@
   },
   "dependencies": {
     "@digitalcredentials/vc-status-list": "^8.0.0",
-    "@docknetwork/crypto-wasm-ts": "0.64.0",
+    "@docknetwork/crypto-wasm-ts": "0.63.0",
     "@docknetwork/node-types": "^0.17.0",
     "@juanelas/base64": "^1.0.5",
     "@polkadot/api": "10.12.4",

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
   },
   "dependencies": {
     "@digitalcredentials/vc-status-list": "^8.0.0",
-    "@docknetwork/crypto-wasm-ts": "0.66.0",
+    "@docknetwork/crypto-wasm-ts": "0.64.0",
     "@docknetwork/node-types": "^0.17.0",
     "@juanelas/base64": "^1.0.5",
     "@polkadot/api": "10.12.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@docknetwork/sdk",
-  "version": "9.0.0",
+  "version": "9.2.1",
   "main": "index.js",
   "license": "MIT",
   "repository": {

--- a/src/utils/vc/crypto/common/DockCryptoSignature.js
+++ b/src/utils/vc/crypto/common/DockCryptoSignature.js
@@ -110,12 +110,8 @@ export default withExtendedStaticProperties(
         [serializedCredential, credSchema] = await this.constructor.convertCredentialToSerializedForSigning(options);
       }
 
-      const useConstantTimeEncoder = semver.gte(credSchema.version, '0.5.0');
       // Encode messages, retrieve names/values array
-      const nameValues = useConstantTimeEncoder ? credSchema.encoder.encodeMessageObjectConstantTime(
-        serializedCredential,
-        false,
-      ) : credSchema.encoder.encodeMessageObject(
+      const nameValues = credSchema.encoder.encodeMessageObject(
         serializedCredential,
         false,
       );
@@ -448,8 +444,6 @@ export default withExtendedStaticProperties(
           },
           false,
           { version: '0.0.1' },
-          undefined,
-          false,
         );
       }
 

--- a/tests/integration/anoncreds/demo.test.js
+++ b/tests/integration/anoncreds/demo.test.js
@@ -88,7 +88,7 @@ for (const {
             // different way.
             encoded.push(Accumulator.encodeBytesAsAccumulatorMember(attrs[i]));
           } else {
-            encoded.push(Signature.encodeMessageForSigningConstantTime(attrs[i]));
+            encoded.push(Signature.encodeMessageForSigning(attrs[i]));
           }
         }
         return encoded;

--- a/tests/integration/anoncreds/r1cs-circom.test.js
+++ b/tests/integration/anoncreds/r1cs-circom.test.js
@@ -132,7 +132,7 @@ for (const {
       await initializeWasm();
 
       // Setup encoder
-      const defaultEncoder = (v) => Signature.encodeMessageForSigningConstantTime(
+      const defaultEncoder = (v) => Signature.encodeMessageForSigning(
         Uint8Array.from(Buffer.from(v.toString(), 'utf-8')),
       );
       encoder = new Encoder(undefined, defaultEncoder);

--- a/tests/integration/anoncreds/saver-and-bound-check.test.js
+++ b/tests/integration/anoncreds/saver-and-bound-check.test.js
@@ -84,7 +84,7 @@ for (const {
           } else if (i === boundedAttrIdx) {
             encoded.push(Signature.encodePositiveNumberForSigning(attrs[i]));
           } else {
-            encoded.push(Signature.encodeMessageForSigningConstantTime(attrs[i]));
+            encoded.push(Signature.encodeMessageForSigning(attrs[i]));
           }
         }
         return encoded;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2878,10 +2878,10 @@
     fix-esm "^1.0.1"
     jsonld digitalcredentials/jsonld.js#v10.x
 
-"@docknetwork/crypto-wasm-ts@0.66.0":
-  version "0.66.0"
-  resolved "https://registry.yarnpkg.com/@docknetwork/crypto-wasm-ts/-/crypto-wasm-ts-0.66.0.tgz#c579c3f0ace11659c365addb5f2a6b46d89fc09c"
-  integrity sha512-wjnln7wOpX+RW/lSoy3SOr2NeMfsxfuN6y/8z9YDWIegpggn8eAJ3TWqsT5vShEAx4BloxSVjom7u6MUDAMQ1w==
+"@docknetwork/crypto-wasm-ts@0.64.0":
+  version "0.64.0"
+  resolved "https://registry.yarnpkg.com/@docknetwork/crypto-wasm-ts/-/crypto-wasm-ts-0.64.0.tgz#7b490b33b588c00e00a2cc6214b3aae494b28b7a"
+  integrity sha512-bfPxVT1PG0zEXxJzSULFHbjp7Kp//rtNU1yPiqYfrFEC2IbJsdEf/RPhqLuaNMt65EiEXu3j8MyOgyMh/flFeQ==
   dependencies:
     "@types/flat" "^5.0.2"
     "@types/lodash" "^4.14.195"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2878,15 +2878,15 @@
     fix-esm "^1.0.1"
     jsonld digitalcredentials/jsonld.js#v10.x
 
-"@docknetwork/crypto-wasm-ts@0.64.0":
-  version "0.64.0"
-  resolved "https://registry.yarnpkg.com/@docknetwork/crypto-wasm-ts/-/crypto-wasm-ts-0.64.0.tgz#7b490b33b588c00e00a2cc6214b3aae494b28b7a"
-  integrity sha512-bfPxVT1PG0zEXxJzSULFHbjp7Kp//rtNU1yPiqYfrFEC2IbJsdEf/RPhqLuaNMt65EiEXu3j8MyOgyMh/flFeQ==
+"@docknetwork/crypto-wasm-ts@0.63.0":
+  version "0.63.0"
+  resolved "https://registry.yarnpkg.com/@docknetwork/crypto-wasm-ts/-/crypto-wasm-ts-0.63.0.tgz#f1ab39693b63e70d682d362e9eacd85842ae56e0"
+  integrity sha512-KryDPIf6suwi5NS1iqA76vpuLmZv4PLV1Dt7I6Z4YS3rDKK43m7j8mox6lhQgkVL7QZdJ1DdZGxcPLekXZYQ1w==
   dependencies:
     "@types/flat" "^5.0.2"
     "@types/lodash" "^4.14.195"
     bs58 "5.0.0"
-    crypto-wasm-new "npm:@docknetwork/crypto-wasm@0.32.0"
+    crypto-wasm-new "npm:@docknetwork/crypto-wasm@0.30.0"
     flat "^5.0.2"
     json-pointer "^0.6.2"
     json-stringify-deterministic "^1.0.11"
@@ -6747,10 +6747,10 @@ crypto-ld@^6.0.0:
   resolved "https://registry.yarnpkg.com/crypto-ld/-/crypto-ld-6.0.0.tgz#cf8dcf566cb3020bdb27f0279e6cc9b46d031cd7"
   integrity sha512-XWL1LslqggNoaCI/m3I7HcvaSt9b2tYzdrXO+jHLUj9G1BvRfvV7ZTFDVY5nifYuIGAPdAGu7unPxLRustw3VA==
 
-"crypto-wasm-new@npm:@docknetwork/crypto-wasm@0.32.0":
-  version "0.32.0"
-  resolved "https://registry.yarnpkg.com/@docknetwork/crypto-wasm/-/crypto-wasm-0.32.0.tgz#636c67447179b59dbd82d46c93f3921186387dc6"
-  integrity sha512-Xdppk2zted+7GmeSgVYz5mTML5NHOSKlZLwYbbpekHaX32NJ5VjnJ12frilXyEGaPDgW0sdX9rxWU2hUBz27JA==
+"crypto-wasm-new@npm:@docknetwork/crypto-wasm@0.30.0":
+  version "0.30.0"
+  resolved "https://registry.yarnpkg.com/@docknetwork/crypto-wasm/-/crypto-wasm-0.30.0.tgz#d54a56989cf98847e6e4ebe8119b6eb6012d8da4"
+  integrity sha512-xwDtakDBaiOf0Cm6H74JsJ2I610rc+d9tSrgjuACE7QBpmkTug6QX4Q4OzxXA12wp86K5QqRMHoCzc6geS1Z0g==
   dependencies:
     buffer "^6.0.3"
 


### PR DESCRIPTION
Those two commits have broken validation of existing anoncreds credentials, and the wallet cannot verify the newer issued ones. This PR can be reverted once confirmed and a breaking SDK change deployed simultaneously if needed.