### PR TITLE
Allow to verify credentials with no revealed subject

### DIFF
--- a/examples/CHANGELOG.md
+++ b/examples/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @docknetwork/sdk-examples
 
+## 0.6.2
+
+### Patch Changes
+
+- Updated dependencies
+  - @docknetwork/credential-sdk@0.16.0
+  - @docknetwork/dock-blockchain-api@0.8.2
+  - @docknetwork/dock-blockchain-modules@0.9.2
+
 ## 0.6.1
 
 ### Patch Changes

--- a/examples/package.json
+++ b/examples/package.json
@@ -2,7 +2,7 @@
   "name": "@docknetwork/sdk-examples",
   "private": true,
   "type": "module",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "scripts": {
     "bbs-dock-example": "babel-node ./bbs-dock.js",
     "claim-deduction-example": "babel-node ./claim-deduction.js",
@@ -19,9 +19,9 @@
     "lint": "eslint \"*.js\""
   },
   "dependencies": {
-    "@docknetwork/credential-sdk": "0.15.0",
-    "@docknetwork/dock-blockchain-api": "0.8.1",
-    "@docknetwork/dock-blockchain-modules": "0.9.1"
+    "@docknetwork/credential-sdk": "0.16.0",
+    "@docknetwork/dock-blockchain-api": "0.8.2",
+    "@docknetwork/dock-blockchain-modules": "0.9.2"
   },
   "devDependencies": {
     "babel-eslint": "^10.1.0",

--- a/packages/cheqd-blockchain-api/CHANGELOG.md
+++ b/packages/cheqd-blockchain-api/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @docknetwork/cheqd-blockchain-api
 
+## 0.14.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @docknetwork/credential-sdk@0.16.0
+
 ## 0.14.0
 
 ### Minor Changes

--- a/packages/cheqd-blockchain-api/package.json
+++ b/packages/cheqd-blockchain-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@docknetwork/cheqd-blockchain-api",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "license": "MIT",
   "main": "./dist/esm/index.js",
   "type": "module",
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "@cheqd/sdk": "cjs",
-    "@docknetwork/credential-sdk": "0.15.0"
+    "@docknetwork/credential-sdk": "0.16.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.24.1",

--- a/packages/cheqd-blockchain-modules/CHANGELOG.md
+++ b/packages/cheqd-blockchain-modules/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @docknetwork/cheqd-blockchain-modules
 
+## 0.11.2
+
+### Patch Changes
+
+- Updated dependencies
+  - @docknetwork/credential-sdk@0.16.0
+
 ## 0.11.1
 
 ### Patch Changes

--- a/packages/cheqd-blockchain-modules/package.json
+++ b/packages/cheqd-blockchain-modules/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@docknetwork/cheqd-blockchain-modules",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "type": "module",
   "license": "MIT",
   "main": "./dist/esm/index.js",
@@ -33,7 +33,7 @@
     "node": ">=18.0.0"
   },
   "dependencies": {
-    "@docknetwork/credential-sdk": "0.15.0"
+    "@docknetwork/credential-sdk": "0.16.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.24.1",
@@ -42,7 +42,7 @@
     "@babel/plugin-syntax-import-attributes": "^7.25.6",
     "@babel/plugin-transform-modules-commonjs": "^7.24.1",
     "@babel/preset-env": "^7.24.3",
-    "@docknetwork/cheqd-blockchain-api": "0.14.0",
+    "@docknetwork/cheqd-blockchain-api": "0.14.1",
     "@rollup/plugin-alias": "^4.0.2",
     "@rollup/plugin-babel": "^6.0.4",
     "@rollup/plugin-commonjs": "^24.0.0",

--- a/packages/credential-sdk/CHANGELOG.md
+++ b/packages/credential-sdk/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @docknetwork/credential-sdk
 
+## 0.16.0
+
+### Minor Changes
+
+- Dont require credential subject property
+
 ## 0.15.0
 
 ### Minor Changes

--- a/packages/credential-sdk/package.json
+++ b/packages/credential-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@docknetwork/credential-sdk",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "license": "MIT",
   "type": "module",
   "files": [

--- a/packages/credential-sdk/src/vc/credentials.js
+++ b/packages/credential-sdk/src/vc/credentials.js
@@ -180,11 +180,6 @@ export function checkCredentialRequired(credential, isJWT) {
     throw new Error('"type" property is required.');
   }
 
-  // Ensure credential has subject
-  if (!credential.credentialSubject) {
-    throw new Error('"credentialSubject" property is required.');
-  }
-
   // Ensure issuer and issue date is valid, only for non-jwt as that is defined in the header
   if (!isJWT) {
     const issuer = getId(credential.issuer);
@@ -517,6 +512,11 @@ export async function issueCredential(
 
   // Ensure credential is valid
   checkCredential(cred);
+
+  // Ensure credential has subject
+  if (!cred.credentialSubject) {
+    throw new Error('"credentialSubject" property is required.');
+  }
 
   // Should use JWT format?
   if (useJWT) {

--- a/packages/dock-blockchain-api/CHANGELOG.md
+++ b/packages/dock-blockchain-api/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @docknetwork/dock-blockchain-api
 
+## 0.8.2
+
+### Patch Changes
+
+- Updated dependencies
+  - @docknetwork/credential-sdk@0.16.0
+
 ## 0.8.1
 
 ### Patch Changes

--- a/packages/dock-blockchain-api/package.json
+++ b/packages/dock-blockchain-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@docknetwork/dock-blockchain-api",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "license": "MIT",
   "main": "./dist/esm/index.js",
   "type": "module",
@@ -89,7 +89,7 @@
     "@polkadot/api": "10.12.4"
   },
   "dependencies": {
-    "@docknetwork/credential-sdk": "0.15.0",
+    "@docknetwork/credential-sdk": "0.16.0",
     "@docknetwork/node-types": "^0.17.0",
     "@juanelas/base64": "^1.0.5",
     "@polkadot/api": "10.12.4",

--- a/packages/dock-blockchain-modules/CHANGELOG.md
+++ b/packages/dock-blockchain-modules/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @docknetwork/dock-blockchain-modules
 
+## 0.9.2
+
+### Patch Changes
+
+- Updated dependencies
+  - @docknetwork/credential-sdk@0.16.0
+
 ## 0.9.1
 
 ### Patch Changes

--- a/packages/dock-blockchain-modules/package.json
+++ b/packages/dock-blockchain-modules/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@docknetwork/dock-blockchain-modules",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "license": "MIT",
   "type": "module",
   "main": "./dist/esm/index.js",
@@ -33,7 +33,7 @@
     "node": ">=18.0.0"
   },
   "dependencies": {
-    "@docknetwork/credential-sdk": "0.15.0"
+    "@docknetwork/credential-sdk": "0.16.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.24.1",
@@ -42,7 +42,7 @@
     "@babel/plugin-syntax-import-attributes": "^7.25.6",
     "@babel/plugin-transform-modules-commonjs": "^7.24.1",
     "@babel/preset-env": "^7.24.3",
-    "@docknetwork/dock-blockchain-api": "0.8.1",
+    "@docknetwork/dock-blockchain-api": "0.8.2",
     "@rollup/plugin-alias": "^4.0.2",
     "@rollup/plugin-babel": "^6.0.4",
     "@rollup/plugin-commonjs": "^24.0.0",


### PR DESCRIPTION
Anoncreds could have credentials without a revealed subject (rare edge case) - this arbitrary check means we cant verify them