### PR TITLE
Fix schema validation with ID only when ID isnt required

### DIFF
--- a/examples/CHANGELOG.md
+++ b/examples/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @docknetwork/sdk-examples
 
+## 0.6.6
+
+### Patch Changes
+
+- Updated dependencies
+  - @docknetwork/credential-sdk@0.20.0
+  - @docknetwork/dock-blockchain-api@0.8.6
+  - @docknetwork/dock-blockchain-modules@0.11.1
+
 ## 0.6.5
 
 ### Patch Changes

--- a/examples/package.json
+++ b/examples/package.json
@@ -2,7 +2,7 @@
   "name": "@docknetwork/sdk-examples",
   "private": true,
   "type": "module",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "scripts": {
     "bbs-dock-example": "babel-node ./bbs-dock.js",
     "claim-deduction-example": "babel-node ./claim-deduction.js",
@@ -19,9 +19,9 @@
     "lint": "eslint \"*.js\""
   },
   "dependencies": {
-    "@docknetwork/credential-sdk": "0.19.0",
-    "@docknetwork/dock-blockchain-api": "0.8.5",
-    "@docknetwork/dock-blockchain-modules": "0.11.0"
+    "@docknetwork/credential-sdk": "0.20.0",
+    "@docknetwork/dock-blockchain-api": "0.8.6",
+    "@docknetwork/dock-blockchain-modules": "0.11.1"
   },
   "devDependencies": {
     "babel-eslint": "^10.1.0",

--- a/packages/cheqd-blockchain-api/CHANGELOG.md
+++ b/packages/cheqd-blockchain-api/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @docknetwork/cheqd-blockchain-api
 
+## 0.14.5
+
+### Patch Changes
+
+- Updated dependencies
+  - @docknetwork/credential-sdk@0.20.0
+
 ## 0.14.4
 
 ### Patch Changes

--- a/packages/cheqd-blockchain-api/package.json
+++ b/packages/cheqd-blockchain-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@docknetwork/cheqd-blockchain-api",
-  "version": "0.14.4",
+  "version": "0.14.5",
   "license": "MIT",
   "main": "./dist/esm/index.js",
   "type": "module",
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "@cheqd/sdk": "cjs",
-    "@docknetwork/credential-sdk": "0.19.0"
+    "@docknetwork/credential-sdk": "0.20.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.24.1",

--- a/packages/cheqd-blockchain-modules/CHANGELOG.md
+++ b/packages/cheqd-blockchain-modules/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @docknetwork/cheqd-blockchain-modules
 
+## 0.13.2
+
+### Patch Changes
+
+- Updated dependencies
+  - @docknetwork/credential-sdk@0.20.0
+
 ## 0.13.1
 
 ### Patch Changes

--- a/packages/cheqd-blockchain-modules/package.json
+++ b/packages/cheqd-blockchain-modules/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@docknetwork/cheqd-blockchain-modules",
-  "version": "0.13.1",
+  "version": "0.13.2",
   "type": "module",
   "license": "MIT",
   "main": "./dist/esm/index.js",
@@ -33,7 +33,7 @@
     "node": ">=18.0.0"
   },
   "dependencies": {
-    "@docknetwork/credential-sdk": "0.19.0"
+    "@docknetwork/credential-sdk": "0.20.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.24.1",
@@ -42,7 +42,7 @@
     "@babel/plugin-syntax-import-attributes": "^7.25.6",
     "@babel/plugin-transform-modules-commonjs": "^7.24.1",
     "@babel/preset-env": "^7.24.3",
-    "@docknetwork/cheqd-blockchain-api": "0.14.4",
+    "@docknetwork/cheqd-blockchain-api": "0.14.5",
     "@rollup/plugin-alias": "^4.0.2",
     "@rollup/plugin-babel": "^6.0.4",
     "@rollup/plugin-commonjs": "^24.0.0",

--- a/packages/credential-sdk/CHANGELOG.md
+++ b/packages/credential-sdk/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @docknetwork/credential-sdk
 
+## 0.20.0
+
+### Minor Changes
+
+- Fix schema validation with ID only when ID isnt required
+
 ## 0.19.0
 
 ### Minor Changes

--- a/packages/credential-sdk/package.json
+++ b/packages/credential-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@docknetwork/credential-sdk",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "license": "MIT",
   "type": "module",
   "files": [

--- a/packages/credential-sdk/src/vc/schema.js
+++ b/packages/credential-sdk/src/vc/schema.js
@@ -31,10 +31,6 @@ export async function validateCredentialSchema(
     : [credentialSubject];
   for (let i = 0; i < subjects.length; i++) {
     const subject = { ...subjects[i] };
-    if (!requiresID) {
-      // The id will not be part of schema. The spec mentioned that id will be popped off from subject
-      delete subject[credentialIDField];
-    }
 
     // eslint-disable-next-line
     const compacted = await jsonld.compact(subject, context, {
@@ -42,8 +38,14 @@ export async function validateCredentialSchema(
     });
     delete compacted[credentialContextField];
 
+    // Check emptyness/JSON-LD errors before removing ID to avoid edge case of credential with ID field only
     if (Object.keys(compacted).length === 0) {
       throw new Error('Compacted subject is empty, likely invalid');
+    }
+
+    if (!requiresID) {
+      // The id will not be part of schema. The spec mentioned that id will be popped off from subject
+      delete compacted.id;
     }
 
     const schemaObj = schema.schema || schema;

--- a/packages/dock-blockchain-api/CHANGELOG.md
+++ b/packages/dock-blockchain-api/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @docknetwork/dock-blockchain-api
 
+## 0.8.6
+
+### Patch Changes
+
+- Updated dependencies
+  - @docknetwork/credential-sdk@0.20.0
+
 ## 0.8.5
 
 ### Patch Changes

--- a/packages/dock-blockchain-api/package.json
+++ b/packages/dock-blockchain-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@docknetwork/dock-blockchain-api",
-  "version": "0.8.5",
+  "version": "0.8.6",
   "license": "MIT",
   "main": "./dist/esm/index.js",
   "type": "module",
@@ -89,7 +89,7 @@
     "@polkadot/api": "10.12.4"
   },
   "dependencies": {
-    "@docknetwork/credential-sdk": "0.19.0",
+    "@docknetwork/credential-sdk": "0.20.0",
     "@docknetwork/node-types": "^0.17.0",
     "@juanelas/base64": "^1.0.5",
     "@polkadot/api": "10.12.4",

--- a/packages/dock-blockchain-modules/CHANGELOG.md
+++ b/packages/dock-blockchain-modules/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @docknetwork/dock-blockchain-modules
 
+## 0.11.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @docknetwork/credential-sdk@0.20.0
+
 ## 0.11.0
 
 ### Minor Changes

--- a/packages/dock-blockchain-modules/package.json
+++ b/packages/dock-blockchain-modules/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@docknetwork/dock-blockchain-modules",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "license": "MIT",
   "type": "module",
   "main": "./dist/esm/index.js",
@@ -33,7 +33,7 @@
     "node": ">=18.0.0"
   },
   "dependencies": {
-    "@docknetwork/credential-sdk": "0.19.0"
+    "@docknetwork/credential-sdk": "0.20.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.24.1",
@@ -42,7 +42,7 @@
     "@babel/plugin-syntax-import-attributes": "^7.25.6",
     "@babel/plugin-transform-modules-commonjs": "^7.24.1",
     "@babel/preset-env": "^7.24.3",
-    "@docknetwork/dock-blockchain-api": "0.8.5",
+    "@docknetwork/dock-blockchain-api": "0.8.6",
     "@rollup/plugin-alias": "^4.0.2",
     "@rollup/plugin-babel": "^6.0.4",
     "@rollup/plugin-commonjs": "^24.0.0",


### PR DESCRIPTION
Fixes edge case where subject contains only ID, but schema doesnt mention it/mark as a requirement. In this case subject is empty, which the SDK then thinks is a JSON-LD error. To solve this we remove the ID field after checking for empty compaction