### PR TITLE
feat(ap2): emit TypeScript declarations for @docknetwork/ap2

### DIFF
--- a/.changeset/tame-mice-jump.md
+++ b/.changeset/tame-mice-jump.md
@@ -1,0 +1,10 @@
+---
+"@docknetwork/ap2": patch
+---
+
+Ship TypeScript declaration files (`.d.ts`) with the package. Previously
+`@docknetwork/ap2` had no `types` field and emitted no declarations, so
+TypeScript consumers got no type information on import. Declarations are
+now generated from the existing JSDoc-annotated source via a `tsc`
+declaration-only build step, mirroring the approach already used in
+`@docknetwork/vc-delegation-engine`.

--- a/packages/ap2/package.json
+++ b/packages/ap2/package.json
@@ -4,6 +4,7 @@
   "description": "Basic AP2 support",
   "license": "MIT",
   "type": "module",
+  "types": "dist/types/index.d.ts",
   "files": [
     "dist",
     "examples",
@@ -13,11 +14,13 @@
   ],
   "exports": {
     ".": {
+      "types": "./dist/types/index.d.ts",
       "import": "./dist/esm/index.js",
       "require": "./dist/cjs/index.cjs",
       "default": "./dist/esm/index.js"
     },
     "./src/*": {
+      "types": "./dist/types/*",
       "import": "./dist/esm/*",
       "require": "./dist/cjs/*",
       "default": "./dist/esm/*"
@@ -43,15 +46,19 @@
     "@rollup/plugin-commonjs": "^28.0.1",
     "@rollup/plugin-json": "^6.1.0",
     "@rollup/plugin-node-resolve": "^15.3.1",
+    "@types/node": "^24.10.1",
     "babel-jest": "^29.7.0",
     "eslint": "^8.0.0",
     "jest": "^29.7.0",
     "rollup": "^4.28.0",
     "rollup-plugin-multi-input": "^1.4.1",
+    "typescript": "^5.6.3",
     "zod": "^4.4.3"
   },
   "scripts": {
-    "build": "rollup -c",
+    "build:js": "rollup -c",
+    "build:types": "tsc -p tsconfig.build.json",
+    "build": "yarn build:js && yarn build:types",
     "generate-schemas": "node scripts/generate-schemas.mjs",
     "example:receipt": "yarn build && node examples/issue-and-verify-receipt.mjs",
     "test": "jest --runInBand",

--- a/packages/ap2/tsconfig.build.json
+++ b/packages/ap2/tsconfig.build.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "resolveJsonModule": true,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "allowJs": true,
+    "checkJs": false,
+    "skipLibCheck": true,
+    "outDir": "dist/types",
+    "rootDir": "src",
+    "types": ["node"]
+  },
+  "include": ["src/**/*.js"]
+}


### PR DESCRIPTION
The package shipped no .d.ts files, so TS consumers got no types on import. Add a tsc declaration-only build (mirroring vc-delegation-engine) and wire it into package.json's types field, exports conditions, and build script.