### PR TITLE
extract JsonWebKey from @transmute/json-web-signature

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -8,6 +8,7 @@ jobs:
       CHEQD_MNEMONIC: "steak come surprise obvious remain black trouble measure design volume retreat float coach amused match album moment radio stuff crack orphan ranch dose endorse"
       CHEQD_IMAGE_TAG: 4.1.7
       CHEQD_NETWORK: "testnet"
+      INFURA_API_KEY: ${{ secrets.INFURA_API_KEY }}
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v4
@@ -16,7 +17,7 @@ jobs:
       - run: yarn install --frozen-lockfile --ignore-scripts
       - run: npm install -g turbo@2.0.5
       - run: turbo telemetry disable
-      - run: CHEQD_MNEMONIC=$CHEQD_MNEMONIC CHEQD_IMAGE_TAG=$CHEQD_IMAGE_TAG CHEQD_NETWORK=$CHEQD_NETWORK turbo run examples-with-node
+      - run: CHEQD_MNEMONIC=$CHEQD_MNEMONIC CHEQD_IMAGE_TAG=$CHEQD_IMAGE_TAG CHEQD_NETWORK=$CHEQD_NETWORK INFURA_API_KEY=$INFURA_API_KEY turbo run examples-with-node
 
   mainnet:
     runs-on: ubuntu-latest
@@ -24,6 +25,7 @@ jobs:
       CHEQD_MNEMONIC: "steak come surprise obvious remain black trouble measure design volume retreat float coach amused match album moment radio stuff crack orphan ranch dose endorse"
       CHEQD_IMAGE_TAG: 4.1.7
       CHEQD_NETWORK: "mainnet"
+      INFURA_API_KEY: ${{ secrets.INFURA_API_KEY }}
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v4
@@ -32,4 +34,4 @@ jobs:
       - run: yarn install --frozen-lockfile --ignore-scripts
       - run: npm install -g turbo@2.0.5
       - run: turbo telemetry disable
-      - run: CHEQD_MNEMONIC=$CHEQD_MNEMONIC CHEQD_IMAGE_TAG=$CHEQD_IMAGE_TAG CHEQD_NETWORK=$CHEQD_NETWORK turbo run examples-with-node
+      - run: CHEQD_MNEMONIC=$CHEQD_MNEMONIC CHEQD_IMAGE_TAG=$CHEQD_IMAGE_TAG CHEQD_NETWORK=$CHEQD_NETWORK INFURA_API_KEY=$INFURA_API_KEY turbo run examples-with-node

--- a/examples/src/env.js
+++ b/examples/src/env.js
@@ -16,3 +16,5 @@ export const faucet = {
 
 export const url = process.env.CHEQD_RPC_URL || 'http://localhost:26657';
 export const network = process.env.CHEQD_NETWORK || CheqdNetwork.Testnet;
+
+export const infuraApiKey = process.env.INFURA_API_KEY || '';

--- a/examples/src/resolver.js
+++ b/examples/src/resolver.js
@@ -20,7 +20,9 @@ import {
   Ed25519Keypair,
   DidKeypair,
 } from '@docknetwork/credential-sdk/keypairs';
-import { faucet, network, url } from './env.js';
+import {
+  faucet, network, url, infuraApiKey,
+} from './env.js';
 
 const universalResolverUrl = 'https://uniresolver.io';
 
@@ -29,7 +31,7 @@ const ethereumProviderConfig = {
   networks: [
     {
       name: 'mainnet',
-      rpcUrl: 'https://mainnet.infura.io/v3/05f321c3606e44599c54dbc92510e6a9',
+      rpcUrl: `https://mainnet.infura.io/v3/${infuraApiKey}`,
     },
   ],
 };

--- a/packages/credential-sdk/package.json
+++ b/packages/credential-sdk/package.json
@@ -28,11 +28,6 @@
       "default": "./dist/esm/*"
     }
   },
-  "resolutions": {
-    "@digitalbazaar/http-client": "^3.4.1",
-    "jsonld/@digitalbazaar/http-client": "^3.4.1",
-    "@transmute/jsonld/jsonld/@digitalbazaar/http-client": "^3.4.1"
-  },
   "repository": {
     "type": "git",
     "url": "https://github.com/docknetwork/sdk"
@@ -49,7 +44,10 @@
     "@juanelas/base64": "^1.1.5",
     "@sphereon/pex": "^5.0.0-unstable.28",
     "@sphereon/ssi-sdk-ext.did-resolver-jwk": "^0.26.0",
-    "@transmute/json-web-signature": "^0.7.0-unstable.82",
+    "@transmute/ed25519-key-pair": "0.7.0-unstable.82",
+    "@transmute/jose-ld": "0.7.0-unstable.82",
+    "@transmute/secp256k1-key-pair": "0.7.0-unstable.82",
+    "@transmute/web-crypto-key-pair": "0.7.0-unstable.82",
     "base64url": "^3.0.1",
     "blake2b": "2.1.4",
     "blakejs": "^1.2.1",
@@ -59,7 +57,7 @@
     "json-canonicalize": "1.0.4",
     "json-stringify-deterministic": "^1.0.12",
     "jsonld": "^6.0.0",
-    "jsonld-signatures": "^9.3.1",
+    "jsonld-signatures": "^10.0.0",
     "jsonschema": "1.4.1",
     "key-did-resolver": "^1.4.0",
     "mrklt": "^0.2.0",

--- a/packages/credential-sdk/src/vc/crypto/JsonWebKey.js
+++ b/packages/credential-sdk/src/vc/crypto/JsonWebKey.js
@@ -1,19 +1,23 @@
-import {
-  Ed25519KeyPair,
-} from '@transmute/ed25519-key-pair';
-import {
-  Secp256k1KeyPair,
-} from '@transmute/secp256k1-key-pair';
-
+// Local copy of JsonWebKey from @transmute/json-web-signature@0.7.0-unstable.82,
+// extracted to drop that package's broken jsonld@5 -> @digitalbazaar/http-client@1
+// -> esm dependency chain (JsonWebKey itself never touches it).
+// 0.7.0-unstable.82 is the `latest` npm dist-tag for all @transmute packages —
+// no stable release exists, so there is no newer version to upgrade to. The
+// four @transmute deps are pinned exactly to keep them in sync with this copy.
+// These @transmute packages are CommonJS. Named ESM imports off them break
+// under Node's native loader (the examples-with-node CI job); a default import
+// breaks under babel/jest. `import * as` resolves to a namespace exposing the
+// named members in both, so destructure off that.
 import crypto from 'crypto';
-import { JWS } from '@transmute/jose-ld';
+import * as ed25519 from '@transmute/ed25519-key-pair';
+import * as secp256k1 from '@transmute/secp256k1-key-pair';
+import * as joseLd from '@transmute/jose-ld';
+import * as webCrypto from '@transmute/web-crypto-key-pair';
 
-import {
-  WebCryptoKey,
-  JsonWebKey2020,
-} from '@transmute/web-crypto-key-pair';
-
-export { JsonWebKey2020 };
+const { Ed25519KeyPair } = ed25519;
+const { Secp256k1KeyPair } = secp256k1;
+const { JWS } = joseLd;
+const { WebCryptoKey } = webCrypto;
 
 const getKeyPairForKtyAndCrv = (kty, crv) => {
   if (kty === 'OKP' && crv === 'Ed25519') {

--- a/packages/credential-sdk/src/vc/crypto/JsonWebKey.js
+++ b/packages/credential-sdk/src/vc/crypto/JsonWebKey.js
@@ -8,6 +8,9 @@
 // under Node's native loader (the examples-with-node CI job); a default import
 // breaks under babel/jest. `import * as` resolves to a namespace exposing the
 // named members in both, so destructure off that.
+// Deviations from upstream: getSigner reads `alg` from the exported JWK
+// (matching getVerifier) instead of `k.alg`, and useJwa restores the original
+// signer/verifier factories so it can be re-applied with new options.
 import crypto from 'crypto';
 import * as ed25519 from '@transmute/ed25519-key-pair';
 import * as secp256k1 from '@transmute/secp256k1-key-pair';
@@ -72,7 +75,7 @@ const getVerifier = async (k, options = { detached: true }) => {
   const jwa = jwaFor(kty, crv, alg);
   if (!jwa) {
     throw new Error(
-      `getVerifier does not suppport ${JSON.stringify(publicKeyJwk, null, 2)}`,
+      `getVerifier does not support ${JSON.stringify(publicKeyJwk, null, 2)}`,
     );
   }
   const [keySuite, jwsAlg] = jwa;
@@ -81,11 +84,11 @@ const getVerifier = async (k, options = { detached: true }) => {
 
 const getSigner = async (k, options = { detached: true }) => {
   const { publicKeyJwk } = await k.export({ type: 'JsonWebKey2020' });
-  const { kty, crv } = publicKeyJwk;
-  const jwa = jwaFor(kty, crv, k.alg);
+  const { kty, crv, alg } = publicKeyJwk;
+  const jwa = jwaFor(kty, crv, alg);
   if (!jwa) {
     throw new Error(
-      `getSigner does not suppport ${JSON.stringify(publicKeyJwk, null, 2)}`,
+      `getSigner does not support ${JSON.stringify(publicKeyJwk, null, 2)}`,
     );
   }
   const [keySuite, jwsAlg] = jwa;
@@ -105,8 +108,17 @@ const applyJwa = async (k, options) => {
 };
 
 const useJwa = async (k, options) => {
+  // applyJwa replaces `verifier`/`signer` with 0-arg wrappers, so keep the
+  // original factories and restore them before re-applying with new options.
+  const { verifier, signer } = k;
   // eslint-disable-next-line no-param-reassign
-  k.useJwa = async (opts) => applyJwa(k, opts);
+  k.useJwa = async (opts) => {
+    // eslint-disable-next-line no-param-reassign
+    k.verifier = verifier;
+    // eslint-disable-next-line no-param-reassign
+    k.signer = signer;
+    return applyJwa(k, opts);
+  };
   return applyJwa(k, options);
 };
 

--- a/packages/credential-sdk/src/vc/crypto/JsonWebKey.js
+++ b/packages/credential-sdk/src/vc/crypto/JsonWebKey.js
@@ -1,0 +1,170 @@
+import {
+  Ed25519KeyPair,
+} from '@transmute/ed25519-key-pair';
+import {
+  Secp256k1KeyPair,
+} from '@transmute/secp256k1-key-pair';
+
+import crypto from 'crypto';
+import { JWS } from '@transmute/jose-ld';
+
+import {
+  WebCryptoKey,
+  JsonWebKey2020,
+} from '@transmute/web-crypto-key-pair';
+
+export { JsonWebKey2020 };
+
+const getKeyPairForKtyAndCrv = (kty, crv) => {
+  if (kty === 'OKP') {
+    if (crv === 'Ed25519') {
+      return Ed25519KeyPair;
+    }
+  }
+  if (kty === 'EC') {
+    if (crv === 'secp256k1') {
+      return Secp256k1KeyPair;
+    }
+
+    if (['P-256', 'P-384', 'P-521'].includes(crv)) {
+      return WebCryptoKey;
+    }
+  }
+  throw new Error(`getKeyPairForKtyAndCrv does not support: ${kty} and ${crv}`);
+};
+
+const getKeyPairForType = (k) => {
+  if (k.type === 'JsonWebKey2020') {
+    return getKeyPairForKtyAndCrv(k.publicKeyJwk.kty, k.publicKeyJwk.crv);
+  }
+  if (k.type === 'Ed25519VerificationKey2018') {
+    return Ed25519KeyPair;
+  }
+  if (k.type === 'EcdsaSecp256k1VerificationKey2019') {
+    return Secp256k1KeyPair;
+  }
+
+  if (['P256Key2021', 'P384Key2021', 'P521Key2021'].includes(k.type)) {
+    return WebCryptoKey;
+  }
+
+  throw new Error(`getKeyPairForType does not support type: ${k.type}`);
+};
+
+const getVerifier = async (k, options = { detached: true }) => {
+  const { publicKeyJwk } = await k.export({ type: 'JsonWebKey2020' });
+  const { kty, crv, alg } = publicKeyJwk;
+  if (kty === 'OKP') {
+    if (crv === 'Ed25519') {
+      return JWS.createVerifier(k.verifier('EdDsa'), 'EdDSA', options);
+    }
+  }
+
+  if (kty === 'EC') {
+    if (crv === 'secp256k1') {
+      if (alg && alg === 'ES256K-R') {
+        return JWS.createVerifier(k.verifier('EcRecover'), 'ES256K-R', options);
+      }
+      return JWS.createVerifier(k.verifier('Ecdsa'), 'ES256K', options);
+    }
+
+    if (crv === 'P-256') {
+      return JWS.createVerifier(k.verifier('Ecdsa'), 'ES256', options);
+    }
+    if (crv === 'P-384') {
+      return JWS.createVerifier(k.verifier('Ecdsa'), 'ES384', options);
+    }
+    if (crv === 'P-521') {
+      return JWS.createVerifier(k.verifier('Ecdsa'), 'ES512', options);
+    }
+  }
+
+  throw new Error(
+    `getVerifier does not suppport ${JSON.stringify(publicKeyJwk, null, 2)}`,
+  );
+};
+
+const getSigner = async (k, options = { detached: true }) => {
+  const { publicKeyJwk } = await k.export({ type: 'JsonWebKey2020' });
+  const { kty, crv } = publicKeyJwk;
+  const { alg } = k;
+  if (kty === 'OKP') {
+    if (crv === 'Ed25519') {
+      return JWS.createSigner(k.signer('EdDsa'), 'EdDSA', options);
+    }
+  }
+  if (kty === 'EC') {
+    if (crv === 'secp256k1') {
+      if (alg && alg === 'ES256K-R') {
+        return JWS.createSigner(k.signer('EcRecover'), 'ES256K-R', options);
+      }
+      return JWS.createSigner(k.signer('Ecdsa'), 'ES256K', options);
+    }
+    if (crv === 'P-256') {
+      return JWS.createSigner(k.signer('Ecdsa'), 'ES256', options);
+    }
+    if (crv === 'P-384') {
+      return JWS.createSigner(k.signer('Ecdsa'), 'ES384', options);
+    }
+    if (crv === 'P-521') {
+      return JWS.createSigner(k.signer('Ecdsa'), 'ES512', options);
+    }
+  }
+  throw new Error(
+    `getSigner does not suppport ${JSON.stringify(publicKeyJwk, null, 2)}`,
+  );
+};
+
+const applyJwa = async (k, options) => {
+  const verifier = await getVerifier(k, options);
+  // eslint-disable-next-line no-param-reassign
+  k.verifier = () => verifier;
+  if (k.privateKey) {
+    const signer = await getSigner(k, options);
+    // eslint-disable-next-line no-param-reassign
+    k.signer = () => signer;
+  }
+  return k;
+};
+
+// this is dirty...
+const useJwa = async (k, options) => {
+  // before mutation, annotate the apply function....
+  // eslint-disable-next-line no-param-reassign
+  k.useJwa = async (opts) => applyJwa(k, opts);
+  return applyJwa(k, options);
+};
+
+export class JsonWebKey {
+  static generate = async (
+    options = {
+      kty: 'OKP',
+      crv: 'Ed25519',
+      detached: true,
+    },
+  ) => {
+    const KeyPair = getKeyPairForKtyAndCrv(options.kty, options.crv);
+    if (!options.secureRandom) {
+      // eslint-disable-next-line no-param-reassign
+      options.secureRandom = () => crypto.randomBytes(32);
+    }
+    const kp = await KeyPair.generate({
+      kty: options.kty,
+      crvOrSize: options.crv,
+      secureRandom: options.secureRandom,
+    });
+    const { detached } = options;
+    return useJwa(kp, { detached });
+  };
+
+  static from = async (k, options = { detached: true }) => {
+    const KeyPair = getKeyPairForType(k);
+    const kp = await KeyPair.from(k);
+    let { detached } = options;
+    const { header } = options;
+    if (detached === undefined) {
+      detached = true;
+    }
+    return useJwa(kp, { detached, header });
+  };
+}

--- a/packages/credential-sdk/src/vc/crypto/JsonWebKey.js
+++ b/packages/credential-sdk/src/vc/crypto/JsonWebKey.js
@@ -16,21 +16,32 @@ import {
 export { JsonWebKey2020 };
 
 const getKeyPairForKtyAndCrv = (kty, crv) => {
-  if (kty === 'OKP') {
-    if (crv === 'Ed25519') {
-      return Ed25519KeyPair;
-    }
+  if (kty === 'OKP' && crv === 'Ed25519') {
+    return Ed25519KeyPair;
   }
-  if (kty === 'EC') {
-    if (crv === 'secp256k1') {
-      return Secp256k1KeyPair;
-    }
-
-    if (['P-256', 'P-384', 'P-521'].includes(crv)) {
-      return WebCryptoKey;
-    }
+  if (kty === 'EC' && crv === 'secp256k1') {
+    return Secp256k1KeyPair;
+  }
+  if (kty === 'EC' && ['P-256', 'P-384', 'P-521'].includes(crv)) {
+    return WebCryptoKey;
   }
   throw new Error(`getKeyPairForKtyAndCrv does not support: ${kty} and ${crv}`);
+};
+
+// Maps a JWK (kty, crv, alg) to the [keySuite, jwsAlg] pair passed to jose-ld.
+const jwaFor = (kty, crv, alg) => {
+  if (kty === 'OKP' && crv === 'Ed25519') {
+    return ['EdDsa', 'EdDSA'];
+  }
+  if (kty === 'EC' && crv === 'secp256k1') {
+    return alg === 'ES256K-R'
+      ? ['EcRecover', 'ES256K-R']
+      : ['Ecdsa', 'ES256K'];
+  }
+  if (kty === 'EC' && crv === 'P-256') return ['Ecdsa', 'ES256'];
+  if (kty === 'EC' && crv === 'P-384') return ['Ecdsa', 'ES384'];
+  if (kty === 'EC' && crv === 'P-521') return ['Ecdsa', 'ES512'];
+  return null;
 };
 
 const getKeyPairForType = (k) => {
@@ -54,65 +65,27 @@ const getKeyPairForType = (k) => {
 const getVerifier = async (k, options = { detached: true }) => {
   const { publicKeyJwk } = await k.export({ type: 'JsonWebKey2020' });
   const { kty, crv, alg } = publicKeyJwk;
-  if (kty === 'OKP') {
-    if (crv === 'Ed25519') {
-      return JWS.createVerifier(k.verifier('EdDsa'), 'EdDSA', options);
-    }
+  const jwa = jwaFor(kty, crv, alg);
+  if (!jwa) {
+    throw new Error(
+      `getVerifier does not suppport ${JSON.stringify(publicKeyJwk, null, 2)}`,
+    );
   }
-
-  if (kty === 'EC') {
-    if (crv === 'secp256k1') {
-      if (alg && alg === 'ES256K-R') {
-        return JWS.createVerifier(k.verifier('EcRecover'), 'ES256K-R', options);
-      }
-      return JWS.createVerifier(k.verifier('Ecdsa'), 'ES256K', options);
-    }
-
-    if (crv === 'P-256') {
-      return JWS.createVerifier(k.verifier('Ecdsa'), 'ES256', options);
-    }
-    if (crv === 'P-384') {
-      return JWS.createVerifier(k.verifier('Ecdsa'), 'ES384', options);
-    }
-    if (crv === 'P-521') {
-      return JWS.createVerifier(k.verifier('Ecdsa'), 'ES512', options);
-    }
-  }
-
-  throw new Error(
-    `getVerifier does not suppport ${JSON.stringify(publicKeyJwk, null, 2)}`,
-  );
+  const [keySuite, jwsAlg] = jwa;
+  return JWS.createVerifier(k.verifier(keySuite), jwsAlg, options);
 };
 
 const getSigner = async (k, options = { detached: true }) => {
   const { publicKeyJwk } = await k.export({ type: 'JsonWebKey2020' });
   const { kty, crv } = publicKeyJwk;
-  const { alg } = k;
-  if (kty === 'OKP') {
-    if (crv === 'Ed25519') {
-      return JWS.createSigner(k.signer('EdDsa'), 'EdDSA', options);
-    }
+  const jwa = jwaFor(kty, crv, k.alg);
+  if (!jwa) {
+    throw new Error(
+      `getSigner does not suppport ${JSON.stringify(publicKeyJwk, null, 2)}`,
+    );
   }
-  if (kty === 'EC') {
-    if (crv === 'secp256k1') {
-      if (alg && alg === 'ES256K-R') {
-        return JWS.createSigner(k.signer('EcRecover'), 'ES256K-R', options);
-      }
-      return JWS.createSigner(k.signer('Ecdsa'), 'ES256K', options);
-    }
-    if (crv === 'P-256') {
-      return JWS.createSigner(k.signer('Ecdsa'), 'ES256', options);
-    }
-    if (crv === 'P-384') {
-      return JWS.createSigner(k.signer('Ecdsa'), 'ES384', options);
-    }
-    if (crv === 'P-521') {
-      return JWS.createSigner(k.signer('Ecdsa'), 'ES512', options);
-    }
-  }
-  throw new Error(
-    `getSigner does not suppport ${JSON.stringify(publicKeyJwk, null, 2)}`,
-  );
+  const [keySuite, jwsAlg] = jwa;
+  return JWS.createSigner(k.signer(keySuite), jwsAlg, options);
 };
 
 const applyJwa = async (k, options) => {

--- a/packages/credential-sdk/src/vc/crypto/JsonWebKey.js
+++ b/packages/credential-sdk/src/vc/crypto/JsonWebKey.js
@@ -127,9 +127,7 @@ const applyJwa = async (k, options) => {
   return k;
 };
 
-// this is dirty...
 const useJwa = async (k, options) => {
-  // before mutation, annotate the apply function....
   // eslint-disable-next-line no-param-reassign
   k.useJwa = async (opts) => applyJwa(k, opts);
   return applyJwa(k, options);

--- a/packages/credential-sdk/src/vc/crypto/JsonWebKey.js
+++ b/packages/credential-sdk/src/vc/crypto/JsonWebKey.js
@@ -131,14 +131,11 @@ export class JsonWebKey {
     },
   ) => {
     const KeyPair = getKeyPairForKtyAndCrv(options.kty, options.crv);
-    if (!options.secureRandom) {
-      // eslint-disable-next-line no-param-reassign
-      options.secureRandom = () => crypto.randomBytes(32);
-    }
+    const secureRandom = options.secureRandom || (() => crypto.randomBytes(32));
     const kp = await KeyPair.generate({
       kty: options.kty,
       crvOrSize: options.crv,
-      secureRandom: options.secureRandom,
+      secureRandom,
     });
     const { detached } = options;
     return useJwa(kp, { detached });

--- a/packages/credential-sdk/src/vc/crypto/JsonWebSignature2020.js
+++ b/packages/credential-sdk/src/vc/crypto/JsonWebSignature2020.js
@@ -1,4 +1,4 @@
-import { JsonWebKey } from '@transmute/json-web-signature';
+import { JsonWebKey } from './JsonWebKey';
 import CustomLinkedDataSignature from './common/CustomLinkedDataSignature';
 
 const SUITE_CONTEXT_URL = 'https://w3id.org/security/suites/jws-2020/v1';

--- a/packages/credential-sdk/src/vc/helpers.js
+++ b/packages/credential-sdk/src/vc/helpers.js
@@ -1,5 +1,5 @@
 import jsonld from 'jsonld';
-import { JsonWebKey } from '@transmute/json-web-signature';
+import { JsonWebKey } from './crypto/JsonWebKey';
 import defaultDocumentLoader from './document-loader';
 
 import {

--- a/packages/vc-delegation-engine/tsconfig.build.json
+++ b/packages/vc-delegation-engine/tsconfig.build.json
@@ -11,7 +11,7 @@
     "outDir": "dist/types",
     "rootDir": "src",
     "types": ["node"],
-    "typeRoots": ["./types", "./node_modules/@types"]
+    "typeRoots": ["./types", "./node_modules/@types", "../../node_modules/@types"]
   },
   "include": ["src/**/*.js", "types/**/*.d.ts"]
 }

--- a/turbo.json
+++ b/turbo.json
@@ -36,7 +36,7 @@
       "cache": false,
       "dependsOn": ["^build"],
       "outputs": [],
-      "env": ["CHEQD_MNEMONIC", "CHEQD_IMAGE_TAG", "CHEQD_NETWORK"]
+      "env": ["CHEQD_MNEMONIC", "CHEQD_IMAGE_TAG", "CHEQD_NETWORK", "INFURA_API_KEY"]
     },
     "publish-packages": {
       "dependsOn": ["^build"],

--- a/yarn.lock
+++ b/yarn.lock
@@ -7103,6 +7103,11 @@
   dependencies:
     xmlchars "^2.2.0"
 
+"@scure/base@^1.1.3":
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/@scure/base/-/base-1.2.6.tgz#ca917184b8231394dd8847509c67a0be522e59f6"
+  integrity sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==
+
 "@scure/base@^2.0.0":
   version "2.0.0"
   resolved "https://registry.npmjs.org/@scure/base/-/base-2.0.0.tgz"
@@ -9241,14 +9246,14 @@ detect-newline@^3.0.0:
   integrity sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==
 
 "did-jwt-cjs@npm:did-jwt@^8.0.15":
-  version "8.0.18"
-  resolved "https://registry.npmjs.org/did-jwt/-/did-jwt-8.0.18.tgz"
-  integrity sha512-yS3Y+aUKjYqRFrgR/RY77NuOOqS7SFfvfFH4THhWD6+hkxeUZcKQSsdNZ12QR1Vd48yP9exwae2wzbuOZn0NqQ==
+  version "8.0.17"
+  resolved "https://registry.npmjs.org/did-jwt/-/did-jwt-8.0.17.tgz"
+  integrity sha512-qWPog796seH8CzvNShvqvs6YeCRVAYWmKzcPtirnhvH6wjiFvhquztJZwr5E9VHnTosW6V7bclWzrp7/HGJbSw==
   dependencies:
     "@noble/ciphers" "^1.0.0"
     "@noble/curves" "^1.0.0"
     "@noble/hashes" "^1.3.0"
-    "@scure/base" "^2.0.0"
+    "@scure/base" "^1.1.3"
     canonicalize "^2.0.0"
     did-resolver "^4.1.0"
     multibase "^4.0.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -18,7 +18,7 @@
 
 "@achingbrain/ssdp@^4.0.1":
   version "4.2.4"
-  resolved "https://registry.npmjs.org/@achingbrain/ssdp/-/ssdp-4.2.4.tgz"
+  resolved "https://registry.yarnpkg.com/@achingbrain/ssdp/-/ssdp-4.2.4.tgz#ea109d825d8b77b4014eeb697dbed22c8dca21ae"
   integrity sha512-1dZIV7dwYJRS1sTA0qIDzsMdwZAnPa7DGb2YuPqMq4PjEjvzBBuz2WIsXnrkRFCNY00JuqLiMby9GecnGsOgaQ==
   dependencies:
     abort-error "^1.0.0"
@@ -26,7 +26,7 @@
     merge-options "^3.0.4"
     xml2js "^0.6.2"
 
-"@ampproject/remapping@^2.2.0", "@ampproject/remapping@^2.3.0":
+"@ampproject/remapping@^2.3.0":
   version "2.3.0"
   resolved "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz"
   integrity sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==
@@ -36,7 +36,7 @@
 
 "@ar-agents/ap2@^0.3.1":
   version "0.3.1"
-  resolved "https://registry.yarnpkg.com/@ar-agents/ap2/-/ap2-0.3.1.tgz#00ab6bcdeabe657ca39ed9a3e15fa918b384b29f"
+  resolved "https://registry.npmjs.org/@ar-agents/ap2/-/ap2-0.3.1.tgz"
   integrity sha512-9NeH0hGiv5PXRdZPELAAgJXSg6uEdoGu4hiz4+b4SfuYcyPSfRxbZtC1sx77bTm/QXawDEY6ybNfmcMB6yAOJw==
   dependencies:
     jose "^6.2.3"
@@ -49,9 +49,9 @@
     static-eval "2.0.2"
 
 "@babel/cli@^7.24.1":
-  version "7.28.3"
-  resolved "https://registry.npmjs.org/@babel/cli/-/cli-7.28.3.tgz"
-  integrity sha512-n1RU5vuCX0CsaqaXm9I0KUCNKNQMy5epmzl/xdSSm70bSqhg9GWhgeosypyQLc0bK24+Xpk1WGzZlI9pJtkZdg==
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/cli/-/cli-7.29.7.tgz#ae6bd1b11ede44b46ea5624892f62724c4a20ccb"
+  integrity sha512-/75HwRbAYPqXv/Ax1h7Fg3IZfXgdU98jnA8H93/m/QBaPV3Hp5ICoLqzGYye1yHBCgpmXvtqgSUN8oOKX5tojQ==
   dependencies:
     "@jridgewell/trace-mapping" "^0.3.28"
     commander "^6.2.0"
@@ -64,35 +64,35 @@
     "@nicolo-ribaudo/chokidar-2" "2.1.8-no-fsevents.3"
     chokidar "^3.6.0"
 
-"@babel/code-frame@^7.0.0", "@babel/code-frame@^7.10.4", "@babel/code-frame@^7.12.13", "@babel/code-frame@^7.27.1":
-  version "7.27.1"
-  resolved "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz"
-  integrity sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==
+"@babel/code-frame@^7.0.0", "@babel/code-frame@^7.10.4", "@babel/code-frame@^7.12.13", "@babel/code-frame@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.29.7.tgz#f2fbbfea87c44a21590ec515b778b2c26d8866e7"
+  integrity sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==
   dependencies:
-    "@babel/helper-validator-identifier" "^7.27.1"
+    "@babel/helper-validator-identifier" "^7.29.7"
     js-tokens "^4.0.0"
     picocolors "^1.1.1"
 
-"@babel/compat-data@^7.27.2", "@babel/compat-data@^7.27.7", "@babel/compat-data@^7.28.0":
-  version "7.28.0"
-  resolved "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.28.0.tgz"
-  integrity sha512-60X7qkglvrap8mn1lh2ebxXdZYtUcpd7gsmy9kLaBJ4i/WdY8PqTSdxyA8qraikqKQK5C1KRBKXqznrVapyNaw==
+"@babel/compat-data@^7.28.6", "@babel/compat-data@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.29.7.tgz#6f0237f0f36d2e51c0570a636faed9d2d0efe629"
+  integrity sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==
 
 "@babel/core@^7.11.6", "@babel/core@^7.12.3", "@babel/core@^7.23.9", "@babel/core@^7.24.3":
-  version "7.28.3"
-  resolved "https://registry.npmjs.org/@babel/core/-/core-7.28.3.tgz"
-  integrity sha512-yDBHV9kQNcr2/sUr9jghVyz9C3Y5G2zUM2H2lo+9mKv4sFgbA8s8Z9t8D1jiTkGoO/NoIfKMyKWr4s6CN23ZwQ==
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.29.7.tgz#80c10b17248082968b57a857b91640971f2070f7"
+  integrity sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==
   dependencies:
-    "@ampproject/remapping" "^2.2.0"
-    "@babel/code-frame" "^7.27.1"
-    "@babel/generator" "^7.28.3"
-    "@babel/helper-compilation-targets" "^7.27.2"
-    "@babel/helper-module-transforms" "^7.28.3"
-    "@babel/helpers" "^7.28.3"
-    "@babel/parser" "^7.28.3"
-    "@babel/template" "^7.27.2"
-    "@babel/traverse" "^7.28.3"
-    "@babel/types" "^7.28.2"
+    "@babel/code-frame" "^7.29.7"
+    "@babel/generator" "^7.29.7"
+    "@babel/helper-compilation-targets" "^7.29.7"
+    "@babel/helper-module-transforms" "^7.29.7"
+    "@babel/helpers" "^7.29.7"
+    "@babel/parser" "^7.29.7"
+    "@babel/template" "^7.29.7"
+    "@babel/traverse" "^7.29.7"
+    "@babel/types" "^7.29.7"
+    "@jridgewell/remapping" "^2.3.5"
     convert-source-map "^2.0.0"
     debug "^4.1.0"
     gensync "^1.0.0-beta.2"
@@ -101,244 +101,250 @@
 
 "@babel/eslint-parser@^7.25.9":
   version "7.28.6"
-  resolved "https://registry.yarnpkg.com/@babel/eslint-parser/-/eslint-parser-7.28.6.tgz#6a294a4add732ebe7ded8a8d2792dd03dd81dc3f"
+  resolved "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.28.6.tgz"
   integrity sha512-QGmsKi2PBO/MHSQk+AAgA9R6OHQr+VqnniFE0eMWZcVcfBZoA2dKn2hUsl3Csg/Plt9opRUWdY7//VXsrIlEiA==
   dependencies:
     "@nicolo-ribaudo/eslint-scope-5-internals" "5.1.1-v1"
     eslint-visitor-keys "^2.1.0"
     semver "^6.3.1"
 
-"@babel/generator@^7.28.3", "@babel/generator@^7.7.2":
-  version "7.28.3"
-  resolved "https://registry.npmjs.org/@babel/generator/-/generator-7.28.3.tgz"
-  integrity sha512-3lSpxGgvnmZznmBkCRnVREPUFJv2wrv9iAoFDvADJc0ypmdOxdUtcLeBgBJ6zE0PMeTKnxeQzyk0xTBq4Ep7zw==
+"@babel/generator@^7.29.7", "@babel/generator@^7.29.8", "@babel/generator@^7.7.2":
+  version "7.29.8"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.29.8.tgz#4b0b887885422643339e09022148a4c4ebaa4979"
+  integrity sha512-gZbepsdh3WDtgZKWL+vTPh71LSBrm/Y4/QDZBVCcYfmeTEEuoOYwlSy+G1StfJg+/Zy550u/3TATbm7qDbbMtg==
   dependencies:
-    "@babel/parser" "^7.28.3"
-    "@babel/types" "^7.28.2"
+    "@babel/parser" "^7.29.8"
+    "@babel/types" "^7.29.8"
     "@jridgewell/gen-mapping" "^0.3.12"
     "@jridgewell/trace-mapping" "^0.3.28"
     jsesc "^3.0.2"
 
-"@babel/helper-annotate-as-pure@^7.27.1", "@babel/helper-annotate-as-pure@^7.27.3":
-  version "7.27.3"
-  resolved "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.27.3.tgz"
-  integrity sha512-fXSwMQqitTGeHLBC08Eq5yXz2m37E4pJX1qAU1+2cNedz/ifv/bVXft90VeSav5nFO61EcNgwr0aJxbyPaWBPg==
+"@babel/helper-annotate-as-pure@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.29.7.tgz#c70fe3c6ecbdc3fd2dd1b0f498428b88b82ce47f"
+  integrity sha512-OoK6239jHPuSQOoS0kfTVKn0b/rVTk0seKq4Gd2UMLtmOVLjDC0ki3e+c90Trqv2gMfvJFqkiljrr568+qddiw==
   dependencies:
-    "@babel/types" "^7.27.3"
+    "@babel/types" "^7.29.7"
 
-"@babel/helper-compilation-targets@^7.27.1", "@babel/helper-compilation-targets@^7.27.2":
-  version "7.27.2"
-  resolved "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.27.2.tgz"
-  integrity sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==
+"@babel/helper-compilation-targets@^7.28.6", "@babel/helper-compilation-targets@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz#7a1def704302401c47f64fa85589e974ae217042"
+  integrity sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==
   dependencies:
-    "@babel/compat-data" "^7.27.2"
-    "@babel/helper-validator-option" "^7.27.1"
+    "@babel/compat-data" "^7.29.7"
+    "@babel/helper-validator-option" "^7.29.7"
     browserslist "^4.24.0"
     lru-cache "^5.1.1"
     semver "^6.3.1"
 
-"@babel/helper-create-class-features-plugin@^7.27.1", "@babel/helper-create-class-features-plugin@^7.28.3":
-  version "7.28.3"
-  resolved "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.28.3.tgz"
-  integrity sha512-V9f6ZFIYSLNEbuGA/92uOvYsGCJNsuA8ESZ4ldc09bWk/j8H8TKiPw8Mk1eG6olpnO0ALHJmYfZvF4MEE4gajg==
+"@babel/helper-create-class-features-plugin@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.29.7.tgz#6eddf286f2ec418f740c91d60a83347c55838ddd"
+  integrity sha512-IY3ZD9Tmooqr3TUhc3DUWxiuo8xx1DWLhd5M7hQ+ZWJamqM2BbalrBJb2MisSLoYorOj75U03qULCxQTY9r3hg==
   dependencies:
-    "@babel/helper-annotate-as-pure" "^7.27.3"
-    "@babel/helper-member-expression-to-functions" "^7.27.1"
-    "@babel/helper-optimise-call-expression" "^7.27.1"
-    "@babel/helper-replace-supers" "^7.27.1"
-    "@babel/helper-skip-transparent-expression-wrappers" "^7.27.1"
-    "@babel/traverse" "^7.28.3"
+    "@babel/helper-annotate-as-pure" "^7.29.7"
+    "@babel/helper-member-expression-to-functions" "^7.29.7"
+    "@babel/helper-optimise-call-expression" "^7.29.7"
+    "@babel/helper-replace-supers" "^7.29.7"
+    "@babel/helper-skip-transparent-expression-wrappers" "^7.29.7"
+    "@babel/traverse" "^7.29.7"
     semver "^6.3.1"
 
-"@babel/helper-create-regexp-features-plugin@^7.18.6", "@babel/helper-create-regexp-features-plugin@^7.27.1":
-  version "7.27.1"
-  resolved "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.27.1.tgz"
-  integrity sha512-uVDC72XVf8UbrH5qQTc18Agb8emwjTiZrQE11Nv3CuBEZmVvTwwE9CBUEvHku06gQCAyYf8Nv6ja1IN+6LMbxQ==
+"@babel/helper-create-regexp-features-plugin@^7.18.6", "@babel/helper-create-regexp-features-plugin@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.29.7.tgz#5d4c3f928f315cf6c4184ea2fc3b5b38745b2430"
+  integrity sha512-907Uymvqgg1dwUA+7IGwFAOSYzQOuzPXKNJ1yxzwPffzkYFg2q2eHi1fIOs6sXkG9NbIUMunnUlkYsfRFNvomg==
   dependencies:
-    "@babel/helper-annotate-as-pure" "^7.27.1"
-    regexpu-core "^6.2.0"
+    "@babel/helper-annotate-as-pure" "^7.29.7"
+    regexpu-core "^6.3.1"
     semver "^6.3.1"
 
-"@babel/helper-define-polyfill-provider@^0.6.5":
-  version "0.6.5"
-  resolved "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.6.5.tgz"
-  integrity sha512-uJnGFcPsWQK8fvjgGP5LZUZZsYGIoPeRjSF5PGwrelYgq7Q15/Ft9NGFp1zglwgIv//W0uG4BevRuSJRyylZPg==
+"@babel/helper-define-polyfill-provider@^0.6.8":
+  version "0.6.8"
+  resolved "https://registry.yarnpkg.com/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.6.8.tgz#cf1e4462b613f2b54c41e6ff758d5dfcaa2c85d1"
+  integrity sha512-47UwBLPpQi1NoWzLuHNjRoHlYXMwIJoBf7MFou6viC/sIHWYygpvr0B6IAyh5sBdA2nr2LPIRww8lfaUVQINBA==
   dependencies:
-    "@babel/helper-compilation-targets" "^7.27.2"
-    "@babel/helper-plugin-utils" "^7.27.1"
-    debug "^4.4.1"
+    "@babel/helper-compilation-targets" "^7.28.6"
+    "@babel/helper-plugin-utils" "^7.28.6"
+    debug "^4.4.3"
     lodash.debounce "^4.0.8"
-    resolve "^1.22.10"
+    resolve "^1.22.11"
 
-"@babel/helper-globals@^7.28.0":
-  version "7.28.0"
-  resolved "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz"
-  integrity sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==
+"@babel/helper-globals@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-globals/-/helper-globals-7.29.7.tgz#f04a96fbd8473241b1079243f5b3f03a3010ab7b"
+  integrity sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==
 
-"@babel/helper-member-expression-to-functions@^7.27.1":
-  version "7.27.1"
-  resolved "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.27.1.tgz"
-  integrity sha512-E5chM8eWjTp/aNoVpcbfM7mLxu9XGLWYise2eBKGQomAk/Mb4XoxyqXTZbuTohbsl8EKqdlMhnDI2CCLfcs9wA==
+"@babel/helper-member-expression-to-functions@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.29.7.tgz#8dbdb3ce0b5c487e1aec10e13c9a43a500814df8"
+  integrity sha512-j+7JYmk1JYDtACIGj0QJqqWZjoUpMoEikQGADMaHgCMCSDqd2+P32rfcibUNrGOMWrlzK1WJBdxrB3JJQZwWtg==
   dependencies:
-    "@babel/traverse" "^7.27.1"
-    "@babel/types" "^7.27.1"
+    "@babel/traverse" "^7.29.7"
+    "@babel/types" "^7.29.7"
 
-"@babel/helper-module-imports@^7.18.6", "@babel/helper-module-imports@^7.27.1":
-  version "7.27.1"
-  resolved "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.27.1.tgz"
-  integrity sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==
+"@babel/helper-module-imports@^7.18.6", "@babel/helper-module-imports@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz#ef25048a518e828d7393fac5882ddd73921d7396"
+  integrity sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==
   dependencies:
-    "@babel/traverse" "^7.27.1"
-    "@babel/types" "^7.27.1"
+    "@babel/traverse" "^7.29.7"
+    "@babel/types" "^7.29.7"
 
-"@babel/helper-module-transforms@^7.27.1", "@babel/helper-module-transforms@^7.28.3":
-  version "7.28.3"
-  resolved "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.3.tgz"
-  integrity sha512-gytXUbs8k2sXS9PnQptz5o0QnpLL51SwASIORY6XaBKF88nsOT0Zw9szLqlSGQDP/4TljBAD5y98p2U1fqkdsw==
+"@babel/helper-module-transforms@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz#b062747a5997ba138637201328bbff77960574ae"
+  integrity sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==
   dependencies:
-    "@babel/helper-module-imports" "^7.27.1"
-    "@babel/helper-validator-identifier" "^7.27.1"
-    "@babel/traverse" "^7.28.3"
+    "@babel/helper-module-imports" "^7.29.7"
+    "@babel/helper-validator-identifier" "^7.29.7"
+    "@babel/traverse" "^7.29.7"
 
-"@babel/helper-optimise-call-expression@^7.27.1":
-  version "7.27.1"
-  resolved "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.27.1.tgz"
-  integrity sha512-URMGH08NzYFhubNSGJrpUEphGKQwMQYBySzat5cAByY1/YgIRkULnIy3tAMeszlL/so2HbeilYloUmSpd7GdVw==
+"@babel/helper-optimise-call-expression@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.29.7.tgz#77b0b5b94f1997fa9d6e3125f445227b1faf9d85"
+  integrity sha512-+kmGVjcT9RGYzoDwdwEqEvGgKe3BYq+O1iGzjFubaNgZHwYHP6lsF2Yghf4kEuv9BV7tYDZ913aBW9am6YKong==
   dependencies:
-    "@babel/types" "^7.27.1"
+    "@babel/types" "^7.29.7"
 
-"@babel/helper-plugin-utils@^7.0.0", "@babel/helper-plugin-utils@^7.10.4", "@babel/helper-plugin-utils@^7.12.13", "@babel/helper-plugin-utils@^7.14.5", "@babel/helper-plugin-utils@^7.18.6", "@babel/helper-plugin-utils@^7.27.1", "@babel/helper-plugin-utils@^7.8.0":
-  version "7.27.1"
-  resolved "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.27.1.tgz"
-  integrity sha512-1gn1Up5YXka3YYAHGKpbideQ5Yjf1tDa9qYcgysz+cNCXukyLl6DjPXhD3VRwSb8c0J9tA4b2+rHEZtc6R0tlw==
+"@babel/helper-plugin-utils@^7.0.0", "@babel/helper-plugin-utils@^7.10.4", "@babel/helper-plugin-utils@^7.12.13", "@babel/helper-plugin-utils@^7.14.5", "@babel/helper-plugin-utils@^7.18.6", "@babel/helper-plugin-utils@^7.28.6", "@babel/helper-plugin-utils@^7.29.7", "@babel/helper-plugin-utils@^7.8.0":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz#c0a0766f1a13617d8a17407d7ab8f9d486225ea4"
+  integrity sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==
 
-"@babel/helper-remap-async-to-generator@^7.27.1":
-  version "7.27.1"
-  resolved "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.27.1.tgz"
-  integrity sha512-7fiA521aVw8lSPeI4ZOD3vRFkoqkJcS+z4hFo82bFSH/2tNd6eJ5qCVMS5OzDmZh/kaHQeBaeyxK6wljcPtveA==
+"@babel/helper-remap-async-to-generator@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.29.7.tgz#34b1f68dd75b86d31df781a29c3ff2df88da82e6"
+  integrity sha512-16AMiW26DbXWBbr3B8wNozKM0ydMLB892vaOaJW/fPJdnT8vJk5sdkQcU/isqUxyCE0cEoa8wZOcbgDuC4b6Og==
   dependencies:
-    "@babel/helper-annotate-as-pure" "^7.27.1"
-    "@babel/helper-wrap-function" "^7.27.1"
-    "@babel/traverse" "^7.27.1"
+    "@babel/helper-annotate-as-pure" "^7.29.7"
+    "@babel/helper-wrap-function" "^7.29.7"
+    "@babel/traverse" "^7.29.7"
 
-"@babel/helper-replace-supers@^7.27.1":
-  version "7.27.1"
-  resolved "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.27.1.tgz"
-  integrity sha512-7EHz6qDZc8RYS5ElPoShMheWvEgERonFCs7IAonWLLUTXW59DP14bCZt89/GKyreYn8g3S83m21FelHKbeDCKA==
+"@babel/helper-replace-supers@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-replace-supers/-/helper-replace-supers-7.29.7.tgz#bc3c3964329043c79112e513c1b198f16589ac21"
+  integrity sha512-atfGXWSeCiF4DnKZIfmJfQRkSw9b9gNNXR1kqKjbhG4pGYCOnkp8OcTB8E3NXjBu8NpheSnOeNKz8KT7UNFTmQ==
   dependencies:
-    "@babel/helper-member-expression-to-functions" "^7.27.1"
-    "@babel/helper-optimise-call-expression" "^7.27.1"
-    "@babel/traverse" "^7.27.1"
+    "@babel/helper-member-expression-to-functions" "^7.29.7"
+    "@babel/helper-optimise-call-expression" "^7.29.7"
+    "@babel/traverse" "^7.29.7"
 
-"@babel/helper-skip-transparent-expression-wrappers@^7.27.1":
-  version "7.27.1"
-  resolved "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.27.1.tgz"
-  integrity sha512-Tub4ZKEXqbPjXgWLl2+3JpQAYBJ8+ikpQ2Ocj/q/r0LwE3UhENh7EUabyHjz2kCEsrRY83ew2DQdHluuiDQFzg==
+"@babel/helper-skip-transparent-expression-wrappers@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.29.7.tgz#50c95c7e4c4f54936cfa0116428edc559862d551"
+  integrity sha512-brcMGQaVzIeUb+6/bs1Av0f8YuNNjKY2JyvfRCsFuFsdKccEQ5Ges2y74D74NZ1Rz8lKJ9ksJkfqwQFJ/iNEyQ==
   dependencies:
-    "@babel/traverse" "^7.27.1"
-    "@babel/types" "^7.27.1"
+    "@babel/traverse" "^7.29.7"
+    "@babel/types" "^7.29.7"
 
 "@babel/helper-string-parser@^7.27.1":
   version "7.27.1"
   resolved "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz"
   integrity sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==
 
-"@babel/helper-validator-identifier@^7.27.1":
-  version "7.27.1"
-  resolved "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz"
-  integrity sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==
+"@babel/helper-string-parser@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz#7f0871d99824d23137d60f86fcf6130fd5a1b51f"
+  integrity sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==
 
 "@babel/helper-validator-identifier@^7.28.5":
   version "7.28.5"
   resolved "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz"
   integrity sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==
 
-"@babel/helper-validator-option@^7.27.1":
-  version "7.27.1"
-  resolved "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz"
-  integrity sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==
+"@babel/helper-validator-identifier@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz#bd87084ced0c796ec46bda492de6e83d29e89fc2"
+  integrity sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==
 
-"@babel/helper-wrap-function@^7.27.1":
-  version "7.28.3"
-  resolved "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.28.3.tgz"
-  integrity sha512-zdf983tNfLZFletc0RRXYrHrucBEg95NIFMkn6K9dbeMYnsgHaSBGcQqdsCSStG2PYwRre0Qc2NNSCXbG+xc6g==
-  dependencies:
-    "@babel/template" "^7.27.2"
-    "@babel/traverse" "^7.28.3"
-    "@babel/types" "^7.28.2"
+"@babel/helper-validator-option@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz#cf315be940213b354eb4abcc0bd01ebe3f73bc2a"
+  integrity sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==
 
-"@babel/helpers@^7.28.3":
-  version "7.28.3"
-  resolved "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.3.tgz"
-  integrity sha512-PTNtvUQihsAsDHMOP5pfobP8C6CM4JWXmP8DrEIt46c3r2bf87Ua1zoqevsMo9g+tWDwgWrFP5EIxuBx5RudAw==
+"@babel/helper-wrap-function@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-wrap-function/-/helper-wrap-function-7.29.7.tgz#eec72163044548a0935e9d182bf2d547ec5ff483"
+  integrity sha512-iES0Skag9ERIF68aXadpO6dbXa03mNWK3sEqJaMnLNs/eC3l0lkImdfoy6Y09/SfkpawdAB4RjQ7PVA7TcVGdw==
   dependencies:
-    "@babel/template" "^7.27.2"
-    "@babel/types" "^7.28.2"
+    "@babel/template" "^7.29.7"
+    "@babel/traverse" "^7.29.7"
+    "@babel/types" "^7.29.7"
+
+"@babel/helpers@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.29.7.tgz#45abfde7548997e34376c3e69feb475cffb4a607"
+  integrity sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==
+  dependencies:
+    "@babel/template" "^7.29.7"
+    "@babel/types" "^7.29.7"
 
 "@babel/node@^7.23.9":
-  version "7.28.0"
-  resolved "https://registry.npmjs.org/@babel/node/-/node-7.28.0.tgz"
-  integrity sha512-6u1Mmn3SIMUH8uwTq543L062X3JDgms9HPf06o/pIGdDjeD/zNQ+dfZPQD27sCyvtP0ZOlJtwnl2RIdPe9bHeQ==
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/node/-/node-7.29.7.tgz#5df05c3615606de6ce21e4a0e2856ae7db411466"
+  integrity sha512-nfdPXz8/mD3/t+1nE1DKwGR14Ccjt5xeF7u3g7sqWnLi4yR6n+9Z0kThIROF8SRM07ZKpEtiWSKpWKxsMiJeew==
   dependencies:
-    "@babel/register" "^7.27.1"
+    "@babel/register" "^7.29.7"
     commander "^6.2.0"
-    core-js "^3.30.2"
+    core-js "^3.48.0"
     node-environment-flags "^1.0.5"
     regenerator-runtime "^0.14.0"
     v8flags "^3.1.1"
 
-"@babel/parser@^7.1.0", "@babel/parser@^7.14.7", "@babel/parser@^7.20.7", "@babel/parser@^7.23.9", "@babel/parser@^7.27.2", "@babel/parser@^7.28.3", "@babel/parser@^7.7.0", "@babel/parser@^7.9.4":
-  version "7.28.3"
-  resolved "https://registry.npmjs.org/@babel/parser/-/parser-7.28.3.tgz"
-  integrity sha512-7+Ey1mAgYqFAx2h0RuoxcQT5+MlG3GTV0TQrgr7/ZliKsm/MNDxVVutlWaziMq7wJNAz8MTqz55XLpWvva6StA==
+"@babel/parser@^7.1.0", "@babel/parser@^7.14.7", "@babel/parser@^7.20.7", "@babel/parser@^7.23.9", "@babel/parser@^7.25.4", "@babel/parser@^7.29.7", "@babel/parser@^7.29.8", "@babel/parser@^7.7.0", "@babel/parser@^7.9.4":
+  version "7.29.8"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.29.8.tgz#9653716a2f10c677b98fbc63d4bfb000c302cf17"
+  integrity sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==
   dependencies:
-    "@babel/types" "^7.28.2"
+    "@babel/types" "^7.29.8"
 
-"@babel/parser@^7.25.4":
-  version "7.28.5"
-  resolved "https://registry.npmjs.org/@babel/parser/-/parser-7.28.5.tgz"
-  integrity sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ==
+"@babel/plugin-bugfix-firefox-class-in-computed-class-key@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-bugfix-firefox-class-in-computed-class-key/-/plugin-bugfix-firefox-class-in-computed-class-key-7.29.7.tgz#2b535896d933a85aa92377eaa3d51a437d54a4e3"
+  integrity sha512-j8SrR0zLZrRsC09DlszEx8FpMiwukKffYXMK0d5LmOglO7vGG6sz/BR/20yHqWH+Lnn31JTt2PE3hIWNgM2J6w==
   dependencies:
-    "@babel/types" "^7.28.5"
+    "@babel/helper-plugin-utils" "^7.29.7"
+    "@babel/traverse" "^7.29.7"
 
-"@babel/plugin-bugfix-firefox-class-in-computed-class-key@^7.27.1":
-  version "7.27.1"
-  resolved "https://registry.npmjs.org/@babel/plugin-bugfix-firefox-class-in-computed-class-key/-/plugin-bugfix-firefox-class-in-computed-class-key-7.27.1.tgz"
-  integrity sha512-QPG3C9cCVRQLxAVwmefEmwdTanECuUBMQZ/ym5kiw3XKCGA7qkuQLcjWWHcrD/GKbn/WmJwaezfuuAOcyKlRPA==
+"@babel/plugin-bugfix-safari-class-field-initializer-scope@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-bugfix-safari-class-field-initializer-scope/-/plugin-bugfix-safari-class-field-initializer-scope-7.29.7.tgz#b00711a9e52bf4fe55ef7e54b2ef4a881bf804c8"
+  integrity sha512-r8j8escF+U2FUHo0KOhPUdMzUO+jp9fInva6+ACVAF3Y97Ev+5iNZwiqTghmzNeWwDkOPlYuTcfb1vDaoZKmAQ==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.27.1"
-    "@babel/traverse" "^7.27.1"
+    "@babel/helper-plugin-utils" "^7.29.7"
 
-"@babel/plugin-bugfix-safari-class-field-initializer-scope@^7.27.1":
-  version "7.27.1"
-  resolved "https://registry.npmjs.org/@babel/plugin-bugfix-safari-class-field-initializer-scope/-/plugin-bugfix-safari-class-field-initializer-scope-7.27.1.tgz"
-  integrity sha512-qNeq3bCKnGgLkEXUuFry6dPlGfCdQNZbn7yUAPCInwAJHMU7THJfrBSozkcWq5sNM6RcF3S8XyQL2A52KNR9IA==
+"@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/-/plugin-bugfix-safari-id-destructuring-collision-in-function-expression-7.29.7.tgz#2375328852026a3cf6bc0bcf2de7d236f2d5e701"
+  integrity sha512-GE1TFSiuFeGsCxmYXZl8HwoPrVlwe4rHPFE8weieGKZqnDORK+Ar3vgWMgW+AOxQ6/2TgLSKx9p6W7O4rC6qgQ==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.27.1"
+    "@babel/helper-plugin-utils" "^7.29.7"
 
-"@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@^7.27.1":
-  version "7.27.1"
-  resolved "https://registry.npmjs.org/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/-/plugin-bugfix-safari-id-destructuring-collision-in-function-expression-7.27.1.tgz"
-  integrity sha512-g4L7OYun04N1WyqMNjldFwlfPCLVkgB54A/YCXICZYBsvJJE3kByKv9c9+R/nAfmIfjl2rKYLNyMHboYbZaWaA==
+"@babel/plugin-bugfix-safari-rest-destructuring-rhs-array@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-bugfix-safari-rest-destructuring-rhs-array/-/plugin-bugfix-safari-rest-destructuring-rhs-array-7.29.7.tgz#759a857c46c4d2a6199685cf71070d81ae5f743a"
+  integrity sha512-oBNVCvnO5tND+xSopWvV8WNGfpTfgP4Zr/YXXSj8zfmcPktp5Ku/aZlsIowgSD4fjmgHn6sGmB9APVsU5zOdhA==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.27.1"
+    "@babel/helper-plugin-utils" "^7.29.7"
+    "@babel/helper-skip-transparent-expression-wrappers" "^7.29.7"
 
-"@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@^7.27.1":
-  version "7.27.1"
-  resolved "https://registry.npmjs.org/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/-/plugin-bugfix-v8-spread-parameters-in-optional-chaining-7.27.1.tgz"
-  integrity sha512-oO02gcONcD5O1iTLi/6frMJBIwWEHceWGSGqrpCmEL8nogiS6J9PBlE48CaK20/Jx1LuRml9aDftLgdjXT8+Cw==
+"@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/-/plugin-bugfix-v8-spread-parameters-in-optional-chaining-7.29.7.tgz#86de98dd8e03836178231ea96c27dab26016a705"
+  integrity sha512-QQt9qKHZ2sg/kivaLr7lnQr8HVrQDdBNSfCsTjiDxRuX/K5ORyKq+Bu8Xr0cDE3Dfkv0cw28Ve0EKyKMvulkOw==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.27.1"
-    "@babel/helper-skip-transparent-expression-wrappers" "^7.27.1"
-    "@babel/plugin-transform-optional-chaining" "^7.27.1"
+    "@babel/helper-plugin-utils" "^7.29.7"
+    "@babel/helper-skip-transparent-expression-wrappers" "^7.29.7"
+    "@babel/plugin-transform-optional-chaining" "^7.29.7"
 
-"@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly@^7.28.3":
-  version "7.28.3"
-  resolved "https://registry.npmjs.org/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly/-/plugin-bugfix-v8-static-class-fields-redefine-readonly-7.28.3.tgz"
-  integrity sha512-b6YTX108evsvE4YgWyQ921ZAFFQm3Bn+CA3+ZXlNVnPhx+UfsVURoPjfGAPCjBgrqo30yX/C2nZGX96DxvR9Iw==
+"@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly/-/plugin-bugfix-v8-static-class-fields-redefine-readonly-7.29.7.tgz#f5d892681dbf4b08753436a5e55000d5ba728d6d"
+  integrity sha512-pn6QacGLgvCcwc+syUhKE/qSjV2D1IHDB84RNxWYSt1mW3K/SCtjinZ2p0cETJxAWBjPy3K/1lHwG5BjjPxNlw==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.27.1"
-    "@babel/traverse" "^7.28.3"
+    "@babel/helper-plugin-utils" "^7.29.7"
+    "@babel/traverse" "^7.29.7"
 
 "@babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.2":
   version "7.21.0-placeholder-for-preset-env.2"
@@ -373,19 +379,19 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.14.5"
 
-"@babel/plugin-syntax-import-assertions@^7.27.1":
-  version "7.27.1"
-  resolved "https://registry.npmjs.org/@babel/plugin-syntax-import-assertions/-/plugin-syntax-import-assertions-7.27.1.tgz"
-  integrity sha512-UT/Jrhw57xg4ILHLFnzFpPDlMbcdEicaAtjPQpbj9wa8T4r5KVWCimHcL/460g8Ht0DMxDyjsLgiWSkVjnwPFg==
+"@babel/plugin-syntax-import-assertions@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-import-assertions/-/plugin-syntax-import-assertions-7.29.7.tgz#c5cd868505269126cc18882e1f01f7b0e0e24b4e"
+  integrity sha512-/An1OCBN93thpBAGyfsK2pcf0jvju1SAtKkL2Ny++B5Sy6sqgzXDQH1cZxWbF96Wuk+bn41MDA9bLd4VVAw6rw==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.27.1"
+    "@babel/helper-plugin-utils" "^7.29.7"
 
-"@babel/plugin-syntax-import-attributes@^7.24.7", "@babel/plugin-syntax-import-attributes@^7.25.6", "@babel/plugin-syntax-import-attributes@^7.27.1":
-  version "7.27.1"
-  resolved "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.27.1.tgz"
-  integrity sha512-oFT0FrKHgF53f4vOsZGi2Hh3I35PfSmVs4IBFLFj4dnafP+hIWDLg3VyKmUHfLoLHlyxY4C7DGtmHuJgn+IGww==
+"@babel/plugin-syntax-import-attributes@^7.24.7", "@babel/plugin-syntax-import-attributes@^7.25.6", "@babel/plugin-syntax-import-attributes@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.29.7.tgz#6115264516e95ead0f35a41710906612e447f605"
+  integrity sha512-zGYcYfq/WmZ4V+kBIXQon9dSSc8ircGZqw9ZaNhhGj9nZkeBu1jHLBDQqYYi5WA9uawvA2sIMbry2nCFhf5Djg==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.27.1"
+    "@babel/helper-plugin-utils" "^7.29.7"
 
 "@babel/plugin-syntax-import-meta@^7.10.4":
   version "7.10.4"
@@ -402,11 +408,11 @@
     "@babel/helper-plugin-utils" "^7.8.0"
 
 "@babel/plugin-syntax-jsx@^7.7.2":
-  version "7.27.1"
-  resolved "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.27.1.tgz"
-  integrity sha512-y8YTNIeKoyhGd9O0Jiyzyyqk8gdjnumGTQPsz0xOZOQ2RmkVJeZ1vmmfIvFEKqucBG6axJGBZDE/7iI5suUI/w==
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.29.7.tgz#622c16f9ad63782fe6e83dadc7e40330744b7f1e"
+  integrity sha512-TSu8+mHCoEaaCDEZ0I3+6mvTBYR4PCxQwf2z9/r5Tbztv6NaLR3B9thGTTxX2WGuGHJqRiAbKPeGTJ5XWXVg6A==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.27.1"
+    "@babel/helper-plugin-utils" "^7.29.7"
 
 "@babel/plugin-syntax-logical-assignment-operators@^7.10.4":
   version "7.10.4"
@@ -465,11 +471,11 @@
     "@babel/helper-plugin-utils" "^7.14.5"
 
 "@babel/plugin-syntax-typescript@^7.7.2":
-  version "7.27.1"
-  resolved "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.27.1.tgz"
-  integrity sha512-xfYCBMxveHrRMnAWl1ZlPXOZjzkN82THFvLhQhFXFt81Z5HnN+EtUkZhv/zcKpmT3fzmWZB0ywiBrbC3vogbwQ==
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.29.7.tgz#7c29388932313ed58413a0343048d75d92fb5b24"
+  integrity sha512-ngr+82Sh0xMz25TPCZi+nC2iTzjfCdWS2ONXTp/PtSCHCgaCNBpdMqgvJ2ccdLlClVZ7sisIgB914j/JFe+RZA==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.27.1"
+    "@babel/helper-plugin-utils" "^7.29.7"
 
 "@babel/plugin-syntax-unicode-sets-regex@^7.18.6":
   version "7.18.6"
@@ -479,477 +485,478 @@
     "@babel/helper-create-regexp-features-plugin" "^7.18.6"
     "@babel/helper-plugin-utils" "^7.18.6"
 
-"@babel/plugin-transform-arrow-functions@^7.27.1":
-  version "7.27.1"
-  resolved "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.27.1.tgz"
-  integrity sha512-8Z4TGic6xW70FKThA5HYEKKyBpOOsucTOD1DjU3fZxDg+K3zBJcXMFnt/4yQiZnf5+MiOMSXQ9PaEK/Ilh1DeA==
+"@babel/plugin-transform-arrow-functions@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.29.7.tgz#d651343f562c03f47951bd1802195d0e10605f27"
+  integrity sha512-N7zArUXWzAMzm+/N0uPBeVB3Fam5lMxtUwMmDK5f/IBBS7a7p1qeUoxd/6CckXoxUdgsntq1Dh8xNW06maZbDQ==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.27.1"
+    "@babel/helper-plugin-utils" "^7.29.7"
 
-"@babel/plugin-transform-async-generator-functions@^7.28.0":
-  version "7.28.0"
-  resolved "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.28.0.tgz"
-  integrity sha512-BEOdvX4+M765icNPZeidyADIvQ1m1gmunXufXxvRESy/jNNyfovIqUyE7MVgGBjWktCoJlzvFA1To2O4ymIO3Q==
+"@babel/plugin-transform-async-generator-functions@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.29.7.tgz#a5365617921d82a1fee33124a1102bb38a1e677d"
+  integrity sha512-d98gXZkgswvkyohMBABkhm3GeXhYj8psWfwQ2C7gtfrKGTykQa/iOIi+JJhwMjPlZ6Vm2XN+DCf3Es1EoG4ZLA==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.27.1"
-    "@babel/helper-remap-async-to-generator" "^7.27.1"
-    "@babel/traverse" "^7.28.0"
+    "@babel/helper-plugin-utils" "^7.29.7"
+    "@babel/helper-remap-async-to-generator" "^7.29.7"
+    "@babel/traverse" "^7.29.7"
 
-"@babel/plugin-transform-async-to-generator@^7.27.1":
-  version "7.27.1"
-  resolved "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.27.1.tgz"
-  integrity sha512-NREkZsZVJS4xmTr8qzE5y8AfIPqsdQfRuUiLRTEzb7Qii8iFWCyDKaUV2c0rCuh4ljDZ98ALHP/PetiBV2nddA==
+"@babel/plugin-transform-async-to-generator@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.29.7.tgz#3b5e8f1fb58133cf701bcf0baaf6f01bfd1a8889"
+  integrity sha512-pcUb2SS+RMo9TWVBwKGI5ShtoG7R+zBsFmCKDa6fe8c+hPr3XJlZgoE5j6i8W7gDjhyvy+85vmYexanvXh3d1w==
   dependencies:
-    "@babel/helper-module-imports" "^7.27.1"
-    "@babel/helper-plugin-utils" "^7.27.1"
-    "@babel/helper-remap-async-to-generator" "^7.27.1"
+    "@babel/helper-module-imports" "^7.29.7"
+    "@babel/helper-plugin-utils" "^7.29.7"
+    "@babel/helper-remap-async-to-generator" "^7.29.7"
 
-"@babel/plugin-transform-block-scoped-functions@^7.27.1":
-  version "7.27.1"
-  resolved "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.27.1.tgz"
-  integrity sha512-cnqkuOtZLapWYZUYM5rVIdv1nXYuFVIltZ6ZJ7nIj585QsjKM5dhL2Fu/lICXZ1OyIAFc7Qy+bvDAtTXqGrlhg==
+"@babel/plugin-transform-block-scoped-functions@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.29.7.tgz#96d292634434082d6687bcdb81139affedf77e8c"
+  integrity sha512-cUSmjh72N+rN4PrkFlN1dJwNCwjVp5d38/CQrEsFggkD10UiFlBFgdH3tv5dNsLuHY+3S8db2xCHjhZcv5WgvA==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.27.1"
+    "@babel/helper-plugin-utils" "^7.29.7"
 
-"@babel/plugin-transform-block-scoping@^7.28.0":
-  version "7.28.0"
-  resolved "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.28.0.tgz"
-  integrity sha512-gKKnwjpdx5sER/wl0WN0efUBFzF/56YZO0RJrSYP4CljXnP31ByY7fol89AzomdlLNzI36AvOTmYHsnZTCkq8Q==
+"@babel/plugin-transform-block-scoping@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.29.7.tgz#baa376691ae16244cd14335422fca6900f54e17d"
+  integrity sha512-ONyr4+AZhKh8yKWInVxU9AXA9EbsyeLcL6V0dJy6M2/62vuvpGm29zzuymbTpdc451GEpDIdAyPLP3r+P61yKQ==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.27.1"
+    "@babel/helper-plugin-utils" "^7.29.7"
 
-"@babel/plugin-transform-class-properties@^7.27.1":
-  version "7.27.1"
-  resolved "https://registry.npmjs.org/@babel/plugin-transform-class-properties/-/plugin-transform-class-properties-7.27.1.tgz"
-  integrity sha512-D0VcalChDMtuRvJIu3U/fwWjf8ZMykz5iZsg77Nuj821vCKI3zCyRLwRdWbsuJ/uRwZhZ002QtCqIkwC/ZkvbA==
+"@babel/plugin-transform-class-properties@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-class-properties/-/plugin-transform-class-properties-7.29.7.tgz#034897b8a21beec163332fac2de235b14409abdf"
+  integrity sha512-GtcpjFvanPfzNQi3eTitsCqtRRmmqzpy/A+yhTR1HaZo1Ly3EA8ZXxlPyHdR8/IuRMYc3E4wdGBewB2QKQjAaA==
   dependencies:
-    "@babel/helper-create-class-features-plugin" "^7.27.1"
-    "@babel/helper-plugin-utils" "^7.27.1"
+    "@babel/helper-create-class-features-plugin" "^7.29.7"
+    "@babel/helper-plugin-utils" "^7.29.7"
 
-"@babel/plugin-transform-class-static-block@^7.28.3":
-  version "7.28.3"
-  resolved "https://registry.npmjs.org/@babel/plugin-transform-class-static-block/-/plugin-transform-class-static-block-7.28.3.tgz"
-  integrity sha512-LtPXlBbRoc4Njl/oh1CeD/3jC+atytbnf/UqLoqTDcEYGUPj022+rvfkbDYieUrSj3CaV4yHDByPE+T2HwfsJg==
+"@babel/plugin-transform-class-static-block@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-class-static-block/-/plugin-transform-class-static-block-7.29.7.tgz#fed8efd19f3dd3e1114ee390707c70912778fd7c"
+  integrity sha512-kibJgmEdX2iMwsHY2tSZNDgj8PwIlCQz7FK9KuGKO8zsuoUwSEhoNnNVp/emKWrbY4HeO6kkXfdMqRKKKXBm2A==
   dependencies:
-    "@babel/helper-create-class-features-plugin" "^7.28.3"
-    "@babel/helper-plugin-utils" "^7.27.1"
+    "@babel/helper-create-class-features-plugin" "^7.29.7"
+    "@babel/helper-plugin-utils" "^7.29.7"
 
-"@babel/plugin-transform-classes@^7.28.3":
-  version "7.28.3"
-  resolved "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.28.3.tgz"
-  integrity sha512-DoEWC5SuxuARF2KdKmGUq3ghfPMO6ZzR12Dnp5gubwbeWJo4dbNWXJPVlwvh4Zlq6Z7YVvL8VFxeSOJgjsx4Sg==
+"@babel/plugin-transform-classes@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-classes/-/plugin-transform-classes-7.29.7.tgz#61d3e5aaae0c838acc3204d9db7c8dc05c25815b"
+  integrity sha512-qV0OGGBVacduzQHE649JyCneOFI/maT+YKsO+K4Yi3xv2wTPNjM/W2o2gdzMwEAZz7fXNTHAe0NcSg30bIN69g==
   dependencies:
-    "@babel/helper-annotate-as-pure" "^7.27.3"
-    "@babel/helper-compilation-targets" "^7.27.2"
-    "@babel/helper-globals" "^7.28.0"
-    "@babel/helper-plugin-utils" "^7.27.1"
-    "@babel/helper-replace-supers" "^7.27.1"
-    "@babel/traverse" "^7.28.3"
+    "@babel/helper-annotate-as-pure" "^7.29.7"
+    "@babel/helper-compilation-targets" "^7.29.7"
+    "@babel/helper-globals" "^7.29.7"
+    "@babel/helper-plugin-utils" "^7.29.7"
+    "@babel/helper-replace-supers" "^7.29.7"
+    "@babel/traverse" "^7.29.7"
 
-"@babel/plugin-transform-computed-properties@^7.27.1":
-  version "7.27.1"
-  resolved "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.27.1.tgz"
-  integrity sha512-lj9PGWvMTVksbWiDT2tW68zGS/cyo4AkZ/QTp0sQT0mjPopCmrSkzxeXkznjqBxzDI6TclZhOJbBmbBLjuOZUw==
+"@babel/plugin-transform-computed-properties@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.29.7.tgz#95028787ca31901b9a20b5c6d9605c32346f55ad"
+  integrity sha512-RK7/IyU5phpuCdBAuig5VkzG/EnbDaui5SQGdU9BFrHdV+mV4cUjLMQ9lJDjLNtWHsqtiefpGZUXQP2BiTYMsA==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.27.1"
-    "@babel/template" "^7.27.1"
+    "@babel/helper-plugin-utils" "^7.29.7"
+    "@babel/template" "^7.29.7"
 
-"@babel/plugin-transform-destructuring@^7.28.0":
-  version "7.28.0"
-  resolved "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.28.0.tgz"
-  integrity sha512-v1nrSMBiKcodhsyJ4Gf+Z0U/yawmJDBOTpEB3mcQY52r9RIyPneGyAS/yM6seP/8I+mWI3elOMtT5dB8GJVs+A==
+"@babel/plugin-transform-destructuring@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.29.7.tgz#5781ec6947852e27b64c1165f0db431f408090e4"
+  integrity sha512-iPX8aD6H9zV5s7ZsqTdNocPN/MGQ5sSMnElKrktxjJRMnB2jN/1p2+R7GkfD6CAYoVFqy5A4XnSIUeGgJzIWpg==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.27.1"
-    "@babel/traverse" "^7.28.0"
+    "@babel/helper-plugin-utils" "^7.29.7"
+    "@babel/traverse" "^7.29.7"
 
-"@babel/plugin-transform-dotall-regex@^7.27.1":
-  version "7.27.1"
-  resolved "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.27.1.tgz"
-  integrity sha512-gEbkDVGRvjj7+T1ivxrfgygpT7GUd4vmODtYpbs0gZATdkX8/iSnOtZSxiZnsgm1YjTgjI6VKBGSJJevkrclzw==
+"@babel/plugin-transform-dotall-regex@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.29.7.tgz#b203de9740e4c7ff6b55ce436ed5313b88d70af8"
+  integrity sha512-3qc18hsD2RdZiyJNDNc7HQpv6xbncwh8FYtxNFFzclSyh/trPD9KkVR9BDECUjDLvb7yJVF15GfYUuC+LMkkiQ==
   dependencies:
-    "@babel/helper-create-regexp-features-plugin" "^7.27.1"
-    "@babel/helper-plugin-utils" "^7.27.1"
+    "@babel/helper-create-regexp-features-plugin" "^7.29.7"
+    "@babel/helper-plugin-utils" "^7.29.7"
 
-"@babel/plugin-transform-duplicate-keys@^7.27.1":
-  version "7.27.1"
-  resolved "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.27.1.tgz"
-  integrity sha512-MTyJk98sHvSs+cvZ4nOauwTTG1JeonDjSGvGGUNHreGQns+Mpt6WX/dVzWBHgg+dYZhkC4X+zTDfkTU+Vy9y7Q==
+"@babel/plugin-transform-duplicate-keys@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.29.7.tgz#8f3fe721835cb7a433420841dae90afc962ea7ae"
+  integrity sha512-6IvRRriEMqnBwD6chtxdLpMYCHWEzN+oL5cyQtjykya19UgzbmKhxmhZgKC/LHxS2nYr9Q/qYPZ5Lr6jOL9+yQ==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.27.1"
+    "@babel/helper-plugin-utils" "^7.29.7"
 
-"@babel/plugin-transform-duplicate-named-capturing-groups-regex@^7.27.1":
-  version "7.27.1"
-  resolved "https://registry.npmjs.org/@babel/plugin-transform-duplicate-named-capturing-groups-regex/-/plugin-transform-duplicate-named-capturing-groups-regex-7.27.1.tgz"
-  integrity sha512-hkGcueTEzuhB30B3eJCbCYeCaaEQOmQR0AdvzpD4LoN0GXMWzzGSuRrxR2xTnCrvNbVwK9N6/jQ92GSLfiZWoQ==
+"@babel/plugin-transform-duplicate-named-capturing-groups-regex@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-duplicate-named-capturing-groups-regex/-/plugin-transform-duplicate-named-capturing-groups-regex-7.29.7.tgz#dc6c405e55c01b7657e1827a25332c4ac17e9cac"
+  integrity sha512-2wiIyo2BjtgU7HufSeDnL9L2O7zr8jmhFKuSr65VpRkUiRKRNpb0mdlk56+XPPKoIrfHqzbMuglDvZun0RISsA==
   dependencies:
-    "@babel/helper-create-regexp-features-plugin" "^7.27.1"
-    "@babel/helper-plugin-utils" "^7.27.1"
+    "@babel/helper-create-regexp-features-plugin" "^7.29.7"
+    "@babel/helper-plugin-utils" "^7.29.7"
 
-"@babel/plugin-transform-dynamic-import@^7.27.1":
-  version "7.27.1"
-  resolved "https://registry.npmjs.org/@babel/plugin-transform-dynamic-import/-/plugin-transform-dynamic-import-7.27.1.tgz"
-  integrity sha512-MHzkWQcEmjzzVW9j2q8LGjwGWpG2mjwaaB0BNQwst3FIjqsg8Ct/mIZlvSPJvfi9y2AC8mi/ktxbFVL9pZ1I4A==
+"@babel/plugin-transform-dynamic-import@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-dynamic-import/-/plugin-transform-dynamic-import-7.29.7.tgz#a83a6faec5bab5b619adf9d0eac6c1c270123c2a"
+  integrity sha512-giOlEm/EFjfjr+te9NsdjkUo2v4f8rS/SXPumRVHAtbNcyNlvtREkU1dZzaIDclNpnaVhlCqRdFKhJBjBikzLg==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.27.1"
+    "@babel/helper-plugin-utils" "^7.29.7"
 
-"@babel/plugin-transform-explicit-resource-management@^7.28.0":
-  version "7.28.0"
-  resolved "https://registry.npmjs.org/@babel/plugin-transform-explicit-resource-management/-/plugin-transform-explicit-resource-management-7.28.0.tgz"
-  integrity sha512-K8nhUcn3f6iB+P3gwCv/no7OdzOZQcKchW6N389V6PD8NUWKZHzndOd9sPDVbMoBsbmjMqlB4L9fm+fEFNVlwQ==
+"@babel/plugin-transform-explicit-resource-management@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-explicit-resource-management/-/plugin-transform-explicit-resource-management-7.29.7.tgz#65c8b9f76ec915b02a0e1df703125a0fca58abaa"
+  integrity sha512-Rstj7coNz8sE+7Ju7ihpHLI564lsK5pUpNNlvptCIC/16E/S5hbl6n3kESPKdNRmqEWlpn5xpS5Q2dvXBsySLw==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.27.1"
-    "@babel/plugin-transform-destructuring" "^7.28.0"
+    "@babel/helper-plugin-utils" "^7.29.7"
+    "@babel/plugin-transform-destructuring" "^7.29.7"
 
-"@babel/plugin-transform-exponentiation-operator@^7.27.1":
-  version "7.27.1"
-  resolved "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.27.1.tgz"
-  integrity sha512-uspvXnhHvGKf2r4VVtBpeFnuDWsJLQ6MF6lGJLC89jBR1uoVeqM416AZtTuhTezOfgHicpJQmoD5YUakO/YmXQ==
+"@babel/plugin-transform-exponentiation-operator@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.29.7.tgz#00bf002fde8794356171f5d4df200f6bc0d5a303"
+  integrity sha512-zFpMOTLZBdW5LfObqcSbL6kefg4R4eLdmvS0wbN9M6D5Mym/sKm9toOoWyVOa+xDjvCnuWcHls2YonXwHvH3CQ==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.27.1"
+    "@babel/helper-plugin-utils" "^7.29.7"
 
-"@babel/plugin-transform-export-namespace-from@^7.27.1":
-  version "7.27.1"
-  resolved "https://registry.npmjs.org/@babel/plugin-transform-export-namespace-from/-/plugin-transform-export-namespace-from-7.27.1.tgz"
-  integrity sha512-tQvHWSZ3/jH2xuq/vZDy0jNn+ZdXJeM8gHvX4lnJmsc3+50yPlWdZXIc5ay+umX+2/tJIqHqiEqcJvxlmIvRvQ==
+"@babel/plugin-transform-export-namespace-from@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-export-namespace-from/-/plugin-transform-export-namespace-from-7.29.7.tgz#d6014f45cec61d7691335c6c9804204bee801d51"
+  integrity sha512-24B2nOy2TeJSMheqwPD4DDQOV/elLSIlKxjZt4i05H5AgdPdWR3n18HnNrcJ+j76WJd9gbwb9jPjNYUy6RautA==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.27.1"
+    "@babel/helper-plugin-utils" "^7.29.7"
 
-"@babel/plugin-transform-for-of@^7.27.1":
-  version "7.27.1"
-  resolved "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.27.1.tgz"
-  integrity sha512-BfbWFFEJFQzLCQ5N8VocnCtA8J1CLkNTe2Ms2wocj75dd6VpiqS5Z5quTYcUoo4Yq+DN0rtikODccuv7RU81sw==
+"@babel/plugin-transform-for-of@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.29.7.tgz#c65a678592117717aacdb10c1b73a9cb85e830be"
+  integrity sha512-zeSIHh0+E1Um1WJRXCFlHQYu2ieJNdivLLjlBEp+dIBu3S51n+SZZmIXjxnItw6pz56Cn+KvK68BIBVsxq2JiQ==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.27.1"
-    "@babel/helper-skip-transparent-expression-wrappers" "^7.27.1"
+    "@babel/helper-plugin-utils" "^7.29.7"
+    "@babel/helper-skip-transparent-expression-wrappers" "^7.29.7"
 
-"@babel/plugin-transform-function-name@^7.27.1":
-  version "7.27.1"
-  resolved "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.27.1.tgz"
-  integrity sha512-1bQeydJF9Nr1eBCMMbC+hdwmRlsv5XYOMu03YSWFwNs0HsAmtSxxF1fyuYPqemVldVyFmlCU7w8UE14LupUSZQ==
+"@babel/plugin-transform-function-name@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.29.7.tgz#8b87f8a7504dbcd96135167e3fc4f61126a7bd86"
+  integrity sha512-otRWaHXE6fbAGkePvaj/kvs3HsqXfPhlnzwSOlnFgbqCPMd975dW+4wZ00WFBt+/YlBGcJwNrARQTOJOb4ZrIg==
   dependencies:
-    "@babel/helper-compilation-targets" "^7.27.1"
-    "@babel/helper-plugin-utils" "^7.27.1"
-    "@babel/traverse" "^7.27.1"
+    "@babel/helper-compilation-targets" "^7.29.7"
+    "@babel/helper-plugin-utils" "^7.29.7"
+    "@babel/traverse" "^7.29.7"
 
-"@babel/plugin-transform-json-strings@^7.27.1":
-  version "7.27.1"
-  resolved "https://registry.npmjs.org/@babel/plugin-transform-json-strings/-/plugin-transform-json-strings-7.27.1.tgz"
-  integrity sha512-6WVLVJiTjqcQauBhn1LkICsR2H+zm62I3h9faTDKt1qP4jn2o72tSvqMwtGFKGTpojce0gJs+76eZ2uCHRZh0Q==
+"@babel/plugin-transform-json-strings@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-json-strings/-/plugin-transform-json-strings-7.29.7.tgz#f57d63dcc05b4481c281acedcd8fc4e3e439a1d4"
+  integrity sha512-RRnE2+eon1rJAq8MnoF1b5kTpY1vU88twHcvcKMrsqP/jxIRqDVs9iJB5fqPuqyeFAW0wJo4MlUIPpQCq/aRsg==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.27.1"
+    "@babel/helper-plugin-utils" "^7.29.7"
 
-"@babel/plugin-transform-literals@^7.27.1":
-  version "7.27.1"
-  resolved "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.27.1.tgz"
-  integrity sha512-0HCFSepIpLTkLcsi86GG3mTUzxV5jpmbv97hTETW3yzrAij8aqlD36toB1D0daVFJM8NK6GvKO0gslVQmm+zZA==
+"@babel/plugin-transform-literals@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-literals/-/plugin-transform-literals-7.29.7.tgz#b90bd47463326c2a9d779e1bd5e1f88b9f421921"
+  integrity sha512-DZ/oLP21ZuWx1vKqnoNv6/tvEK48AQOBRai40CX9dTjGluvT/YZCyY3rryDtyUqCEoyNroy5KKPwX2iQCiRvyw==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.27.1"
+    "@babel/helper-plugin-utils" "^7.29.7"
 
-"@babel/plugin-transform-logical-assignment-operators@^7.27.1":
-  version "7.27.1"
-  resolved "https://registry.npmjs.org/@babel/plugin-transform-logical-assignment-operators/-/plugin-transform-logical-assignment-operators-7.27.1.tgz"
-  integrity sha512-SJvDs5dXxiae4FbSL1aBJlG4wvl594N6YEVVn9e3JGulwioy6z3oPjx/sQBO3Y4NwUu5HNix6KJ3wBZoewcdbw==
+"@babel/plugin-transform-logical-assignment-operators@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-logical-assignment-operators/-/plugin-transform-logical-assignment-operators-7.29.7.tgz#9b29425adf5c794967aabe4b046a046a167bac2f"
+  integrity sha512-A0H91hh6W8MFRkp5TqJmMr39jzGD1A1E1Ysiv2O06Sfbhkapm+XyIzxWCEh5kqwOZ1/8QZ0dY3SeQ7XBqfJd5Q==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.27.1"
+    "@babel/helper-plugin-utils" "^7.29.7"
 
-"@babel/plugin-transform-member-expression-literals@^7.27.1":
-  version "7.27.1"
-  resolved "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.27.1.tgz"
-  integrity sha512-hqoBX4dcZ1I33jCSWcXrP+1Ku7kdqXf1oeah7ooKOIiAdKQ+uqftgCFNOSzA5AMS2XIHEYeGFg4cKRCdpxzVOQ==
+"@babel/plugin-transform-member-expression-literals@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.29.7.tgz#1281689fa2fefc17b110d21ebafd0fe9402d5309"
+  integrity sha512-hl1kwFZCCiDyfH25Xmco9jTrkPgnS9pmOzSG7W5I4SaGbLeqKv417hcU2RKmaxoPEgsoJh7ZPOrnPGq99bHoUg==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.27.1"
+    "@babel/helper-plugin-utils" "^7.29.7"
 
-"@babel/plugin-transform-modules-amd@^7.27.1":
-  version "7.27.1"
-  resolved "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.27.1.tgz"
-  integrity sha512-iCsytMg/N9/oFq6n+gFTvUYDZQOMK5kEdeYxmxt91fcJGycfxVP9CnrxoliM0oumFERba2i8ZtwRUCMhvP1LnA==
+"@babel/plugin-transform-modules-amd@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.29.7.tgz#f05ca662c8a1dc4be2f337af9c7e80369c942d6c"
+  integrity sha512-fxtQoH3m5ywUSIfaH0FGCzWu4McsYon5bD3K4XnskC7f+OyQMj7rsOMi4NvvmJ83WwBAg4UCe+ov4VZlqEvyew==
   dependencies:
-    "@babel/helper-module-transforms" "^7.27.1"
-    "@babel/helper-plugin-utils" "^7.27.1"
+    "@babel/helper-module-transforms" "^7.29.7"
+    "@babel/helper-plugin-utils" "^7.29.7"
 
-"@babel/plugin-transform-modules-commonjs@^7.24.1", "@babel/plugin-transform-modules-commonjs@^7.27.1":
-  version "7.27.1"
-  resolved "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.27.1.tgz"
-  integrity sha512-OJguuwlTYlN0gBZFRPqwOGNWssZjfIUdS7HMYtN8c1KmwpwHFBwTeFZrg9XZa+DFTitWOW5iTAG7tyCUPsCCyw==
+"@babel/plugin-transform-modules-commonjs@^7.24.1", "@babel/plugin-transform-modules-commonjs@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.29.7.tgz#70e6835abf2663dafbe94b8ef1f51de7351ef135"
+  integrity sha512-j0vCldybPC5b5dwCQOJ21uKtHzt7hxLygJTg9eF1ScfaikEDNfzn94XoW5Fi+seBR0nCyL23xaBFFkq7dTM8XQ==
   dependencies:
-    "@babel/helper-module-transforms" "^7.27.1"
-    "@babel/helper-plugin-utils" "^7.27.1"
+    "@babel/helper-module-transforms" "^7.29.7"
+    "@babel/helper-plugin-utils" "^7.29.7"
 
-"@babel/plugin-transform-modules-systemjs@^7.27.1":
-  version "7.27.1"
-  resolved "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.27.1.tgz"
-  integrity sha512-w5N1XzsRbc0PQStASMksmUeqECuzKuTJer7kFagK8AXgpCMkeDMO5S+aaFb7A51ZYDF7XI34qsTX+fkHiIm5yA==
+"@babel/plugin-transform-modules-systemjs@^7.29.7":
+  version "7.29.8"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.29.8.tgz#e60a6a42ac63a3095f9cc7264f698a100c8fe05d"
+  integrity sha512-6iSnEK0zlkLKU4heofK/AdmRD4e2SHVpJMtrwnTCzhnaM98ria4rTrOXBBi45BTTYnJtO8txnPsX4fChYXkmeA==
   dependencies:
-    "@babel/helper-module-transforms" "^7.27.1"
-    "@babel/helper-plugin-utils" "^7.27.1"
-    "@babel/helper-validator-identifier" "^7.27.1"
-    "@babel/traverse" "^7.27.1"
+    "@babel/helper-module-transforms" "^7.29.7"
+    "@babel/helper-plugin-utils" "^7.29.7"
+    "@babel/helper-validator-identifier" "^7.29.7"
+    "@babel/traverse" "^7.29.8"
 
-"@babel/plugin-transform-modules-umd@^7.27.1":
-  version "7.27.1"
-  resolved "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.27.1.tgz"
-  integrity sha512-iQBE/xC5BV1OxJbp6WG7jq9IWiD+xxlZhLrdwpPkTX3ydmXdvoCpyfJN7acaIBZaOqTfr76pgzqBJflNbeRK+w==
+"@babel/plugin-transform-modules-umd@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.29.7.tgz#391d1c0215aca6307257f2f608598dfe55feb6cf"
+  integrity sha512-B4UkaTK3QpgCwJnrxKfMPKdo92CN7OKXAlpAAnM3UPu0Q0lCCk57ylA9AJbRy2v8dDKOPAAWcoR6CMyeoHwRCA==
   dependencies:
-    "@babel/helper-module-transforms" "^7.27.1"
-    "@babel/helper-plugin-utils" "^7.27.1"
+    "@babel/helper-module-transforms" "^7.29.7"
+    "@babel/helper-plugin-utils" "^7.29.7"
 
-"@babel/plugin-transform-named-capturing-groups-regex@^7.27.1":
-  version "7.27.1"
-  resolved "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.27.1.tgz"
-  integrity sha512-SstR5JYy8ddZvD6MhV0tM/j16Qds4mIpJTOd1Yu9J9pJjH93bxHECF7pgtc28XvkzTD6Pxcm/0Z73Hvk7kb3Ng==
+"@babel/plugin-transform-named-capturing-groups-regex@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.29.7.tgz#21e75d847b31189842fa7a77703722ed4b43d27d"
+  integrity sha512-vuFoLwr4qnv2xbZ16SQd6uPcH5FNrLHhk/Jzo++0XJFcaDsr4gjJVg6j398oMHiC+83k/GiBzviwF5KBJkPUtQ==
   dependencies:
-    "@babel/helper-create-regexp-features-plugin" "^7.27.1"
-    "@babel/helper-plugin-utils" "^7.27.1"
+    "@babel/helper-create-regexp-features-plugin" "^7.29.7"
+    "@babel/helper-plugin-utils" "^7.29.7"
 
-"@babel/plugin-transform-new-target@^7.27.1":
-  version "7.27.1"
-  resolved "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.27.1.tgz"
-  integrity sha512-f6PiYeqXQ05lYq3TIfIDu/MtliKUbNwkGApPUvyo6+tc7uaR4cPjPe7DFPr15Uyycg2lZU6btZ575CuQoYh7MQ==
+"@babel/plugin-transform-new-target@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.29.7.tgz#714147ce7947e1b49cbd84137ca2e75e92b2a067"
+  integrity sha512-fEo41GmsOUhOBlw8ioo6zvjX5Xc2Lqkzlyfqbpsk3eB6TReV18uhxZ0esfEokVbY2+PVJAQHNKxER6lGrzNd3A==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.27.1"
+    "@babel/helper-plugin-utils" "^7.29.7"
 
-"@babel/plugin-transform-nullish-coalescing-operator@^7.27.1":
-  version "7.27.1"
-  resolved "https://registry.npmjs.org/@babel/plugin-transform-nullish-coalescing-operator/-/plugin-transform-nullish-coalescing-operator-7.27.1.tgz"
-  integrity sha512-aGZh6xMo6q9vq1JGcw58lZ1Z0+i0xB2x0XaauNIUXd6O1xXc3RwoWEBlsTQrY4KQ9Jf0s5rgD6SiNkaUdJegTA==
+"@babel/plugin-transform-nullish-coalescing-operator@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-nullish-coalescing-operator/-/plugin-transform-nullish-coalescing-operator-7.29.7.tgz#8a54cdf88c3f50433a6173117a286195b67714cc"
+  integrity sha512-idmp1dFaekP9GbcMvG24Kvw2BfhFZjHnNJCkV4WuIY4PskJzwI3f1N5OdgYke38T7rftO6ERulFRn2cFeZwRkg==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.27.1"
+    "@babel/helper-plugin-utils" "^7.29.7"
 
-"@babel/plugin-transform-numeric-separator@^7.27.1":
-  version "7.27.1"
-  resolved "https://registry.npmjs.org/@babel/plugin-transform-numeric-separator/-/plugin-transform-numeric-separator-7.27.1.tgz"
-  integrity sha512-fdPKAcujuvEChxDBJ5c+0BTaS6revLV7CJL08e4m3de8qJfNIuCc2nc7XJYOjBoTMJeqSmwXJ0ypE14RCjLwaw==
+"@babel/plugin-transform-numeric-separator@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-numeric-separator/-/plugin-transform-numeric-separator-7.29.7.tgz#0266d5cd42ab87ec40fee45a4e36483cfdcbc66a"
+  integrity sha512-zR7fv/z14OjgHl4AgRtkDBvBMhIzCxqV/qN/2BCRC7LjFwvuzjYe7gDWxC4Wl/SNsLM6SE1IWvRPYMgSJaUvNw==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.27.1"
+    "@babel/helper-plugin-utils" "^7.29.7"
 
-"@babel/plugin-transform-object-rest-spread@^7.28.0":
-  version "7.28.0"
-  resolved "https://registry.npmjs.org/@babel/plugin-transform-object-rest-spread/-/plugin-transform-object-rest-spread-7.28.0.tgz"
-  integrity sha512-9VNGikXxzu5eCiQjdE4IZn8sb9q7Xsk5EXLDBKUYg1e/Tve8/05+KJEtcxGxAgCY5t/BpKQM+JEL/yT4tvgiUA==
+"@babel/plugin-transform-object-rest-spread@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-object-rest-spread/-/plugin-transform-object-rest-spread-7.29.7.tgz#e0d5060241803922c545676613cc8acbbda0d266"
+  integrity sha512-Ld98jn4c0smUywL57m7SgsHq3OpThOa6LqZJif3G6jYOovPleoFhVrBJ1WegRApSFB2wu4+RelAj9AC9G08Z4A==
   dependencies:
-    "@babel/helper-compilation-targets" "^7.27.2"
-    "@babel/helper-plugin-utils" "^7.27.1"
-    "@babel/plugin-transform-destructuring" "^7.28.0"
-    "@babel/plugin-transform-parameters" "^7.27.7"
-    "@babel/traverse" "^7.28.0"
+    "@babel/helper-compilation-targets" "^7.29.7"
+    "@babel/helper-plugin-utils" "^7.29.7"
+    "@babel/plugin-transform-destructuring" "^7.29.7"
+    "@babel/plugin-transform-parameters" "^7.29.7"
+    "@babel/traverse" "^7.29.7"
 
-"@babel/plugin-transform-object-super@^7.27.1":
-  version "7.27.1"
-  resolved "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.27.1.tgz"
-  integrity sha512-SFy8S9plRPbIcxlJ8A6mT/CxFdJx/c04JEctz4jf8YZaVS2px34j7NXRrlGlHkN/M2gnpL37ZpGRGVFLd3l8Ng==
+"@babel/plugin-transform-object-super@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.29.7.tgz#e89283d14fa3c35817d4493ffc6bc649aa10e4eb"
+  integrity sha512-Ea/diGcw0twB5IlZPO5sgET6fJsLJqPABqTuFWIR+iMPGPZJkATEIWx0wa+aEQ5UY1CBQyP/gkAiLEqn1vBiQA==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.27.1"
-    "@babel/helper-replace-supers" "^7.27.1"
+    "@babel/helper-plugin-utils" "^7.29.7"
+    "@babel/helper-replace-supers" "^7.29.7"
 
-"@babel/plugin-transform-optional-catch-binding@^7.27.1":
-  version "7.27.1"
-  resolved "https://registry.npmjs.org/@babel/plugin-transform-optional-catch-binding/-/plugin-transform-optional-catch-binding-7.27.1.tgz"
-  integrity sha512-txEAEKzYrHEX4xSZN4kJ+OfKXFVSWKB2ZxM9dpcE3wT7smwkNmXo5ORRlVzMVdJbD+Q8ILTgSD7959uj+3Dm3Q==
+"@babel/plugin-transform-optional-catch-binding@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-optional-catch-binding/-/plugin-transform-optional-catch-binding-7.29.7.tgz#729664f79985be504eba112c51de9f71d009030b"
+  integrity sha512-sLsyndxK2VwX6yNUOakMb7Sh553ZTe/vVM1XJ+9Z5aW1ytsc8xOIwmyk05NNjN60vkc5/KqoTH6hB4V41LJhng==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.27.1"
+    "@babel/helper-plugin-utils" "^7.29.7"
 
-"@babel/plugin-transform-optional-chaining@^7.27.1":
-  version "7.27.1"
-  resolved "https://registry.npmjs.org/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-7.27.1.tgz"
-  integrity sha512-BQmKPPIuc8EkZgNKsv0X4bPmOoayeu4F1YCwx2/CfmDSXDbp7GnzlUH+/ul5VGfRg1AoFPsrIThlEBj2xb4CAg==
+"@babel/plugin-transform-optional-chaining@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-7.29.7.tgz#b84a1b574b3c73001023092567e16c492b720e51"
+  integrity sha512-6GM1dhvK3gNODkXcEcMCOLEDCLSoZ/sBbro2Ax8HURyasQ4NshagQixkRFdh5niI6E4gmA/jYI/4aT7rRos3ZQ==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.27.1"
-    "@babel/helper-skip-transparent-expression-wrappers" "^7.27.1"
+    "@babel/helper-plugin-utils" "^7.29.7"
+    "@babel/helper-skip-transparent-expression-wrappers" "^7.29.7"
 
-"@babel/plugin-transform-parameters@^7.27.7":
-  version "7.27.7"
-  resolved "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.27.7.tgz"
-  integrity sha512-qBkYTYCb76RRxUM6CcZA5KRu8K4SM8ajzVeUgVdMVO9NN9uI/GaVmBg/WKJJGnNokV9SY8FxNOVWGXzqzUidBg==
+"@babel/plugin-transform-parameters@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.29.7.tgz#a5ddc3b9bfb534814cb8334cbeba47d9cf9db090"
+  integrity sha512-ZDOBqV/qLYJI0YElr8DcENEyARsFQeESqWXH6gZlghYXuPPjvweuDhP4VyEi4BlUBlLRFZVjxoZDMjxhLW766g==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.27.1"
+    "@babel/helper-plugin-utils" "^7.29.7"
 
-"@babel/plugin-transform-private-methods@^7.27.1":
-  version "7.27.1"
-  resolved "https://registry.npmjs.org/@babel/plugin-transform-private-methods/-/plugin-transform-private-methods-7.27.1.tgz"
-  integrity sha512-10FVt+X55AjRAYI9BrdISN9/AQWHqldOeZDUoLyif1Kn05a56xVBXb8ZouL8pZ9jem8QpXaOt8TS7RHUIS+GPA==
+"@babel/plugin-transform-private-methods@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-private-methods/-/plugin-transform-private-methods-7.29.7.tgz#cea8bd3ab99533892897a02999d5b752584ad145"
+  integrity sha512-/6Rz4DK1ETDEM/bWHsPHcaEe7ZaT1EqSXjtSP/L0DijOYuaUhiRiOKcwpZ8P7zR4xXEHc2ITdiCgBm9Tpyv9ug==
   dependencies:
-    "@babel/helper-create-class-features-plugin" "^7.27.1"
-    "@babel/helper-plugin-utils" "^7.27.1"
+    "@babel/helper-create-class-features-plugin" "^7.29.7"
+    "@babel/helper-plugin-utils" "^7.29.7"
 
-"@babel/plugin-transform-private-property-in-object@^7.27.1":
-  version "7.27.1"
-  resolved "https://registry.npmjs.org/@babel/plugin-transform-private-property-in-object/-/plugin-transform-private-property-in-object-7.27.1.tgz"
-  integrity sha512-5J+IhqTi1XPa0DXF83jYOaARrX+41gOewWbkPyjMNRDqgOCqdffGh8L3f/Ek5utaEBZExjSAzcyjmV9SSAWObQ==
+"@babel/plugin-transform-private-property-in-object@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-private-property-in-object/-/plugin-transform-private-property-in-object-7.29.7.tgz#4a2f6be5aba47be7afbdb4cd7903c46edf3a7661"
+  integrity sha512-+BNo06dnrzdNNqCm1X6YUaVv0DKk8Q+JYcoZfOkLhYWNCXzlwTSRq8zGWayT1csjcpNXV9CQTBRRbmTLZac5cA==
   dependencies:
-    "@babel/helper-annotate-as-pure" "^7.27.1"
-    "@babel/helper-create-class-features-plugin" "^7.27.1"
-    "@babel/helper-plugin-utils" "^7.27.1"
+    "@babel/helper-annotate-as-pure" "^7.29.7"
+    "@babel/helper-create-class-features-plugin" "^7.29.7"
+    "@babel/helper-plugin-utils" "^7.29.7"
 
-"@babel/plugin-transform-property-literals@^7.27.1":
-  version "7.27.1"
-  resolved "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.27.1.tgz"
-  integrity sha512-oThy3BCuCha8kDZ8ZkgOg2exvPYUlprMukKQXI1r1pJ47NCvxfkEy8vK+r/hT9nF0Aa4H1WUPZZjHTFtAhGfmQ==
+"@babel/plugin-transform-property-literals@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.29.7.tgz#d45817cd72f9e134ab1f7fbb79264cfcb85cf636"
+  integrity sha512-bOMRLQuI0A5ZqHq3OWJ89/rXpJ/NJrbVhXiP4zwPGMs6kpcVsuTUNjwoE30K0Qm3mf48a/TnRYYD6vPNqcg6jA==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.27.1"
+    "@babel/helper-plugin-utils" "^7.29.7"
 
-"@babel/plugin-transform-regenerator@^7.28.3":
-  version "7.28.3"
-  resolved "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.28.3.tgz"
-  integrity sha512-K3/M/a4+ESb5LEldjQb+XSrpY0nF+ZBFlTCbSnKaYAMfD8v33O6PMs4uYnOk19HlcsI8WMu3McdFPTiQHF/1/A==
+"@babel/plugin-transform-regenerator@^7.29.7":
+  version "7.29.8"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.29.8.tgz#3a4a4dd7214af9d524f0503bb97c99af5f4abf26"
+  integrity sha512-0UpIXPtdDtMXfnV2OJAVMLpj3H/92vmkA6lpSRakmycJvj3VUy6Xs1dM8tXRugupykr5WB+LpiVl0J8LMVg2mg==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.27.1"
+    "@babel/helper-plugin-utils" "^7.29.7"
 
-"@babel/plugin-transform-regexp-modifiers@^7.27.1":
-  version "7.27.1"
-  resolved "https://registry.npmjs.org/@babel/plugin-transform-regexp-modifiers/-/plugin-transform-regexp-modifiers-7.27.1.tgz"
-  integrity sha512-TtEciroaiODtXvLZv4rmfMhkCv8jx3wgKpL68PuiPh2M4fvz5jhsA7697N1gMvkvr/JTF13DrFYyEbY9U7cVPA==
+"@babel/plugin-transform-regexp-modifiers@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-regexp-modifiers/-/plugin-transform-regexp-modifiers-7.29.7.tgz#68311c0c10af2198212528863f8542843e424025"
+  integrity sha512-mB5Fs0VWrJ42ZCmc8114v60qetdaUVNkj9PmSZRmanCZM3S9hm0CFRLjRmYIsuXav14l2jvZ+4T8iiCGnhj3nQ==
   dependencies:
-    "@babel/helper-create-regexp-features-plugin" "^7.27.1"
-    "@babel/helper-plugin-utils" "^7.27.1"
+    "@babel/helper-create-regexp-features-plugin" "^7.29.7"
+    "@babel/helper-plugin-utils" "^7.29.7"
 
-"@babel/plugin-transform-reserved-words@^7.27.1":
-  version "7.27.1"
-  resolved "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.27.1.tgz"
-  integrity sha512-V2ABPHIJX4kC7HegLkYoDpfg9PVmuWy/i6vUM5eGK22bx4YVFD3M5F0QQnWQoDs6AGsUWTVOopBiMFQgHaSkVw==
+"@babel/plugin-transform-reserved-words@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.29.7.tgz#a6feeb179b36a5f1fc6e3154c1eb727bdbe35876"
+  integrity sha512-5+YhdpVgmfSmwZyLMftfaiffLRMHjzIRHFHHLdibcSyJm2pasMrKHrO3Ptrt2DRshjvpgjEJJ1zVW14WPq/6QA==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.27.1"
+    "@babel/helper-plugin-utils" "^7.29.7"
 
-"@babel/plugin-transform-shorthand-properties@^7.27.1":
-  version "7.27.1"
-  resolved "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.27.1.tgz"
-  integrity sha512-N/wH1vcn4oYawbJ13Y/FxcQrWk63jhfNa7jef0ih7PHSIHX2LB7GWE1rkPrOnka9kwMxb6hMl19p7lidA+EHmQ==
+"@babel/plugin-transform-shorthand-properties@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.29.7.tgz#25c0436b98f4bd9ca4b98e1fbd662743bbaab9bf"
+  integrity sha512-I+WYbGBAiCn7nA6xBrlgPH+MB7HWb4u8pv5S0Pv7OtwNvIFvCCb24YlttKEeUFVurfBCEaOTnuhlqsb7f0Z5Dg==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.27.1"
+    "@babel/helper-plugin-utils" "^7.29.7"
 
-"@babel/plugin-transform-spread@^7.27.1":
-  version "7.27.1"
-  resolved "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.27.1.tgz"
-  integrity sha512-kpb3HUqaILBJcRFVhFUs6Trdd4mkrzcGXss+6/mxUd273PfbWqSDHRzMT2234gIg2QYfAjvXLSquP1xECSg09Q==
+"@babel/plugin-transform-spread@^7.29.7":
+  version "7.29.8"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-spread/-/plugin-transform-spread-7.29.8.tgz#c894cff38556a5dafeb412e13fc012b6df4b95a2"
+  integrity sha512-4S9ksMGVWUshvgK0mKfvZky7leuG5/uoFVwMpAomJ8bMoDJiNHRVmc1EglwW/CmGVSqqWpEbXm9FmbRit22qoA==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.27.1"
-    "@babel/helper-skip-transparent-expression-wrappers" "^7.27.1"
+    "@babel/helper-plugin-utils" "^7.29.7"
+    "@babel/helper-skip-transparent-expression-wrappers" "^7.29.7"
 
-"@babel/plugin-transform-sticky-regex@^7.27.1":
-  version "7.27.1"
-  resolved "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.27.1.tgz"
-  integrity sha512-lhInBO5bi/Kowe2/aLdBAawijx+q1pQzicSgnkB6dUPc1+RC8QmJHKf2OjvU+NZWitguJHEaEmbV6VWEouT58g==
+"@babel/plugin-transform-sticky-regex@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.29.7.tgz#a42c0fd1fa42f7e98e1e0c7757f72a1bbca3a015"
+  integrity sha512-BCHzNYJGe9l7EpwwDBN/ztlL2NYFFq8hp9ddjtUEM9f2O7S7kKV/lL6Fwo7IF7NSkYhPK2vO+86nIGltA90MsA==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.27.1"
+    "@babel/helper-plugin-utils" "^7.29.7"
 
-"@babel/plugin-transform-template-literals@^7.27.1":
-  version "7.27.1"
-  resolved "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.27.1.tgz"
-  integrity sha512-fBJKiV7F2DxZUkg5EtHKXQdbsbURW3DZKQUWphDum0uRP6eHGGa/He9mc0mypL680pb+e/lDIthRohlv8NCHkg==
+"@babel/plugin-transform-template-literals@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.29.7.tgz#ada97d8e0832bca8edb315888aa654b1570f3835"
+  integrity sha512-NCSEJ4sLFU2gqAub45HYh4fus2yQ36rr6ei6vpU7NdoJqCpxvEG8E6eJpscGyXP3VHD2Ny+fSXr04k1hoUrFqA==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.27.1"
+    "@babel/helper-plugin-utils" "^7.29.7"
 
-"@babel/plugin-transform-typeof-symbol@^7.27.1":
-  version "7.27.1"
-  resolved "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.27.1.tgz"
-  integrity sha512-RiSILC+nRJM7FY5srIyc4/fGIwUhyDuuBSdWn4y6yT6gm652DpCHZjIipgn6B7MQ1ITOUnAKWixEUjQRIBIcLw==
+"@babel/plugin-transform-typeof-symbol@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.29.7.tgz#d848a4677c1ee3485ab017f4018f04597798911c"
+  integrity sha512-223mNGoTkBiTEWFoK+Q6Go3tueMRclO8vxxxxquNCYuNI4jWOofFKJRRDu6SDrB8Sgo1UEGW9T4GAQ8ZyRso1A==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.27.1"
+    "@babel/helper-plugin-utils" "^7.29.7"
 
-"@babel/plugin-transform-unicode-escapes@^7.27.1":
-  version "7.27.1"
-  resolved "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.27.1.tgz"
-  integrity sha512-Ysg4v6AmF26k9vpfFuTZg8HRfVWzsh1kVfowA23y9j/Gu6dOuahdUVhkLqpObp3JIv27MLSii6noRnuKN8H0Mg==
+"@babel/plugin-transform-unicode-escapes@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.29.7.tgz#1e99554b0cddfd650d649a9f2b996049893e5720"
+  integrity sha512-jCfXxSjf94lf4E0hKE0AByxF6F3/pVFqRdUUNkDJhsY0m1ZKjnN6ZYyMeHNpzflxb/0q5b7t3p+BE+SLF1WOtA==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.27.1"
+    "@babel/helper-plugin-utils" "^7.29.7"
 
-"@babel/plugin-transform-unicode-property-regex@^7.27.1":
-  version "7.27.1"
-  resolved "https://registry.npmjs.org/@babel/plugin-transform-unicode-property-regex/-/plugin-transform-unicode-property-regex-7.27.1.tgz"
-  integrity sha512-uW20S39PnaTImxp39O5qFlHLS9LJEmANjMG7SxIhap8rCHqu0Ik+tLEPX5DKmHn6CsWQ7j3lix2tFOa5YtL12Q==
+"@babel/plugin-transform-unicode-property-regex@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-unicode-property-regex/-/plugin-transform-unicode-property-regex-7.29.7.tgz#44444afc73768c2190fac4d95f7716817b7f204a"
+  integrity sha512-OgZ+zoAJgZLUCunsTRQ5LAjOywDv5zzZ2/hQ5aMw1pGXyY2rtE8/chXYUmu3AlVHKpm10KEdG9aMwbI/K76ZGw==
   dependencies:
-    "@babel/helper-create-regexp-features-plugin" "^7.27.1"
-    "@babel/helper-plugin-utils" "^7.27.1"
+    "@babel/helper-create-regexp-features-plugin" "^7.29.7"
+    "@babel/helper-plugin-utils" "^7.29.7"
 
-"@babel/plugin-transform-unicode-regex@^7.27.1":
-  version "7.27.1"
-  resolved "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.27.1.tgz"
-  integrity sha512-xvINq24TRojDuyt6JGtHmkVkrfVV3FPT16uytxImLeBZqW3/H52yN+kM1MGuyPkIQxrzKwPHs5U/MP3qKyzkGw==
+"@babel/plugin-transform-unicode-regex@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.29.7.tgz#c3064b293ff7f1794b71f7650eec8db9896d3e59"
+  integrity sha512-7D/x/23/d/3VqZ0QA+LGbZMlGwZjztBygSWWWsfTPoQ1oQ6Q1P6Mr3d0kk42XabyUVw+fha3LqdRsFqeKqvCyA==
   dependencies:
-    "@babel/helper-create-regexp-features-plugin" "^7.27.1"
-    "@babel/helper-plugin-utils" "^7.27.1"
+    "@babel/helper-create-regexp-features-plugin" "^7.29.7"
+    "@babel/helper-plugin-utils" "^7.29.7"
 
-"@babel/plugin-transform-unicode-sets-regex@^7.27.1":
-  version "7.27.1"
-  resolved "https://registry.npmjs.org/@babel/plugin-transform-unicode-sets-regex/-/plugin-transform-unicode-sets-regex-7.27.1.tgz"
-  integrity sha512-EtkOujbc4cgvb0mlpQefi4NTPBzhSIevblFevACNLUspmrALgmEBdL/XfnyyITfd8fKBZrZys92zOWcik7j9Tw==
+"@babel/plugin-transform-unicode-sets-regex@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-unicode-sets-regex/-/plugin-transform-unicode-sets-regex-7.29.7.tgz#b03ac9f27326f6197e8e574add83bbf33fc34ecd"
+  integrity sha512-BLOhLht9DOJwIxlmp91wHvkXv1lguuHS3/FwUO8HL1H0u8s4hR1gASVFyilu9iGtcTRYqjTZmlsFFeQletntEg==
   dependencies:
-    "@babel/helper-create-regexp-features-plugin" "^7.27.1"
-    "@babel/helper-plugin-utils" "^7.27.1"
+    "@babel/helper-create-regexp-features-plugin" "^7.29.7"
+    "@babel/helper-plugin-utils" "^7.29.7"
 
 "@babel/preset-env@^7.24.3":
-  version "7.28.3"
-  resolved "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.28.3.tgz"
-  integrity sha512-ROiDcM+GbYVPYBOeCR6uBXKkQpBExLl8k9HO1ygXEyds39j+vCCsjmj7S8GOniZQlEs81QlkdJZe76IpLSiqpg==
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.29.7.tgz#5e2ab5e764b493fdefc99c43aeaa70a9533a37fd"
+  integrity sha512-GYzX36n1nsciIb0uyH0GHwxwtNwPQIcpxSeiVLDtG/B7jB5xXgchnmL1f/jCX5o+pwnaDBtO60ONSJhEBJfxYA==
   dependencies:
-    "@babel/compat-data" "^7.28.0"
-    "@babel/helper-compilation-targets" "^7.27.2"
-    "@babel/helper-plugin-utils" "^7.27.1"
-    "@babel/helper-validator-option" "^7.27.1"
-    "@babel/plugin-bugfix-firefox-class-in-computed-class-key" "^7.27.1"
-    "@babel/plugin-bugfix-safari-class-field-initializer-scope" "^7.27.1"
-    "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression" "^7.27.1"
-    "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining" "^7.27.1"
-    "@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly" "^7.28.3"
+    "@babel/compat-data" "^7.29.7"
+    "@babel/helper-compilation-targets" "^7.29.7"
+    "@babel/helper-plugin-utils" "^7.29.7"
+    "@babel/helper-validator-option" "^7.29.7"
+    "@babel/plugin-bugfix-firefox-class-in-computed-class-key" "^7.29.7"
+    "@babel/plugin-bugfix-safari-class-field-initializer-scope" "^7.29.7"
+    "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression" "^7.29.7"
+    "@babel/plugin-bugfix-safari-rest-destructuring-rhs-array" "^7.29.7"
+    "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining" "^7.29.7"
+    "@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly" "^7.29.7"
     "@babel/plugin-proposal-private-property-in-object" "7.21.0-placeholder-for-preset-env.2"
-    "@babel/plugin-syntax-import-assertions" "^7.27.1"
-    "@babel/plugin-syntax-import-attributes" "^7.27.1"
+    "@babel/plugin-syntax-import-assertions" "^7.29.7"
+    "@babel/plugin-syntax-import-attributes" "^7.29.7"
     "@babel/plugin-syntax-unicode-sets-regex" "^7.18.6"
-    "@babel/plugin-transform-arrow-functions" "^7.27.1"
-    "@babel/plugin-transform-async-generator-functions" "^7.28.0"
-    "@babel/plugin-transform-async-to-generator" "^7.27.1"
-    "@babel/plugin-transform-block-scoped-functions" "^7.27.1"
-    "@babel/plugin-transform-block-scoping" "^7.28.0"
-    "@babel/plugin-transform-class-properties" "^7.27.1"
-    "@babel/plugin-transform-class-static-block" "^7.28.3"
-    "@babel/plugin-transform-classes" "^7.28.3"
-    "@babel/plugin-transform-computed-properties" "^7.27.1"
-    "@babel/plugin-transform-destructuring" "^7.28.0"
-    "@babel/plugin-transform-dotall-regex" "^7.27.1"
-    "@babel/plugin-transform-duplicate-keys" "^7.27.1"
-    "@babel/plugin-transform-duplicate-named-capturing-groups-regex" "^7.27.1"
-    "@babel/plugin-transform-dynamic-import" "^7.27.1"
-    "@babel/plugin-transform-explicit-resource-management" "^7.28.0"
-    "@babel/plugin-transform-exponentiation-operator" "^7.27.1"
-    "@babel/plugin-transform-export-namespace-from" "^7.27.1"
-    "@babel/plugin-transform-for-of" "^7.27.1"
-    "@babel/plugin-transform-function-name" "^7.27.1"
-    "@babel/plugin-transform-json-strings" "^7.27.1"
-    "@babel/plugin-transform-literals" "^7.27.1"
-    "@babel/plugin-transform-logical-assignment-operators" "^7.27.1"
-    "@babel/plugin-transform-member-expression-literals" "^7.27.1"
-    "@babel/plugin-transform-modules-amd" "^7.27.1"
-    "@babel/plugin-transform-modules-commonjs" "^7.27.1"
-    "@babel/plugin-transform-modules-systemjs" "^7.27.1"
-    "@babel/plugin-transform-modules-umd" "^7.27.1"
-    "@babel/plugin-transform-named-capturing-groups-regex" "^7.27.1"
-    "@babel/plugin-transform-new-target" "^7.27.1"
-    "@babel/plugin-transform-nullish-coalescing-operator" "^7.27.1"
-    "@babel/plugin-transform-numeric-separator" "^7.27.1"
-    "@babel/plugin-transform-object-rest-spread" "^7.28.0"
-    "@babel/plugin-transform-object-super" "^7.27.1"
-    "@babel/plugin-transform-optional-catch-binding" "^7.27.1"
-    "@babel/plugin-transform-optional-chaining" "^7.27.1"
-    "@babel/plugin-transform-parameters" "^7.27.7"
-    "@babel/plugin-transform-private-methods" "^7.27.1"
-    "@babel/plugin-transform-private-property-in-object" "^7.27.1"
-    "@babel/plugin-transform-property-literals" "^7.27.1"
-    "@babel/plugin-transform-regenerator" "^7.28.3"
-    "@babel/plugin-transform-regexp-modifiers" "^7.27.1"
-    "@babel/plugin-transform-reserved-words" "^7.27.1"
-    "@babel/plugin-transform-shorthand-properties" "^7.27.1"
-    "@babel/plugin-transform-spread" "^7.27.1"
-    "@babel/plugin-transform-sticky-regex" "^7.27.1"
-    "@babel/plugin-transform-template-literals" "^7.27.1"
-    "@babel/plugin-transform-typeof-symbol" "^7.27.1"
-    "@babel/plugin-transform-unicode-escapes" "^7.27.1"
-    "@babel/plugin-transform-unicode-property-regex" "^7.27.1"
-    "@babel/plugin-transform-unicode-regex" "^7.27.1"
-    "@babel/plugin-transform-unicode-sets-regex" "^7.27.1"
+    "@babel/plugin-transform-arrow-functions" "^7.29.7"
+    "@babel/plugin-transform-async-generator-functions" "^7.29.7"
+    "@babel/plugin-transform-async-to-generator" "^7.29.7"
+    "@babel/plugin-transform-block-scoped-functions" "^7.29.7"
+    "@babel/plugin-transform-block-scoping" "^7.29.7"
+    "@babel/plugin-transform-class-properties" "^7.29.7"
+    "@babel/plugin-transform-class-static-block" "^7.29.7"
+    "@babel/plugin-transform-classes" "^7.29.7"
+    "@babel/plugin-transform-computed-properties" "^7.29.7"
+    "@babel/plugin-transform-destructuring" "^7.29.7"
+    "@babel/plugin-transform-dotall-regex" "^7.29.7"
+    "@babel/plugin-transform-duplicate-keys" "^7.29.7"
+    "@babel/plugin-transform-duplicate-named-capturing-groups-regex" "^7.29.7"
+    "@babel/plugin-transform-dynamic-import" "^7.29.7"
+    "@babel/plugin-transform-explicit-resource-management" "^7.29.7"
+    "@babel/plugin-transform-exponentiation-operator" "^7.29.7"
+    "@babel/plugin-transform-export-namespace-from" "^7.29.7"
+    "@babel/plugin-transform-for-of" "^7.29.7"
+    "@babel/plugin-transform-function-name" "^7.29.7"
+    "@babel/plugin-transform-json-strings" "^7.29.7"
+    "@babel/plugin-transform-literals" "^7.29.7"
+    "@babel/plugin-transform-logical-assignment-operators" "^7.29.7"
+    "@babel/plugin-transform-member-expression-literals" "^7.29.7"
+    "@babel/plugin-transform-modules-amd" "^7.29.7"
+    "@babel/plugin-transform-modules-commonjs" "^7.29.7"
+    "@babel/plugin-transform-modules-systemjs" "^7.29.7"
+    "@babel/plugin-transform-modules-umd" "^7.29.7"
+    "@babel/plugin-transform-named-capturing-groups-regex" "^7.29.7"
+    "@babel/plugin-transform-new-target" "^7.29.7"
+    "@babel/plugin-transform-nullish-coalescing-operator" "^7.29.7"
+    "@babel/plugin-transform-numeric-separator" "^7.29.7"
+    "@babel/plugin-transform-object-rest-spread" "^7.29.7"
+    "@babel/plugin-transform-object-super" "^7.29.7"
+    "@babel/plugin-transform-optional-catch-binding" "^7.29.7"
+    "@babel/plugin-transform-optional-chaining" "^7.29.7"
+    "@babel/plugin-transform-parameters" "^7.29.7"
+    "@babel/plugin-transform-private-methods" "^7.29.7"
+    "@babel/plugin-transform-private-property-in-object" "^7.29.7"
+    "@babel/plugin-transform-property-literals" "^7.29.7"
+    "@babel/plugin-transform-regenerator" "^7.29.7"
+    "@babel/plugin-transform-regexp-modifiers" "^7.29.7"
+    "@babel/plugin-transform-reserved-words" "^7.29.7"
+    "@babel/plugin-transform-shorthand-properties" "^7.29.7"
+    "@babel/plugin-transform-spread" "^7.29.7"
+    "@babel/plugin-transform-sticky-regex" "^7.29.7"
+    "@babel/plugin-transform-template-literals" "^7.29.7"
+    "@babel/plugin-transform-typeof-symbol" "^7.29.7"
+    "@babel/plugin-transform-unicode-escapes" "^7.29.7"
+    "@babel/plugin-transform-unicode-property-regex" "^7.29.7"
+    "@babel/plugin-transform-unicode-regex" "^7.29.7"
+    "@babel/plugin-transform-unicode-sets-regex" "^7.29.7"
     "@babel/preset-modules" "0.1.6-no-external-plugins"
-    babel-plugin-polyfill-corejs2 "^0.4.14"
-    babel-plugin-polyfill-corejs3 "^0.13.0"
-    babel-plugin-polyfill-regenerator "^0.6.5"
-    core-js-compat "^3.43.0"
+    babel-plugin-polyfill-corejs2 "^0.4.15"
+    babel-plugin-polyfill-corejs3 "^0.14.0"
+    babel-plugin-polyfill-regenerator "^0.6.6"
+    core-js-compat "^3.48.0"
     semver "^6.3.1"
 
 "@babel/preset-modules@0.1.6-no-external-plugins":
@@ -961,10 +968,10 @@
     "@babel/types" "^7.4.4"
     esutils "^2.0.2"
 
-"@babel/register@^7.27.1":
-  version "7.28.3"
-  resolved "https://registry.npmjs.org/@babel/register/-/register-7.28.3.tgz"
-  integrity sha512-CieDOtd8u208eI49bYl4z1J22ySFw87IGwE+IswFEExH7e3rLgKb0WNQeumnacQ1+VoDJLYI5QFA3AJZuyZQfA==
+"@babel/register@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/register/-/register-7.29.7.tgz#d5bb4337065512f643b29cb565b6e8ccadcc1ec6"
+  integrity sha512-AMGJoWuES861riy6pcB0fphE1YXybtQnBYQMuIyPv6mKLiosfa79BKTnAOyx215c/3RJPJpdQwoHZ3earVH7AA==
   dependencies:
     clone-deep "^4.0.1"
     find-cache-dir "^2.0.0"
@@ -973,47 +980,47 @@
     source-map-support "^0.5.16"
 
 "@babel/runtime@^7.5.5":
-  version "7.28.3"
-  resolved "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.3.tgz"
-  integrity sha512-9uIQ10o0WGdpP6GDhXcdOJPJuDgFtIDtN/9+ArJQ2NAfAmiuhTQdzkaTGR33v43GYS2UrSA0eX2pPPHoFVvpxA==
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.29.7.tgz#12022450c45a4da6d8d8287b18a4ff2ddb23f768"
+  integrity sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==
 
-"@babel/template@^7.27.1", "@babel/template@^7.27.2", "@babel/template@^7.3.3":
-  version "7.27.2"
-  resolved "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz"
-  integrity sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==
+"@babel/template@^7.29.7", "@babel/template@^7.3.3":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.29.7.tgz#4d9d4004f645cdd304de958c725162784ecac700"
+  integrity sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==
   dependencies:
-    "@babel/code-frame" "^7.27.1"
-    "@babel/parser" "^7.27.2"
-    "@babel/types" "^7.27.1"
+    "@babel/code-frame" "^7.29.7"
+    "@babel/parser" "^7.29.7"
+    "@babel/types" "^7.29.7"
 
-"@babel/traverse@^7.27.1", "@babel/traverse@^7.28.0", "@babel/traverse@^7.28.3", "@babel/traverse@^7.7.0":
-  version "7.28.3"
-  resolved "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.3.tgz"
-  integrity sha512-7w4kZYHneL3A6NP2nxzHvT3HCZ7puDZZjFMqDpBPECub79sTtSO5CGXDkKrTQq8ksAwfD/XI2MRFX23njdDaIQ==
+"@babel/traverse@^7.29.7", "@babel/traverse@^7.29.8", "@babel/traverse@^7.7.0":
+  version "7.29.8"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.29.8.tgz#4111014cdc71a0f95d9471907590baa0b8a6b28a"
+  integrity sha512-I5z7H3bf/41ktsNVLtpN0wAa336HkqIHQ5BuPLEhTkt1jVSyZpeNKIzTgEWmlxjdg81R0IgUCcaE+Ok3NvrfZg==
   dependencies:
-    "@babel/code-frame" "^7.27.1"
-    "@babel/generator" "^7.28.3"
-    "@babel/helper-globals" "^7.28.0"
-    "@babel/parser" "^7.28.3"
-    "@babel/template" "^7.27.2"
-    "@babel/types" "^7.28.2"
+    "@babel/code-frame" "^7.29.7"
+    "@babel/generator" "^7.29.8"
+    "@babel/helper-globals" "^7.29.7"
+    "@babel/parser" "^7.29.8"
+    "@babel/template" "^7.29.7"
+    "@babel/types" "^7.29.8"
     debug "^4.3.1"
 
-"@babel/types@^7.0.0", "@babel/types@^7.20.7", "@babel/types@^7.27.1", "@babel/types@^7.27.3", "@babel/types@^7.28.2", "@babel/types@^7.3.3", "@babel/types@^7.4.4", "@babel/types@^7.7.0":
-  version "7.28.2"
-  resolved "https://registry.npmjs.org/@babel/types/-/types-7.28.2.tgz"
-  integrity sha512-ruv7Ae4J5dUYULmeXw1gmb7rYRz57OWCPM57pHojnLq/3Z1CK2lNSLTCVjxVk1F/TZHwOZZrOWi0ur95BbLxNQ==
-  dependencies:
-    "@babel/helper-string-parser" "^7.27.1"
-    "@babel/helper-validator-identifier" "^7.27.1"
-
-"@babel/types@^7.25.4", "@babel/types@^7.28.5":
+"@babel/types@^7.0.0", "@babel/types@^7.20.7", "@babel/types@^7.25.4", "@babel/types@^7.3.3", "@babel/types@^7.4.4", "@babel/types@^7.7.0":
   version "7.28.5"
   resolved "https://registry.npmjs.org/@babel/types/-/types-7.28.5.tgz"
   integrity sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==
   dependencies:
     "@babel/helper-string-parser" "^7.27.1"
     "@babel/helper-validator-identifier" "^7.28.5"
+
+"@babel/types@^7.28.2", "@babel/types@^7.29.7", "@babel/types@^7.29.8":
+  version "7.29.8"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.29.8.tgz#1229eef31d85156d70fa3f4cd859376d0eaf6863"
+  integrity sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==
+  dependencies:
+    "@babel/helper-string-parser" "^7.29.7"
+    "@babel/helper-validator-identifier" "^7.29.7"
 
 "@bcoe/v8-coverage@^0.2.3":
   version "0.2.3"
@@ -1034,7 +1041,7 @@
 
 "@borewit/text-codec@^0.2.1":
   version "0.2.2"
-  resolved "https://registry.yarnpkg.com/@borewit/text-codec/-/text-codec-0.2.2.tgz#75025f735c0983b3a871668804a57387e3649375"
+  resolved "https://registry.npmjs.org/@borewit/text-codec/-/text-codec-0.2.2.tgz"
   integrity sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==
 
 "@bufbuild/protobuf@^2.2.2", "@bufbuild/protobuf@^2.5.1":
@@ -1043,9 +1050,9 @@
   integrity sha512-sBXGT13cpmPR5BMgHE6UEEfEaShh5Ror6rfN3yEK5si7QVrtZg8LEPQb0VVhiLRUslD2yLnXtnRzG035J/mZXQ==
 
 "@cedar-policy/cedar-wasm@^4.5.0":
-  version "4.7.0"
-  resolved "https://registry.npmjs.org/@cedar-policy/cedar-wasm/-/cedar-wasm-4.7.0.tgz"
-  integrity sha512-JMHXgF6cSBt0SoSjwojI0813emNlEBrhzYqhsVCG/s/gwU0FOHy5Q1Hippxylzu3FVFiBOlt8+rbU0c6sGO1Cw==
+  version "4.8.2"
+  resolved "https://registry.npmjs.org/@cedar-policy/cedar-wasm/-/cedar-wasm-4.8.2.tgz"
+  integrity sha512-S37Kd4wP/IMZN3pdKEcsV8av7jMj4AKRovxzJEYZNTEYq0Wj4fno3dsw8xHHDXqT0dkQGTNUBuQNF8CTvOgE/Q==
 
 "@chainsafe/as-chacha20poly1305@^0.1.0":
   version "0.1.0"
@@ -1105,12 +1112,12 @@
   dependencies:
     "@chainsafe/is-ip" "^2.0.1"
 
-"@changesets/apply-release-plan@^7.0.12":
-  version "7.0.12"
-  resolved "https://registry.npmjs.org/@changesets/apply-release-plan/-/apply-release-plan-7.0.12.tgz"
-  integrity sha512-EaET7As5CeuhTzvXTQCRZeBUcisoYPDDcXvgTE/2jmmypKp0RC7LxKj/yzqeh/1qFTZI7oDGFcL1PHRuQuketQ==
+"@changesets/apply-release-plan@^7.1.1":
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/@changesets/apply-release-plan/-/apply-release-plan-7.1.1.tgz#198c3d4dd9eafd0b3fa402a5d212eabe89db134e"
+  integrity sha512-9qPCm/rLx/xoOFXIHGB229+4GOL76S4MC+7tyOuTsR6+1jYlfFDQORdvwR5hDA6y4FL2BPt3qpbcQIS+dW85LA==
   dependencies:
-    "@changesets/config" "^3.1.1"
+    "@changesets/config" "^3.1.4"
     "@changesets/get-version-range-type" "^0.4.0"
     "@changesets/git" "^3.0.4"
     "@changesets/should-skip-package" "^0.1.2"
@@ -1124,13 +1131,13 @@
     resolve-from "^5.0.0"
     semver "^7.5.3"
 
-"@changesets/assemble-release-plan@^6.0.9":
-  version "6.0.9"
-  resolved "https://registry.npmjs.org/@changesets/assemble-release-plan/-/assemble-release-plan-6.0.9.tgz"
-  integrity sha512-tPgeeqCHIwNo8sypKlS3gOPmsS3wP0zHt67JDuL20P4QcXiw/O4Hl7oXiuLnP9yg+rXLQ2sScdV1Kkzde61iSQ==
+"@changesets/assemble-release-plan@^6.0.10":
+  version "6.0.10"
+  resolved "https://registry.yarnpkg.com/@changesets/assemble-release-plan/-/assemble-release-plan-6.0.10.tgz#cb82efed0dc17b741bc39b6ccd551e3c86a4eb3d"
+  integrity sha512-rSDcqdJ9KbVyjpBIuCidhvZNIiVt1XaIYp73ycVQRIA5n/j6wQaEk0ChRLMUQ1vkxZe51PTQ9OIhbg6HQMW45A==
   dependencies:
     "@changesets/errors" "^0.2.0"
-    "@changesets/get-dependents-graph" "^2.1.3"
+    "@changesets/get-dependents-graph" "^2.1.4"
     "@changesets/should-skip-package" "^0.1.2"
     "@changesets/types" "^6.1.0"
     "@manypkg/get-packages" "^1.1.3"
@@ -1138,38 +1145,36 @@
 
 "@changesets/changelog-git@^0.2.1":
   version "0.2.1"
-  resolved "https://registry.npmjs.org/@changesets/changelog-git/-/changelog-git-0.2.1.tgz"
+  resolved "https://registry.yarnpkg.com/@changesets/changelog-git/-/changelog-git-0.2.1.tgz#7f311f3dc11eae1235aa7fd2c1807112962b409b"
   integrity sha512-x/xEleCFLH28c3bQeQIyeZf8lFXyDFVn1SgcBiR2Tw/r4IAWlk1fzxCEZ6NxQAjF2Nwtczoen3OA2qR+UawQ8Q==
   dependencies:
     "@changesets/types" "^6.1.0"
 
 "@changesets/cli@^2.x.x":
-  version "2.29.6"
-  resolved "https://registry.npmjs.org/@changesets/cli/-/cli-2.29.6.tgz"
-  integrity sha512-6qCcVsIG1KQLhpQ5zE8N0PckIx4+9QlHK3z6/lwKnw7Tir71Bjw8BeOZaxA/4Jt00pcgCnCSWZnyuZf5Il05QQ==
+  version "2.31.1"
+  resolved "https://registry.yarnpkg.com/@changesets/cli/-/cli-2.31.1.tgz#aaef4fc5cc4a2aae4e952696593e48ddc7d75a74"
+  integrity sha512-uO05WTcRBwuVOJVSW8Cmpqw6q0WDL53ajGCMyszutvOe5toOnunbpM4jZzf+qxBOz7i0AzopZ8diBuewjmF40w==
   dependencies:
-    "@changesets/apply-release-plan" "^7.0.12"
-    "@changesets/assemble-release-plan" "^6.0.9"
+    "@changesets/apply-release-plan" "^7.1.1"
+    "@changesets/assemble-release-plan" "^6.0.10"
     "@changesets/changelog-git" "^0.2.1"
-    "@changesets/config" "^3.1.1"
+    "@changesets/config" "^3.1.4"
     "@changesets/errors" "^0.2.0"
-    "@changesets/get-dependents-graph" "^2.1.3"
-    "@changesets/get-release-plan" "^4.0.13"
+    "@changesets/get-dependents-graph" "^2.1.4"
+    "@changesets/get-release-plan" "^4.0.16"
     "@changesets/git" "^3.0.4"
     "@changesets/logger" "^0.1.1"
     "@changesets/pre" "^2.0.2"
-    "@changesets/read" "^0.6.5"
+    "@changesets/read" "^0.6.7"
     "@changesets/should-skip-package" "^0.1.2"
     "@changesets/types" "^6.1.0"
     "@changesets/write" "^0.4.0"
-    "@inquirer/external-editor" "^1.0.0"
+    "@inquirer/external-editor" "^1.0.2"
     "@manypkg/get-packages" "^1.1.3"
     ansi-colors "^4.1.3"
-    ci-info "^3.7.0"
     enquirer "^2.4.1"
     fs-extra "^7.0.1"
     mri "^1.2.0"
-    p-limit "^2.2.0"
     package-manager-detector "^0.2.0"
     picocolors "^1.1.0"
     resolve-from "^5.0.0"
@@ -1177,14 +1182,15 @@
     spawndamnit "^3.0.1"
     term-size "^2.1.0"
 
-"@changesets/config@^3.1.1":
-  version "3.1.1"
-  resolved "https://registry.npmjs.org/@changesets/config/-/config-3.1.1.tgz"
-  integrity sha512-bd+3Ap2TKXxljCggI0mKPfzCQKeV/TU4yO2h2C6vAihIo8tzseAn2e7klSuiyYYXvgu53zMN1OeYMIQkaQoWnA==
+"@changesets/config@^3.1.4":
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/@changesets/config/-/config-3.1.4.tgz#e503be9d86f122e52d64ccca868870e5ea943cfd"
+  integrity sha512-pf0bvD/v6WI2cRlZ6hzpjtZdSlXDXMAJ+Iz7xfFzV4ZxJ8OGGAON+1qYc99ZPrijnt4xp3VGG7eNvAOGS24V1Q==
   dependencies:
     "@changesets/errors" "^0.2.0"
-    "@changesets/get-dependents-graph" "^2.1.3"
+    "@changesets/get-dependents-graph" "^2.1.4"
     "@changesets/logger" "^0.1.1"
+    "@changesets/should-skip-package" "^0.1.2"
     "@changesets/types" "^6.1.0"
     "@manypkg/get-packages" "^1.1.3"
     fs-extra "^7.0.1"
@@ -1197,25 +1203,25 @@
   dependencies:
     extendable-error "^0.1.5"
 
-"@changesets/get-dependents-graph@^2.1.3":
-  version "2.1.3"
-  resolved "https://registry.npmjs.org/@changesets/get-dependents-graph/-/get-dependents-graph-2.1.3.tgz"
-  integrity sha512-gphr+v0mv2I3Oxt19VdWRRUxq3sseyUpX9DaHpTUmLj92Y10AGy+XOtV+kbM6L/fDcpx7/ISDFK6T8A/P3lOdQ==
+"@changesets/get-dependents-graph@^2.1.4":
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/@changesets/get-dependents-graph/-/get-dependents-graph-2.1.4.tgz#a18e56d94b41d45888f62021accc6e17a61b5d7c"
+  integrity sha512-ZsS00x6WvmHq3sQv8oCMwL0f/z3wbXCVuSVTJwCnnmbC/iBdNJGFx1EcbMG4PC6sXRyH69liM4A2WKXzn/kRPg==
   dependencies:
     "@changesets/types" "^6.1.0"
     "@manypkg/get-packages" "^1.1.3"
     picocolors "^1.1.0"
     semver "^7.5.3"
 
-"@changesets/get-release-plan@^4.0.13":
-  version "4.0.13"
-  resolved "https://registry.npmjs.org/@changesets/get-release-plan/-/get-release-plan-4.0.13.tgz"
-  integrity sha512-DWG1pus72FcNeXkM12tx+xtExyH/c9I1z+2aXlObH3i9YA7+WZEVaiHzHl03thpvAgWTRaH64MpfHxozfF7Dvg==
+"@changesets/get-release-plan@^4.0.16":
+  version "4.0.16"
+  resolved "https://registry.yarnpkg.com/@changesets/get-release-plan/-/get-release-plan-4.0.16.tgz#18f01f037c4c9376acf32ab820f7bcb7e292eaa0"
+  integrity sha512-2K5Om6CrMPm45rtvckfzWo7e9jOVCKLCnXia5eUPaURH7/LWzri7pK1TycdzAuAtehLkW7VPbWLCSExTHmiI6g==
   dependencies:
-    "@changesets/assemble-release-plan" "^6.0.9"
-    "@changesets/config" "^3.1.1"
+    "@changesets/assemble-release-plan" "^6.0.10"
+    "@changesets/config" "^3.1.4"
     "@changesets/pre" "^2.0.2"
-    "@changesets/read" "^0.6.5"
+    "@changesets/read" "^0.6.7"
     "@changesets/types" "^6.1.0"
     "@manypkg/get-packages" "^1.1.3"
 
@@ -1226,7 +1232,7 @@
 
 "@changesets/git@^3.0.4":
   version "3.0.4"
-  resolved "https://registry.npmjs.org/@changesets/git/-/git-3.0.4.tgz"
+  resolved "https://registry.yarnpkg.com/@changesets/git/-/git-3.0.4.tgz#75e3811ab407ec010beb51131ceb5c6b3975c914"
   integrity sha512-BXANzRFkX+XcC1q/d27NKvlJ1yf7PSAgi8JG6dt8EfbHFHi4neau7mufcSca5zRhwOL8j9s6EqsxmT+s+/E6Sw==
   dependencies:
     "@changesets/errors" "^0.2.0"
@@ -1242,17 +1248,17 @@
   dependencies:
     picocolors "^1.1.0"
 
-"@changesets/parse@^0.4.1":
-  version "0.4.1"
-  resolved "https://registry.npmjs.org/@changesets/parse/-/parse-0.4.1.tgz"
-  integrity sha512-iwksMs5Bf/wUItfcg+OXrEpravm5rEd9Bf4oyIPL4kVTmJQ7PNDSd6MDYkpSJR1pn7tz/k8Zf2DhTCqX08Ou+Q==
+"@changesets/parse@^0.4.3":
+  version "0.4.3"
+  resolved "https://registry.yarnpkg.com/@changesets/parse/-/parse-0.4.3.tgz#912a7eac7f8cb387b05f749596a68f2f763660e0"
+  integrity sha512-ZDmNc53+dXdWEv7fqIUSgRQOLYoUom5Z40gmLgmATmYR9NbL6FJJHwakcCpzaeCy+1D0m0n7mT4jj2B/MQPl7A==
   dependencies:
     "@changesets/types" "^6.1.0"
-    js-yaml "^3.13.1"
+    js-yaml "^4.1.1"
 
 "@changesets/pre@^2.0.2":
   version "2.0.2"
-  resolved "https://registry.npmjs.org/@changesets/pre/-/pre-2.0.2.tgz"
+  resolved "https://registry.yarnpkg.com/@changesets/pre/-/pre-2.0.2.tgz#b35e84d25fca8b970340642ca04ce76c7fc34ced"
   integrity sha512-HaL/gEyFVvkf9KFg6484wR9s0qjAXlZ8qWPDkTyKF6+zqjBe/I2mygg3MbpZ++hdi0ToqNUF8cjj7fBy0dg8Ug==
   dependencies:
     "@changesets/errors" "^0.2.0"
@@ -1260,14 +1266,14 @@
     "@manypkg/get-packages" "^1.1.3"
     fs-extra "^7.0.1"
 
-"@changesets/read@^0.6.5":
-  version "0.6.5"
-  resolved "https://registry.npmjs.org/@changesets/read/-/read-0.6.5.tgz"
-  integrity sha512-UPzNGhsSjHD3Veb0xO/MwvasGe8eMyNrR/sT9gR8Q3DhOQZirgKhhXv/8hVsI0QpPjR004Z9iFxoJU6in3uGMg==
+"@changesets/read@^0.6.7":
+  version "0.6.7"
+  resolved "https://registry.yarnpkg.com/@changesets/read/-/read-0.6.7.tgz#65e144c960344b34ae8bd85144752a4b687e92d2"
+  integrity sha512-D1G4AUYGrBEk8vj8MGwf75k9GpN6XL3wg8i42P2jZZwFLXnlr2Pn7r9yuQNbaMCarP7ZQWNJbV6XLeysAIMhTA==
   dependencies:
     "@changesets/git" "^3.0.4"
     "@changesets/logger" "^0.1.1"
-    "@changesets/parse" "^0.4.1"
+    "@changesets/parse" "^0.4.3"
     "@changesets/types" "^6.1.0"
     fs-extra "^7.0.1"
     p-filter "^2.1.0"
@@ -1275,7 +1281,7 @@
 
 "@changesets/should-skip-package@^0.1.2":
   version "0.1.2"
-  resolved "https://registry.npmjs.org/@changesets/should-skip-package/-/should-skip-package-0.1.2.tgz"
+  resolved "https://registry.yarnpkg.com/@changesets/should-skip-package/-/should-skip-package-0.1.2.tgz#c018e1e05eab3d97afa4c4590f2b0db7486ae488"
   integrity sha512-qAK/WrqWLNCP22UDdBTMPH5f41elVDlsNyat180A33dWxuUDyNpg6fPi/FyTZwRriVjg0L8gnjJn2F9XAoF0qw==
   dependencies:
     "@changesets/types" "^6.1.0"
@@ -1288,12 +1294,12 @@
 
 "@changesets/types@^6.1.0":
   version "6.1.0"
-  resolved "https://registry.npmjs.org/@changesets/types/-/types-6.1.0.tgz"
+  resolved "https://registry.yarnpkg.com/@changesets/types/-/types-6.1.0.tgz#12a4c8490827d26bc6fbf97a151499be2fb6d2f5"
   integrity sha512-rKQcJ+o1nKNgeoYRHKOS07tAMNd3YSN0uHaJOZYjBAgxfV7TUE7JE+z4BzZdQwb5hKaYbayKN5KrYV7ODb2rAA==
 
 "@changesets/write@^0.4.0":
   version "0.4.0"
-  resolved "https://registry.npmjs.org/@changesets/write/-/write-0.4.0.tgz"
+  resolved "https://registry.yarnpkg.com/@changesets/write/-/write-0.4.0.tgz#ec903cbd8aa9b6da6fa09ef19fb609eedd115ed6"
   integrity sha512-CdTLvIOPiCNuH71pyDu3rA+Q0n65cmAbXnwWH84rKGiFumFzkmHNT8KHTMEchcxN+Kl8I54xGUhJ7l3E7X396Q==
   dependencies:
     "@changesets/types" "^6.1.0"
@@ -1303,7 +1309,7 @@
 
 "@cheqd/sdk@5.5.1":
   version "5.5.1"
-  resolved "https://registry.yarnpkg.com/@cheqd/sdk/-/sdk-5.5.1.tgz#241340a57d219c9a6fac6112a2b0f86d3acab0ed"
+  resolved "https://registry.npmjs.org/@cheqd/sdk/-/sdk-5.5.1.tgz"
   integrity sha512-azd+xG0poZxayF6iGfwXs/HPSaxREabLPxauXAfNhuSBA8BIqoE12giNBjGM+Lhq+dvg02PSy+riS2YU9jXk0A==
   dependencies:
     "@cheqd/ts-proto" "^4.2.0"
@@ -1358,13 +1364,13 @@
     protobufjs "^7.4.0"
 
 "@cheqd/ts-proto@^4.2.0":
-  version "4.2.1"
-  resolved "https://registry.npmjs.org/@cheqd/ts-proto/-/ts-proto-4.2.1.tgz"
-  integrity sha512-8O15Qaj/lyb/zNsKlUfP79XDnZw7lEToeONV8ji04AkFKf+hzPQNXhTMWp7Wf/vywUEzrHYZa1I4DITT6QmCJA==
+  version "4.2.0"
+  resolved "https://registry.npmjs.org/@cheqd/ts-proto/-/ts-proto-4.2.0.tgz"
+  integrity sha512-0/pKFSDtERs5euLW0mcry3Lr9mguDY3Sr+W9uzs7Iru6HEBxs+LjwcpaFr9073wlsKF9fLhsCDHvDJDwNxePkg==
   dependencies:
     "@bufbuild/protobuf" "^2.5.1"
     long "^5.3.2"
-    protobufjs "^8.0.0"
+    protobufjs "^7.5.3"
 
 "@colors/colors@1.6.0", "@colors/colors@^1.6.0":
   version "1.6.0"
@@ -1379,13 +1385,13 @@
     "@comunica/core" "^2.10.0"
     "@comunica/types" "^2.10.0"
 
-"@comunica/actor-abstract-mediatyped@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-abstract-mediatyped/-/actor-abstract-mediatyped-4.2.0.tgz"
-  integrity sha512-+7NuPZQAi7iRJ1Cie9qqhbJjBv0/SadA/24+KrDVU4+4QM6n5usCKibA8D84Nqgt257IsrFrb2G7NndTZ6taww==
+"@comunica/actor-abstract-mediatyped@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-abstract-mediatyped/-/actor-abstract-mediatyped-4.5.0.tgz#66f6528e60c6d77e11c4c7bc65ed64aaf29a4f8d"
+  integrity sha512-KbLuhbTcfAQHJeLo3CDDdffCZdfA1qDu15XIdW+7P03UpUp9xMw4p1G0kYtoXwj9KzWguY704TUtpJVBO1GOnw==
   dependencies:
-    "@comunica/core" "^4.2.0"
-    "@comunica/types" "^4.2.0"
+    "@comunica/core" "^4.5.0"
+    "@comunica/types" "^4.5.0"
 
 "@comunica/actor-abstract-parse@^2.10.0":
   version "2.10.0"
@@ -1395,943 +1401,943 @@
     "@comunica/core" "^2.10.0"
     readable-stream "^4.4.2"
 
-"@comunica/actor-abstract-parse@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-abstract-parse/-/actor-abstract-parse-4.2.0.tgz"
-  integrity sha512-WUHr9Bhr3Z7eJ2GtSGnhj1xCXCarKkC82WPorlG+RhuPuryp152GtJYtdyBIR4pEetP2hL4n+VuvHjXY80LWbQ==
+"@comunica/actor-abstract-parse@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-abstract-parse/-/actor-abstract-parse-4.5.0.tgz#5b5d1ba828c134dc3e4259fad81ed047f37ba9a8"
+  integrity sha512-THNdQsJ58HtkyeW9ghVyLrYEQfSPNfmVAJTDSqOxIujjCdimPbzS2LBXoDdw13GuxWWOATssbm1LwXDlX0xMIQ==
   dependencies:
-    "@comunica/core" "^4.2.0"
+    "@comunica/core" "^4.5.0"
     readable-stream "^4.5.2"
 
-"@comunica/actor-abstract-path@^4.3.0":
-  version "4.3.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-abstract-path/-/actor-abstract-path-4.3.0.tgz"
-  integrity sha512-YESgq6YfNH93dLCBsEaqxhu8XFPEelp3tQay2y77d/cQr95e4+l89R9TXWjxb94L9q20CYFQsXmYM79A7FNcJA==
+"@comunica/actor-abstract-path@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-abstract-path/-/actor-abstract-path-4.5.0.tgz#8fd80a0679f02cd64e321d26b23dd3208a589b26"
+  integrity sha512-oBm9rqCCNErmn570UjhMKa4XSM4NxQ/HtgGw7P0HTR0jx/LBg5ctkmsp0ewSJSx+OVf2fU4S7hodZgsS7jypLw==
   dependencies:
-    "@comunica/bus-query-operation" "^4.2.0"
-    "@comunica/context-entries" "^4.2.0"
-    "@comunica/core" "^4.2.0"
-    "@comunica/types" "^4.2.0"
-    "@comunica/utils-bindings-factory" "^4.2.0"
-    "@comunica/utils-query-operation" "^4.2.0"
+    "@comunica/bus-query-operation" "^4.5.0"
+    "@comunica/context-entries" "^4.5.0"
+    "@comunica/core" "^4.5.0"
+    "@comunica/types" "^4.5.0"
+    "@comunica/utils-bindings-factory" "^4.5.0"
+    "@comunica/utils-query-operation" "^4.5.0"
     "@rdfjs/types" "*"
     asynciterator "^3.9.0"
     rdf-string "^1.6.1"
-    sparqlalgebrajs "^4.3.8"
+    sparqlalgebrajs "^5.0.2"
 
-"@comunica/actor-bindings-aggregator-factory-average@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-bindings-aggregator-factory-average/-/actor-bindings-aggregator-factory-average-4.2.0.tgz"
-  integrity sha512-VXVPsfVB801cXFfAMwnURTsOFrPYUB1qxxQNen1rlV0DVAFJw4kbgmdJLbnmBOR8Job7jx0JqQh5hKvl6uJP9w==
+"@comunica/actor-bindings-aggregator-factory-average@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-bindings-aggregator-factory-average/-/actor-bindings-aggregator-factory-average-4.5.0.tgz#99827f5d74d2695d9b3a8f54200a944107a667fd"
+  integrity sha512-QQIVsCMzi+AvaTDegSZVcc2wjBszFAVayUfNEe/OW6xvXMXKmLiEdA+5q5MSJYcfDIciwR0FR3mTFJx34GgSGQ==
   dependencies:
-    "@comunica/bus-bindings-aggregator-factory" "^4.2.0"
-    "@comunica/bus-function-factory" "^4.2.0"
-    "@comunica/context-entries" "^4.2.0"
-    "@comunica/core" "^4.2.0"
-    "@comunica/types" "^4.2.0"
-    "@comunica/utils-expression-evaluator" "^4.2.0"
+    "@comunica/bus-bindings-aggregator-factory" "^4.5.0"
+    "@comunica/bus-function-factory" "^4.5.0"
+    "@comunica/context-entries" "^4.5.0"
+    "@comunica/core" "^4.5.0"
+    "@comunica/types" "^4.5.0"
+    "@comunica/utils-expression-evaluator" "^4.5.0"
     "@rdfjs/types" "*"
 
-"@comunica/actor-bindings-aggregator-factory-count@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-bindings-aggregator-factory-count/-/actor-bindings-aggregator-factory-count-4.2.0.tgz"
-  integrity sha512-wCo+ezCKYCDrzNwg07i9Z9xfBHHLKQLS10ImTEDMpjRNshR4GWgWB9saHQi2COEsBMTERBpEHADB4BZTx8FC6w==
+"@comunica/actor-bindings-aggregator-factory-count@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-bindings-aggregator-factory-count/-/actor-bindings-aggregator-factory-count-4.5.0.tgz#1ecd07ef71a8f416d8c04dae8ae22887b07b28da"
+  integrity sha512-BExT1O1b0oP3DVjArcFPLTjFyycShz3ineh7G4ccZ2D+h1xo3dWbCcCNvnOTBnP6XBRtvpgfHLqz2i9C/Hs8SA==
   dependencies:
-    "@comunica/bus-bindings-aggregator-factory" "^4.2.0"
-    "@comunica/core" "^4.2.0"
-    "@comunica/types" "^4.2.0"
-    "@comunica/utils-expression-evaluator" "^4.2.0"
+    "@comunica/bus-bindings-aggregator-factory" "^4.5.0"
+    "@comunica/core" "^4.5.0"
+    "@comunica/types" "^4.5.0"
+    "@comunica/utils-expression-evaluator" "^4.5.0"
     "@rdfjs/types" "*"
-    sparqlalgebrajs "^4.2.0"
+    sparqlalgebrajs "^5.0.2"
 
-"@comunica/actor-bindings-aggregator-factory-group-concat@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-bindings-aggregator-factory-group-concat/-/actor-bindings-aggregator-factory-group-concat-4.2.0.tgz"
-  integrity sha512-Npn5Jco1vZLc5tmYe2eRgENEYFXdjuHrIjYagmA74wdw/cWUei74XE2zN1y2G4hW2DmvLVS9WXQ5ww9t0qxdzA==
+"@comunica/actor-bindings-aggregator-factory-group-concat@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-bindings-aggregator-factory-group-concat/-/actor-bindings-aggregator-factory-group-concat-4.5.0.tgz#d440de7e70c4b90ad8f9a4c5c1d8e672485e71bc"
+  integrity sha512-Gpm2uLDc7mCiE0xt1KX/bKVRXXGNyclq/jJ3zKx+QPftB4z8IFvsTUzt4WuimBYawU0OvM6CUlr6Y3pdY6k4qA==
   dependencies:
-    "@comunica/bus-bindings-aggregator-factory" "^4.2.0"
-    "@comunica/context-entries" "^4.2.0"
-    "@comunica/core" "^4.2.0"
-    "@comunica/types" "^4.2.0"
-    "@comunica/utils-expression-evaluator" "^4.2.0"
-    "@rdfjs/types" "*"
-
-"@comunica/actor-bindings-aggregator-factory-max@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-bindings-aggregator-factory-max/-/actor-bindings-aggregator-factory-max-4.2.0.tgz"
-  integrity sha512-T5ApKSMavbKyALe4PadgBQSj4AE2fa0yk6+tUiKRFr0I5WqMyoj57x3SWasVtWXssk/LySyT+PNQzr5c4tlc9w==
-  dependencies:
-    "@comunica/bus-bindings-aggregator-factory" "^4.2.0"
-    "@comunica/core" "^4.2.0"
-    "@comunica/types" "^4.2.0"
+    "@comunica/bus-bindings-aggregator-factory" "^4.5.0"
+    "@comunica/context-entries" "^4.5.0"
+    "@comunica/core" "^4.5.0"
+    "@comunica/types" "^4.5.0"
+    "@comunica/utils-expression-evaluator" "^4.5.0"
     "@rdfjs/types" "*"
 
-"@comunica/actor-bindings-aggregator-factory-min@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-bindings-aggregator-factory-min/-/actor-bindings-aggregator-factory-min-4.2.0.tgz"
-  integrity sha512-kUv1v0pqJrrrmOhx+SfLXMafreJAn48Phb5xcTT7UqyYTQO+WYGa3pXp2+P+9QfitreR4At58FNsv1lz5f9pAw==
+"@comunica/actor-bindings-aggregator-factory-max@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-bindings-aggregator-factory-max/-/actor-bindings-aggregator-factory-max-4.5.0.tgz#c1b1bf419078735138c4112decdb372736a5d23d"
+  integrity sha512-iJZ/NF8s5UhokHIVOCk4fuu8glWH354Oyg2p/VvtBMAXu3x/U3M5EAofsoIGCjwkqcOrknVqG1VGywHgglIAuQ==
   dependencies:
-    "@comunica/bus-bindings-aggregator-factory" "^4.2.0"
-    "@comunica/core" "^4.2.0"
-    "@comunica/types" "^4.2.0"
+    "@comunica/bus-bindings-aggregator-factory" "^4.5.0"
+    "@comunica/core" "^4.5.0"
+    "@comunica/types" "^4.5.0"
     "@rdfjs/types" "*"
 
-"@comunica/actor-bindings-aggregator-factory-sample@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-bindings-aggregator-factory-sample/-/actor-bindings-aggregator-factory-sample-4.2.0.tgz"
-  integrity sha512-uV+3rrTfOAHricPHcuGPRVkufOfsBzQFM7Fa19/bmaZbWiouVS22bwAeQhQbUJXmQ4uU79kCD+eYXOKw689t/Q==
+"@comunica/actor-bindings-aggregator-factory-min@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-bindings-aggregator-factory-min/-/actor-bindings-aggregator-factory-min-4.5.0.tgz#afb307c419832760e2f5c4da64a7f561ac8a8205"
+  integrity sha512-dHkJvOrTr8fLpu0d1HLsssZQov0PdKlFgZczl5gZ/gpTvKUnpaMcI7uSi/FWkbEyZFtJH+mw2Vb9BmVuSnmzkg==
   dependencies:
-    "@comunica/bus-bindings-aggregator-factory" "^4.2.0"
-    "@comunica/core" "^4.2.0"
-    "@comunica/types" "^4.2.0"
+    "@comunica/bus-bindings-aggregator-factory" "^4.5.0"
+    "@comunica/core" "^4.5.0"
+    "@comunica/types" "^4.5.0"
     "@rdfjs/types" "*"
 
-"@comunica/actor-bindings-aggregator-factory-sum@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-bindings-aggregator-factory-sum/-/actor-bindings-aggregator-factory-sum-4.2.0.tgz"
-  integrity sha512-Zh4Fr3IUiPFhr6cv/B49JBshOJHwEHZQ0qKsYN0ZTHc4YVA58/aveufhQX75Ijr/NU8wl9s7XRsy4/PZPk0SDA==
+"@comunica/actor-bindings-aggregator-factory-sample@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-bindings-aggregator-factory-sample/-/actor-bindings-aggregator-factory-sample-4.5.0.tgz#ada05e5a3f633300787562d9ffd25b5ff6f05d00"
+  integrity sha512-4IK9MjfLX0pzB74XxqmSJJIySjB0xr4nId96DkRYrJVvFz7PGdZL5ovr7WJEHrCaFZONUQCcJJdTIMxcazfY/Q==
   dependencies:
-    "@comunica/bus-bindings-aggregator-factory" "^4.2.0"
-    "@comunica/bus-function-factory" "^4.2.0"
-    "@comunica/context-entries" "^4.2.0"
-    "@comunica/core" "^4.2.0"
-    "@comunica/types" "^4.2.0"
-    "@comunica/utils-expression-evaluator" "^4.2.0"
+    "@comunica/bus-bindings-aggregator-factory" "^4.5.0"
+    "@comunica/core" "^4.5.0"
+    "@comunica/types" "^4.5.0"
     "@rdfjs/types" "*"
 
-"@comunica/actor-bindings-aggregator-factory-wildcard-count@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-bindings-aggregator-factory-wildcard-count/-/actor-bindings-aggregator-factory-wildcard-count-4.2.0.tgz"
-  integrity sha512-tBYD4aFjeqPMzYGnCdxngYh6Xwi7rbRE/60jTXy8O3TMiHjt2ogCDxF4qMlO6VJGWVb8Sg2ZTFciuNDwPR28HA==
+"@comunica/actor-bindings-aggregator-factory-sum@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-bindings-aggregator-factory-sum/-/actor-bindings-aggregator-factory-sum-4.5.0.tgz#1d621445ec5eba7a31bb3503e5e7e3e7e2cdbfda"
+  integrity sha512-uw3s58igOuHAFLLXr5mS9nVFfA5V5fWxeyln2o/ggipLyDOVKCtkm0GHtx5oZTBNSdyrN2s7SrATdL9ouLbJMw==
   dependencies:
-    "@comunica/bus-bindings-aggregator-factory" "^4.2.0"
-    "@comunica/core" "^4.2.0"
-    "@comunica/types" "^4.2.0"
-    "@comunica/utils-expression-evaluator" "^4.2.0"
+    "@comunica/bus-bindings-aggregator-factory" "^4.5.0"
+    "@comunica/bus-function-factory" "^4.5.0"
+    "@comunica/context-entries" "^4.5.0"
+    "@comunica/core" "^4.5.0"
+    "@comunica/types" "^4.5.0"
+    "@comunica/utils-expression-evaluator" "^4.5.0"
+    "@rdfjs/types" "*"
+
+"@comunica/actor-bindings-aggregator-factory-wildcard-count@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-bindings-aggregator-factory-wildcard-count/-/actor-bindings-aggregator-factory-wildcard-count-4.5.0.tgz#ed5b0d44bf18a14fb8f539a0112509860c351522"
+  integrity sha512-2D+uykC2LmwmgjQnDaGM5dOJf7CIAetRHUlL29P6WA5J3iWVuRZurIVajexvi7yufk+emajuTGnGuZIeB00SnA==
+  dependencies:
+    "@comunica/bus-bindings-aggregator-factory" "^4.5.0"
+    "@comunica/core" "^4.5.0"
+    "@comunica/types" "^4.5.0"
+    "@comunica/utils-expression-evaluator" "^4.5.0"
     "@rdfjs/types" "*"
     rdf-string "^1.6.3"
 
-"@comunica/actor-context-preprocess-convert-shortcuts@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-context-preprocess-convert-shortcuts/-/actor-context-preprocess-convert-shortcuts-4.2.0.tgz"
-  integrity sha512-M1ruybVTRaaRkLBKlCDyLYOvxeDvFTW28R2USnTxoqMSYEA8kt4Wl7WHq3CeswCQjJy09MzNFsMieUplJXcJsA==
+"@comunica/actor-context-preprocess-convert-shortcuts@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-context-preprocess-convert-shortcuts/-/actor-context-preprocess-convert-shortcuts-4.5.0.tgz#ae114360b1d0f53fe5cf73159213c5a3bfbd9567"
+  integrity sha512-Uu2buxdBxq/0u6Pr/An4FDdafH1bvDCdImeEBBIVfleeYuUNR4klbXZS0M7YxTpYanpNOw9v/i6nHIfNMgFT7w==
   dependencies:
-    "@comunica/bus-context-preprocess" "^4.2.0"
-    "@comunica/core" "^4.2.0"
-    "@comunica/types" "^4.2.0"
+    "@comunica/bus-context-preprocess" "^4.5.0"
+    "@comunica/core" "^4.5.0"
+    "@comunica/types" "^4.5.0"
 
-"@comunica/actor-context-preprocess-query-source-identify@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-context-preprocess-query-source-identify/-/actor-context-preprocess-query-source-identify-4.2.0.tgz"
-  integrity sha512-5Y1FgCjDxuZVdaHFeBr71pIcDO++kIuHEiXqSi2JN4JjAv/if7Ds2Y7xkyU5c3Ql9Qh5G7rkFZ37jvpW+hiu/g==
+"@comunica/actor-context-preprocess-query-source-identify@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-context-preprocess-query-source-identify/-/actor-context-preprocess-query-source-identify-4.5.0.tgz#91d693751fbc0a8e1b714864817ec6f1deaee281"
+  integrity sha512-iabRMWYIvolhN90lREOW/nvHY2JmF+oRrQUsELFjyDQnEirY0IHFl7kUskn8RvGoLmgPCKD9nIB3yNPgL/Ggpg==
   dependencies:
-    "@comunica/bus-context-preprocess" "^4.2.0"
-    "@comunica/bus-http-invalidate" "^4.2.0"
-    "@comunica/bus-query-source-identify" "^4.2.0"
-    "@comunica/context-entries" "^4.2.0"
-    "@comunica/core" "^4.2.0"
-    "@comunica/types" "^4.2.0"
+    "@comunica/bus-context-preprocess" "^4.5.0"
+    "@comunica/bus-http-invalidate" "^4.5.0"
+    "@comunica/bus-query-source-identify" "^4.5.0"
+    "@comunica/context-entries" "^4.5.0"
+    "@comunica/core" "^4.5.0"
+    "@comunica/types" "^4.5.0"
     lru-cache "^10.0.0"
 
-"@comunica/actor-context-preprocess-query-source-skolemize@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-context-preprocess-query-source-skolemize/-/actor-context-preprocess-query-source-skolemize-4.2.0.tgz"
-  integrity sha512-5QL1DI0vBeCRDJItM1LfM+vk1G2kUi1CpSb4uAwaa8o8hkwdExtWXguPp+w8GCk/h5ot4P23vgWgwZTZ3nwW2A==
+"@comunica/actor-context-preprocess-query-source-skolemize@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-context-preprocess-query-source-skolemize/-/actor-context-preprocess-query-source-skolemize-4.5.0.tgz#978b0ec8bf7e4251fd8c465546eaa564f19af0d7"
+  integrity sha512-BTzlIXHFcX4+tniNAnnh+whGVy7Cy0Gsj57O3jcPjFYdj1Z0AFRValT28G1sYn0avPYoOE9JDAM5cgZVdxUHHg==
   dependencies:
-    "@comunica/bus-context-preprocess" "^4.2.0"
-    "@comunica/context-entries" "^4.2.0"
-    "@comunica/core" "^4.2.0"
-    "@comunica/types" "^4.2.0"
+    "@comunica/bus-context-preprocess" "^4.5.0"
+    "@comunica/context-entries" "^4.5.0"
+    "@comunica/core" "^4.5.0"
+    "@comunica/types" "^4.5.0"
     "@comunica/utils-data-factory" "^4.0.1"
-    "@comunica/utils-metadata" "^4.2.0"
+    "@comunica/utils-metadata" "^4.5.0"
     "@rdfjs/types" "*"
     asynciterator "^3.9.0"
     rdf-terms "^1.11.0"
-    sparqlalgebrajs "^4.3.8"
+    sparqlalgebrajs "^5.0.2"
 
-"@comunica/actor-context-preprocess-set-defaults@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-context-preprocess-set-defaults/-/actor-context-preprocess-set-defaults-4.2.0.tgz"
-  integrity sha512-opUbREA93zVZc9OgPvWYQ3UGZy/WvS4d7bQ8FAcQxfv6zPR6UPC5gCC9/iPMa8f1zFSndj71vd+8AY8JqoB3lA==
+"@comunica/actor-context-preprocess-set-defaults@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-context-preprocess-set-defaults/-/actor-context-preprocess-set-defaults-4.5.0.tgz#3bc96a54ea00bb667872da557466db547d332ba1"
+  integrity sha512-xEm7KPg9G6IcciLbZ2tJ0v6vrluuy/fCZN2wCOYQ1ba6bgxZm/C15kFTwjm4YSsDhtQDADteiQZa+kzkBkuudQ==
   dependencies:
-    "@comunica/bus-context-preprocess" "^4.2.0"
-    "@comunica/context-entries" "^4.2.0"
-    "@comunica/core" "^4.2.0"
-    "@comunica/types" "^4.2.0"
+    "@comunica/bus-context-preprocess" "^4.5.0"
+    "@comunica/context-entries" "^4.5.0"
+    "@comunica/core" "^4.5.0"
+    "@comunica/types" "^4.5.0"
     "@rdfjs/types" "*"
     rdf-data-factory "^1.1.2"
 
-"@comunica/actor-context-preprocess-source-to-destination@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-context-preprocess-source-to-destination/-/actor-context-preprocess-source-to-destination-4.2.0.tgz"
-  integrity sha512-s3CkLRLQnHWRzZF44vsuRjxslcEK3hH4CnvkSv3SIrHFVuzIrbUFYDUBvuaFmQJFDLmFJEwk7G49MCWh1RmofQ==
+"@comunica/actor-context-preprocess-source-to-destination@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-context-preprocess-source-to-destination/-/actor-context-preprocess-source-to-destination-4.5.0.tgz#21d1ddbc6b7297f2112202beacbe75ea42010919"
+  integrity sha512-ndpws/8GzO8CsOuqYS4f4IJ5DXNaCGjp7LXcabeAGobY8F5B3eQ8zWKHjC3jZEaTt89rCiMzkudY2sNWGM0ZbA==
   dependencies:
-    "@comunica/bus-context-preprocess" "^4.2.0"
-    "@comunica/context-entries" "^4.2.0"
-    "@comunica/core" "^4.2.0"
-    "@comunica/types" "^4.2.0"
+    "@comunica/bus-context-preprocess" "^4.5.0"
+    "@comunica/context-entries" "^4.5.0"
+    "@comunica/core" "^4.5.0"
+    "@comunica/types" "^4.5.0"
 
-"@comunica/actor-expression-evaluator-factory-default@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-expression-evaluator-factory-default/-/actor-expression-evaluator-factory-default-4.2.0.tgz"
-  integrity sha512-LrAySdpna3PdyW67emqIezNGIANsB5XDV38V8IeLiCiK5L1eIIZtk9izHSHhj/aEEWJSsLn7LTzBQcE8a8tjaw==
+"@comunica/actor-expression-evaluator-factory-default@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-expression-evaluator-factory-default/-/actor-expression-evaluator-factory-default-4.5.0.tgz#324378fd2c1d4723a57d8eb289320ed3109e6013"
+  integrity sha512-1vXRPmcRBTwowYu9FAjEiHeaQv3m2rzhB2jqh/USoPFm0Zn4oR5Xdclyv3WfuhNJRaJWi2uB6P5ddRzimTuTCg==
   dependencies:
-    "@comunica/bus-expression-evaluator-factory" "^4.2.0"
-    "@comunica/bus-function-factory" "^4.2.0"
-    "@comunica/bus-query-operation" "^4.2.0"
-    "@comunica/context-entries" "^4.2.0"
-    "@comunica/core" "^4.2.0"
-    "@comunica/types" "^4.2.0"
-    "@comunica/utils-bindings-factory" "^4.2.0"
-    "@comunica/utils-expression-evaluator" "^4.2.0"
-    "@comunica/utils-query-operation" "^4.2.0"
+    "@comunica/bus-expression-evaluator-factory" "^4.5.0"
+    "@comunica/bus-function-factory" "^4.5.0"
+    "@comunica/bus-query-operation" "^4.5.0"
+    "@comunica/context-entries" "^4.5.0"
+    "@comunica/core" "^4.5.0"
+    "@comunica/types" "^4.5.0"
+    "@comunica/utils-bindings-factory" "^4.5.0"
+    "@comunica/utils-expression-evaluator" "^4.5.0"
+    "@comunica/utils-query-operation" "^4.5.0"
     "@rdfjs/types" "*"
-    sparqlalgebrajs "^4.3.7"
+    sparqlalgebrajs "^5.0.2"
 
-"@comunica/actor-function-factory-expression-bnode@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-function-factory-expression-bnode/-/actor-function-factory-expression-bnode-4.2.0.tgz"
-  integrity sha512-s67te7Rts2g+JBmWOcM6/leOg/UB4ilH6Pn0aVeDC3cILn0WuZkqOfMiVlkbvZ/D9sG7eKH/nyPqsoSylUq0HA==
+"@comunica/actor-function-factory-expression-bnode@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-expression-bnode/-/actor-function-factory-expression-bnode-4.5.0.tgz#b89542a87e693d8165f9eda068b4a8b255152780"
+  integrity sha512-wIj6ertjQBSSiV6Kbk0h6AuxjQe/IUVJGGBuZRu+VvCdGTX+I/rY00/LdUzzbdMFJgamEwK5ML/Bwu2tZUFN3w==
   dependencies:
-    "@comunica/bus-function-factory" "^4.2.0"
-    "@comunica/context-entries" "^4.2.0"
-    "@comunica/types" "^4.2.0"
+    "@comunica/bus-function-factory" "^4.5.0"
+    "@comunica/context-entries" "^4.5.0"
+    "@comunica/types" "^4.5.0"
     "@comunica/utils-data-factory" "^4.0.1"
-    "@comunica/utils-expression-evaluator" "^4.2.0"
+    "@comunica/utils-expression-evaluator" "^4.5.0"
 
-"@comunica/actor-function-factory-expression-bound@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-function-factory-expression-bound/-/actor-function-factory-expression-bound-4.2.0.tgz"
-  integrity sha512-SU5V0ndU921PjPyX5kUqt5/91ILD+vXz5f+DvkIC5iZqNuVZ0jbXGMAKxQ1Dcy78SN5ll4z0LOIwBx3SyD2ItQ==
+"@comunica/actor-function-factory-expression-bound@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-expression-bound/-/actor-function-factory-expression-bound-4.5.0.tgz#7a80051ca134047515113b20d2a06519b66f6144"
+  integrity sha512-aClq0SWhyhL3G9HRlri0yyyVcb/gCdexXi3HHiWhI9udBK+oAZeOR/lM49i7/twS5ujPHE/CzbL6C0gtosZzvA==
   dependencies:
-    "@comunica/bus-function-factory" "^4.2.0"
-    "@comunica/context-entries" "^4.2.0"
-    "@comunica/types" "^4.2.0"
-    "@comunica/utils-expression-evaluator" "^4.2.0"
+    "@comunica/bus-function-factory" "^4.5.0"
+    "@comunica/context-entries" "^4.5.0"
+    "@comunica/types" "^4.5.0"
+    "@comunica/utils-expression-evaluator" "^4.5.0"
 
-"@comunica/actor-function-factory-expression-coalesce@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-function-factory-expression-coalesce/-/actor-function-factory-expression-coalesce-4.2.0.tgz"
-  integrity sha512-c9t33f/EBfCK4361orkjEhWMEK/eUBkml6xts3eoV2B/aw6fmz2Kht4uve3GX+veTTs7vEW8IjeCmDANxvOvTA==
+"@comunica/actor-function-factory-expression-coalesce@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-expression-coalesce/-/actor-function-factory-expression-coalesce-4.5.0.tgz#9424c9854c35e702e336da6fe84b3e79470b5590"
+  integrity sha512-xD8oGIsKkzaEvzb7j2HMXzJfRi1onRCaUXRmVVWhf2sWA2YIoQWoG3nHMOAucMseo2FDcY+vYN2pIiSts+C2ng==
   dependencies:
-    "@comunica/bus-function-factory" "^4.2.0"
-    "@comunica/utils-expression-evaluator" "^4.2.0"
+    "@comunica/bus-function-factory" "^4.5.0"
+    "@comunica/utils-expression-evaluator" "^4.5.0"
 
-"@comunica/actor-function-factory-expression-concat@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-function-factory-expression-concat/-/actor-function-factory-expression-concat-4.2.0.tgz"
-  integrity sha512-S+YtHwxnkwedZUE8MDcZYDYiuFCXmmaaWXZIfkbmkm2u5v0fv1NP1UMuEyoLHPHg+COZ4YUmn/dC+vx03fQI+A==
+"@comunica/actor-function-factory-expression-concat@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-expression-concat/-/actor-function-factory-expression-concat-4.5.0.tgz#573bb4db0ba1cbd9f92b43c472220775d1dc40d1"
+  integrity sha512-zaNB23vpQkr+49MfBr2fnjahVEb0jTzUjOKO1Hxrb8geocB0coHAhQljejghATCRwnnsnWwcCeOvVE0bjCoU6A==
   dependencies:
-    "@comunica/bus-function-factory" "^4.2.0"
-    "@comunica/context-entries" "^4.2.0"
-    "@comunica/utils-expression-evaluator" "^4.2.0"
+    "@comunica/bus-function-factory" "^4.5.0"
+    "@comunica/context-entries" "^4.5.0"
+    "@comunica/utils-expression-evaluator" "^4.5.0"
 
-"@comunica/actor-function-factory-expression-extensions@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-function-factory-expression-extensions/-/actor-function-factory-expression-extensions-4.2.0.tgz"
-  integrity sha512-88n8WY2wqKKoCRknf/FFUkxBmpCDnG8e35czIIajwzSN4ks5Hiaf4A7m4dm/2ppoxevilz53SollC+Q4gA8iRA==
+"@comunica/actor-function-factory-expression-extensions@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-expression-extensions/-/actor-function-factory-expression-extensions-4.5.0.tgz#e1b5f9d65a231ee43e3815ee7317c04cba3c2c1b"
+  integrity sha512-wCF5jGU/MtTCL3vO0jImgwzthKDqSjJP8D+kK3Y9Sj4j6xumaF+cttj5EoflzK68uvkhhuMLsZY0PKLGkAnvXA==
   dependencies:
-    "@comunica/bus-function-factory" "^4.2.0"
-    "@comunica/context-entries" "^4.2.0"
-    "@comunica/core" "^4.2.0"
-    "@comunica/types" "^4.2.0"
-    "@comunica/utils-expression-evaluator" "^4.2.0"
+    "@comunica/bus-function-factory" "^4.5.0"
+    "@comunica/context-entries" "^4.5.0"
+    "@comunica/core" "^4.5.0"
+    "@comunica/types" "^4.5.0"
+    "@comunica/utils-expression-evaluator" "^4.5.0"
     rdf-data-factory "^1.1.2"
 
-"@comunica/actor-function-factory-expression-if@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-function-factory-expression-if/-/actor-function-factory-expression-if-4.2.0.tgz"
-  integrity sha512-NjQXhjqJmq263NWy9CmcfiR9yU7mWBRmdFpoG0FjITEK/M0Naaw4uqoAc7XqT9/JLVamBGvPRcnLQbnRheL60g==
+"@comunica/actor-function-factory-expression-if@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-expression-if/-/actor-function-factory-expression-if-4.5.0.tgz#30937d057444a4710270980fc8a7fe53aa822b78"
+  integrity sha512-1nE7bXcMVcesnaMABAX7LKKc8PVNeIrg/TJ+LkbZ4LyV4GjUu0zQspuFRFFp/HMfpYOfO1pmhP3Y+kdVkRuFpQ==
   dependencies:
-    "@comunica/bus-function-factory" "^4.2.0"
-    "@comunica/types" "^4.2.0"
-    "@comunica/utils-expression-evaluator" "^4.2.0"
+    "@comunica/bus-function-factory" "^4.5.0"
+    "@comunica/types" "^4.5.0"
+    "@comunica/utils-expression-evaluator" "^4.5.0"
 
-"@comunica/actor-function-factory-expression-in@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-function-factory-expression-in/-/actor-function-factory-expression-in-4.2.0.tgz"
-  integrity sha512-fcvuCduoXIR+tnfFLDoXhAmlVN2883F7cekVxae1uohDbhC0T+R34N/oipw7TlnYucNlFcG3anpOj1KyEgM6ng==
+"@comunica/actor-function-factory-expression-in@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-expression-in/-/actor-function-factory-expression-in-4.5.0.tgz#05b48b05e3208abb2a188f9a3d6a7f89eb97a7a3"
+  integrity sha512-ubIy7q0VmO8f/ffuXWPkhjKSI7+r1toltgGonunb9VJVmNe7IbpMKIdSiw0PtAyeZMavp/f5d7uIjYfgYbCsbw==
   dependencies:
-    "@comunica/bus-function-factory" "^4.2.0"
-    "@comunica/types" "^4.2.0"
-    "@comunica/utils-expression-evaluator" "^4.2.0"
+    "@comunica/bus-function-factory" "^4.5.0"
+    "@comunica/types" "^4.5.0"
+    "@comunica/utils-expression-evaluator" "^4.5.0"
 
-"@comunica/actor-function-factory-expression-logical-and@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-function-factory-expression-logical-and/-/actor-function-factory-expression-logical-and-4.2.0.tgz"
-  integrity sha512-M18sNb0kDItuf6z8oOLESWenLXLeEuw8NU+H1LB9sFe5S/MWGbj+mKsKTM+4+TsfsUUBXPtdYz68P6QmZo/HTw==
+"@comunica/actor-function-factory-expression-logical-and@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-expression-logical-and/-/actor-function-factory-expression-logical-and-4.5.0.tgz#e3603edb4dbbfd6f3fe454f3910f065629cfcd24"
+  integrity sha512-8Eawz0jPMmP7JFuhtEPwuSBw3hIVpscAuM/RUTOBfsgecjRZTQGMsRJ7LoDgLJVNlevbXoxtzBjL9COjUFBJ1Q==
   dependencies:
-    "@comunica/bus-function-factory" "^4.2.0"
-    "@comunica/types" "^4.2.0"
-    "@comunica/utils-expression-evaluator" "^4.2.0"
+    "@comunica/bus-function-factory" "^4.5.0"
+    "@comunica/types" "^4.5.0"
+    "@comunica/utils-expression-evaluator" "^4.5.0"
 
-"@comunica/actor-function-factory-expression-logical-or@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-function-factory-expression-logical-or/-/actor-function-factory-expression-logical-or-4.2.0.tgz"
-  integrity sha512-HrJJva+8MrC/2Ekj07whjDcDme3li9qo94eNWPt4T5QipgJjoetjcgKmbv8MZT8HnimaHE/Z/joJ0znGE1bLHw==
+"@comunica/actor-function-factory-expression-logical-or@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-expression-logical-or/-/actor-function-factory-expression-logical-or-4.5.0.tgz#7e3acd7321de6c06a0172f40ad5576aff5011f45"
+  integrity sha512-SMJrSpbmOpP1DaHurnM5qm7oWk+dDNaoQZh+8dDCdxz9shSV7eOO7jhjWKhcuZsW6E94G6JSZFZZJkxtmKMrsg==
   dependencies:
-    "@comunica/bus-function-factory" "^4.2.0"
-    "@comunica/types" "^4.2.0"
-    "@comunica/utils-expression-evaluator" "^4.2.0"
+    "@comunica/bus-function-factory" "^4.5.0"
+    "@comunica/types" "^4.5.0"
+    "@comunica/utils-expression-evaluator" "^4.5.0"
 
-"@comunica/actor-function-factory-expression-not-in@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-function-factory-expression-not-in/-/actor-function-factory-expression-not-in-4.2.0.tgz"
-  integrity sha512-bQXdzZPo1GBIXr1mNY5Y2YDnf2WrVtO+wg0GvyoEJyMs0pLp+TLU5Sl9iDtbqZUsvl1Lqq1NVQS0c/O3IzambA==
+"@comunica/actor-function-factory-expression-not-in@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-expression-not-in/-/actor-function-factory-expression-not-in-4.5.0.tgz#bd61ef18f9e280234af3dd8547bbe0497b39a187"
+  integrity sha512-FIJGyTDCXLkz7OmBCB8ed/cCqK2QSmGtwNn/rFh6q9UBrks7A6BzZAH5H/32q6ndcMJwx+6DYb2aQMPlScgRkg==
   dependencies:
-    "@comunica/bus-function-factory" "^4.2.0"
-    "@comunica/types" "^4.2.0"
-    "@comunica/utils-expression-evaluator" "^4.2.0"
+    "@comunica/bus-function-factory" "^4.5.0"
+    "@comunica/types" "^4.5.0"
+    "@comunica/utils-expression-evaluator" "^4.5.0"
 
-"@comunica/actor-function-factory-expression-same-term@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-function-factory-expression-same-term/-/actor-function-factory-expression-same-term-4.2.0.tgz"
-  integrity sha512-8anp3qVn/T1Z6p5XIM0kCR5OPhULkw4ebg8/MKWFmGABJ5CYIfRdzLAxqaFv0whOA6WI3fcriluRscG0YX5zIw==
+"@comunica/actor-function-factory-expression-same-term@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-expression-same-term/-/actor-function-factory-expression-same-term-4.5.0.tgz#1188ed331b69b6eaf4aae1cff155825f3dbe0ddf"
+  integrity sha512-uJxyZl9FXFFXN1Be90cPBLSJqXSVSYxVZ9j+rR4A1I47dc+TfAS/jWkoBsxLCtox3igm6ZkPzmMB066rHN/K5Q==
   dependencies:
-    "@comunica/bus-function-factory" "^4.2.0"
-    "@comunica/context-entries" "^4.2.0"
-    "@comunica/types" "^4.2.0"
-    "@comunica/utils-expression-evaluator" "^4.2.0"
+    "@comunica/bus-function-factory" "^4.5.0"
+    "@comunica/context-entries" "^4.5.0"
+    "@comunica/types" "^4.5.0"
+    "@comunica/utils-expression-evaluator" "^4.5.0"
 
-"@comunica/actor-function-factory-term-abs@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-function-factory-term-abs/-/actor-function-factory-term-abs-4.2.0.tgz"
-  integrity sha512-7VyPSyZ5MWkVlTwuGgp0pQhfVEFeneub7HCP2vLnjvSA4LVZiol98y/oC9p1Y1w8aSoIA4NbTGg4KVXaMPtmUg==
+"@comunica/actor-function-factory-term-abs@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-abs/-/actor-function-factory-term-abs-4.5.0.tgz#9e03d35c696d077b1aec9333588fc5c7e29ae301"
+  integrity sha512-bqupPX30zWCJ0nirI3XkO9uzIuUSnw4jaWNQpI4rHXGdMLrjUNrokBXIZ4FfSXAaAnQOUb771st/XrNbEDJ+gQ==
   dependencies:
-    "@comunica/bus-function-factory" "^4.2.0"
-    "@comunica/utils-expression-evaluator" "^4.2.0"
+    "@comunica/bus-function-factory" "^4.5.0"
+    "@comunica/utils-expression-evaluator" "^4.5.0"
 
-"@comunica/actor-function-factory-term-addition@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-function-factory-term-addition/-/actor-function-factory-term-addition-4.2.0.tgz"
-  integrity sha512-KpqP4AYg7NDRVRbSUvf7n2MOz7dcFwUtEAVaQpDJmcr7Rfy5eAxaFooozaL8MDFOtom/Ekwqafq7tsLe6EzwZQ==
+"@comunica/actor-function-factory-term-addition@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-addition/-/actor-function-factory-term-addition-4.5.0.tgz#e8757a88bb88b3f18c073b95579fcc11fd01ecf7"
+  integrity sha512-pqJIeZFvCas3r4PFy4tGdXFiYR9ds99G87rytAWQkVnoBstOUFKXmc6Oq8dwoKCfAnZdfi/GH++Al8buu2I2Cw==
   dependencies:
-    "@comunica/bus-function-factory" "^4.2.0"
-    "@comunica/utils-expression-evaluator" "^4.2.0"
+    "@comunica/bus-function-factory" "^4.5.0"
+    "@comunica/utils-expression-evaluator" "^4.5.0"
     bignumber.js "^9.1.2"
 
-"@comunica/actor-function-factory-term-ceil@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-function-factory-term-ceil/-/actor-function-factory-term-ceil-4.2.0.tgz"
-  integrity sha512-+xiX6Qz9xP/WX+lBq5TSBHzx89gTeZq/uWdTN0V5q7DskPmpjScdobhtsCSENIB0NPPM+yiXo2TDXl+WdfQDww==
+"@comunica/actor-function-factory-term-ceil@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-ceil/-/actor-function-factory-term-ceil-4.5.0.tgz#0d8c8d9ab987acb7f155a22c5549b647fa8077f3"
+  integrity sha512-Gape3scVRZgvY4DKGSFH5PSRB1TgnpcRJRWiGy9abvP1QXye3Ob4NIqEyO4iwPLd6U7zf3nyHYAec+4MgQp0nQ==
   dependencies:
-    "@comunica/bus-function-factory" "^4.2.0"
-    "@comunica/utils-expression-evaluator" "^4.2.0"
+    "@comunica/bus-function-factory" "^4.5.0"
+    "@comunica/utils-expression-evaluator" "^4.5.0"
 
-"@comunica/actor-function-factory-term-contains@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-function-factory-term-contains/-/actor-function-factory-term-contains-4.2.0.tgz"
-  integrity sha512-t/OE6LJ7qFGd+Ptpe61VeLfa0rZcbj4RuwWQ5NV/FKIOyO+EOVvs3jSnsO2fxx+ecQlmXIoxqYKw28MIHmjMdA==
+"@comunica/actor-function-factory-term-contains@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-contains/-/actor-function-factory-term-contains-4.5.0.tgz#481a3d72a735ad25b808182eaa39f1e7624af256"
+  integrity sha512-qUv31t9RJ+n0OaMcQBLLruTj3u8BdWj69Fq/tF01E8vRkaZgNf0WkAVfkJRRaYQxr4fpMtgWxzSCZ3VSaiXFUQ==
   dependencies:
-    "@comunica/bus-function-factory" "^4.2.0"
-    "@comunica/utils-expression-evaluator" "^4.2.0"
+    "@comunica/bus-function-factory" "^4.5.0"
+    "@comunica/utils-expression-evaluator" "^4.5.0"
 
-"@comunica/actor-function-factory-term-datatype@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-function-factory-term-datatype/-/actor-function-factory-term-datatype-4.2.0.tgz"
-  integrity sha512-Ilvh8RQcpUFoVHtiZBJfGkbcjw2c+SelG4phelKDaQJgdqQmJ1OguoQHXLatsUJMBwcrd6boSfqUt41Yiv18Ug==
+"@comunica/actor-function-factory-term-datatype@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-datatype/-/actor-function-factory-term-datatype-4.5.0.tgz#103d42b478879900e4128799439134d022de8af4"
+  integrity sha512-mjucrTW+MJoyCOsvxKJUBqawbNsSacVCvkazKscEBdk1Gj/b75xWUEi7cJHCd1cD1ESHn4EA5PEqhYXUyDsxzw==
   dependencies:
-    "@comunica/bus-function-factory" "^4.2.0"
-    "@comunica/utils-expression-evaluator" "^4.2.0"
+    "@comunica/bus-function-factory" "^4.5.0"
+    "@comunica/utils-expression-evaluator" "^4.5.0"
 
-"@comunica/actor-function-factory-term-day@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-function-factory-term-day/-/actor-function-factory-term-day-4.2.0.tgz"
-  integrity sha512-V3Wd3l+/gHrmiu481MHzhpJ3Lztc3oY2/cr1wsZC0+dzvgf8ZGsZPH+DQy5IYHoX9puzUeIa7pU1bf6mXMVVcQ==
+"@comunica/actor-function-factory-term-day@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-day/-/actor-function-factory-term-day-4.5.0.tgz#1b423b214b841e84985a740eb6188d0ccc9a575c"
+  integrity sha512-B2f3MniYbd7WR7vo8MJzO9jSBIeVOtXotpg9Mxo73Vyhknh7w6td95MpVxPJT8BXFVzFrkAh/OmU9nDcgcdB+Q==
   dependencies:
-    "@comunica/bus-function-factory" "^4.2.0"
-    "@comunica/utils-expression-evaluator" "^4.2.0"
+    "@comunica/bus-function-factory" "^4.5.0"
+    "@comunica/utils-expression-evaluator" "^4.5.0"
 
-"@comunica/actor-function-factory-term-division@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-function-factory-term-division/-/actor-function-factory-term-division-4.2.0.tgz"
-  integrity sha512-5RWmZmkxxuSz4M0h3GR9XoFSGizIMsXjrry/L0YFYh7HVy8MVyrY7I4SzajtpLwbxBWh+G4g43Uula1hKpGqSA==
+"@comunica/actor-function-factory-term-division@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-division/-/actor-function-factory-term-division-4.5.0.tgz#a5d7ded84eec20267690c5d7aa9515d9eb4057b9"
+  integrity sha512-IJ/5INqBDXkxuvESllxYNE7Ted/Y6lRQPDvzu1HDw3T+hj/KtBINEr7zPh9yLuapuTCzapygd+kIGVaoemoSJA==
   dependencies:
-    "@comunica/bus-function-factory" "^4.2.0"
-    "@comunica/utils-expression-evaluator" "^4.2.0"
+    "@comunica/bus-function-factory" "^4.5.0"
+    "@comunica/utils-expression-evaluator" "^4.5.0"
     bignumber.js "^9.1.2"
 
-"@comunica/actor-function-factory-term-encode-for-uri@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-function-factory-term-encode-for-uri/-/actor-function-factory-term-encode-for-uri-4.2.0.tgz"
-  integrity sha512-nZscihmc0w1N5kHr4TVy65gBZ/p9B6E3SZkOq7ynbZiJtcISYihYgGo7zH28eygT4XuIjnfWQrh24AcGrRYBLQ==
+"@comunica/actor-function-factory-term-encode-for-uri@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-encode-for-uri/-/actor-function-factory-term-encode-for-uri-4.5.0.tgz#3ea0298b9aa9bd15f9c274a7c89c368e35288b5d"
+  integrity sha512-3/8YNcg2gqG/Hc/0e24jTwepJqfU2mqhUG55kXNy5J3hKOyYza1wbNhBQUAQVFQcdpwKA/bzpb/YHwSov429Qw==
   dependencies:
-    "@comunica/bus-function-factory" "^4.2.0"
-    "@comunica/utils-expression-evaluator" "^4.2.0"
+    "@comunica/bus-function-factory" "^4.5.0"
+    "@comunica/utils-expression-evaluator" "^4.5.0"
 
-"@comunica/actor-function-factory-term-equality@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-function-factory-term-equality/-/actor-function-factory-term-equality-4.2.0.tgz"
-  integrity sha512-+bMnfco/d6GnO2uQk1GVOM3CkSz+1kCWoI+bq7m6e99VilfshTSVQdH49el0ni7cmtQuoHjroXzLv0Ctis0Veg==
+"@comunica/actor-function-factory-term-equality@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-equality/-/actor-function-factory-term-equality-4.5.0.tgz#2e54db2ac913b9add6b39b2ec36ea7a268693273"
+  integrity sha512-1q0L42931jvjv1b92nc18B/WAomYYEacg1gFJpUSsfqhGGAulA42+fTR2ngRDT0sQw/J1kT1WgY3fY1rHNADIQ==
   dependencies:
-    "@comunica/bus-function-factory" "^4.2.0"
-    "@comunica/context-entries" "^4.2.0"
-    "@comunica/utils-expression-evaluator" "^4.2.0"
+    "@comunica/bus-function-factory" "^4.5.0"
+    "@comunica/context-entries" "^4.5.0"
+    "@comunica/utils-expression-evaluator" "^4.5.0"
 
-"@comunica/actor-function-factory-term-floor@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-function-factory-term-floor/-/actor-function-factory-term-floor-4.2.0.tgz"
-  integrity sha512-DcB/U9TWYYP5NXxANUexvbBgFFhvgOSg6s6lbph9RjizcRW2kLDBWGs/KLximidRm1DHrKey6z2m4k8oHH9P4g==
+"@comunica/actor-function-factory-term-floor@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-floor/-/actor-function-factory-term-floor-4.5.0.tgz#35bbf2c225a56ee603434d373841a7b2e417bb6a"
+  integrity sha512-E4jxcs8M5wLZbPdzlmOuoIAwNtTzu5oVzH3gnZnE9iBE0pfSrN6N6g0sRY7vFXKfMgJQqVMlPiFt+Cda7ZcPHA==
   dependencies:
-    "@comunica/bus-function-factory" "^4.2.0"
-    "@comunica/utils-expression-evaluator" "^4.2.0"
+    "@comunica/bus-function-factory" "^4.5.0"
+    "@comunica/utils-expression-evaluator" "^4.5.0"
 
-"@comunica/actor-function-factory-term-greater-than-equal@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-function-factory-term-greater-than-equal/-/actor-function-factory-term-greater-than-equal-4.2.0.tgz"
-  integrity sha512-aNCSKytsQf6AaD6Rnbs1/DPJLvlvPnpUBim5R7dqOhqggmD5pclmAViKd7Oonq5elRck0/A8/+QRiH7KoYsj5g==
+"@comunica/actor-function-factory-term-greater-than-equal@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-greater-than-equal/-/actor-function-factory-term-greater-than-equal-4.5.0.tgz#48bded6487b92fb6360c596bbf34d3ce5e2bf0b5"
+  integrity sha512-vziCkcJNQedtqHC5kxvDMlvkJ+uJzO520q/4QjMMsftxyvDfpbWfX3VKQitJdRlvnAcmdZpWKb8ylltbZ/aT/A==
   dependencies:
-    "@comunica/bus-function-factory" "^4.2.0"
-    "@comunica/utils-expression-evaluator" "^4.2.0"
+    "@comunica/bus-function-factory" "^4.5.0"
+    "@comunica/utils-expression-evaluator" "^4.5.0"
 
-"@comunica/actor-function-factory-term-greater-than@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-function-factory-term-greater-than/-/actor-function-factory-term-greater-than-4.2.0.tgz"
-  integrity sha512-Hs/S6UyR9lUWl8+WhpEe3RwFnA2undypWyVcO7j5BJ0hsYN0KNdGDATMKmloiRXGpOyqfTF2n9+pQcjxzhDDcg==
+"@comunica/actor-function-factory-term-greater-than@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-greater-than/-/actor-function-factory-term-greater-than-4.5.0.tgz#4882b315ff2518a4f74b83b7425cc3ed44e5fe08"
+  integrity sha512-4WcYnNaXX6d0gXHHChW7QwmG4Ywq7CRihYC4AAkIqP9e9TX+lqz7cXaMMyGICh0uHY4JwAg33i3Pxv54TdwCog==
   dependencies:
-    "@comunica/bus-function-factory" "^4.2.0"
-    "@comunica/utils-expression-evaluator" "^4.2.0"
+    "@comunica/bus-function-factory" "^4.5.0"
+    "@comunica/utils-expression-evaluator" "^4.5.0"
 
-"@comunica/actor-function-factory-term-hours@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-function-factory-term-hours/-/actor-function-factory-term-hours-4.2.0.tgz"
-  integrity sha512-TYzhArFJV1vPItVIM1M2pOpkmyhjZLk5UzZX4VYtXpBCH/+YDIgrqxLOxOp1JnG1RlfBywk9hcV6jEo/rNHctw==
+"@comunica/actor-function-factory-term-hours@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-hours/-/actor-function-factory-term-hours-4.5.0.tgz#a09081883952d2541024465da078198af93e475b"
+  integrity sha512-0GkHX9KnU1N+lHzgmGLKndt8QX+8o5Mb5I+QIZWHgm7tkGHIGOQWtN0eBWhiVnzV8MBz471vyAVPHYB/OKsi5w==
   dependencies:
-    "@comunica/bus-function-factory" "^4.2.0"
-    "@comunica/utils-expression-evaluator" "^4.2.0"
+    "@comunica/bus-function-factory" "^4.5.0"
+    "@comunica/utils-expression-evaluator" "^4.5.0"
 
-"@comunica/actor-function-factory-term-inequality@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-function-factory-term-inequality/-/actor-function-factory-term-inequality-4.2.0.tgz"
-  integrity sha512-Yl8nu6KiFQVPVszsm60BnWy0uLY0Tvmsl0hbCFP2q8Qrm7dLJSIakYCJy1VbQPGTQrXXEgVyrnjid2ZlzQFZJQ==
+"@comunica/actor-function-factory-term-inequality@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-inequality/-/actor-function-factory-term-inequality-4.5.0.tgz#4a1dd15ab6f65db168f14903da0ce6ade9400f16"
+  integrity sha512-p89dQB30AZsuFnJhFzGczz72wTIsR3nQzROP8NMwDpyic5xMrKEw1QljK+leWugrhlCprBuMQTpWWAFGe9EVfQ==
   dependencies:
-    "@comunica/bus-function-factory" "^4.2.0"
-    "@comunica/utils-expression-evaluator" "^4.2.0"
+    "@comunica/bus-function-factory" "^4.5.0"
+    "@comunica/utils-expression-evaluator" "^4.5.0"
 
-"@comunica/actor-function-factory-term-iri@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-function-factory-term-iri/-/actor-function-factory-term-iri-4.2.0.tgz"
-  integrity sha512-HLtn1gOUXpfJcfsfrDw+UeEKNxyMSCosyug1bAbXDO6qtG0BcM6xYHkg65m8dNEa0qm7jljHnrF0EH8Gu0QlOg==
+"@comunica/actor-function-factory-term-iri@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-iri/-/actor-function-factory-term-iri-4.5.0.tgz#712c5750260ac03dde2e224b2bdcb881550c4c91"
+  integrity sha512-LZ3HHdBiWOmNnulKdu+7XhcJQyysRGwtBvIkW6WFnIvQpapeHC/KZO1gD2gevUDo/VJ3l5Rg6bcPY+InVnPDug==
   dependencies:
-    "@comunica/bus-function-factory" "^4.2.0"
-    "@comunica/context-entries" "^4.2.0"
-    "@comunica/utils-expression-evaluator" "^4.2.0"
+    "@comunica/bus-function-factory" "^4.5.0"
+    "@comunica/context-entries" "^4.5.0"
+    "@comunica/utils-expression-evaluator" "^4.5.0"
     relative-to-absolute-iri "^1.0.7"
 
-"@comunica/actor-function-factory-term-is-blank@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-function-factory-term-is-blank/-/actor-function-factory-term-is-blank-4.2.0.tgz"
-  integrity sha512-GVaCnhIHlIBBYKR7kewBUHf7fYmErX5FyTmikp9F1YhfXlL511jmLYbcENu9zSos8QWbqcFGiQ8wzBB+cJdhEg==
+"@comunica/actor-function-factory-term-is-blank@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-is-blank/-/actor-function-factory-term-is-blank-4.5.0.tgz#86ff92e1d430d960f215d6c4af66adb9f128abaa"
+  integrity sha512-hUlXgv+gJn7XyZQn9KPpi9R4ss+cFSMWxVvp02ZsmTZ8FKHYYkVP7CyGT1DqkBi17AjLlB4OcotjxY9qu43bTQ==
   dependencies:
-    "@comunica/bus-function-factory" "^4.2.0"
-    "@comunica/utils-expression-evaluator" "^4.2.0"
+    "@comunica/bus-function-factory" "^4.5.0"
+    "@comunica/utils-expression-evaluator" "^4.5.0"
 
-"@comunica/actor-function-factory-term-is-iri@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-function-factory-term-is-iri/-/actor-function-factory-term-is-iri-4.2.0.tgz"
-  integrity sha512-xob3nm4z9EmvA7JR0jvf8OVTmx/P1ErOgQGH7y81awzeSjT6eQ4Y3o2e1nSbecfoaiVqObBRpEiD+E9L2H9vUw==
+"@comunica/actor-function-factory-term-is-iri@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-is-iri/-/actor-function-factory-term-is-iri-4.5.0.tgz#ba9524ea5f42fc3ecb669b6da088d438c993e911"
+  integrity sha512-OzTNf4Lq+80x4M4rhHrptjJTpdu7Icl2Sk+K8B9v1adAPvinHoOEgiT1leRVqExccSstdtyOwBYCCBsJ/fhXtQ==
   dependencies:
-    "@comunica/bus-function-factory" "^4.2.0"
-    "@comunica/utils-expression-evaluator" "^4.2.0"
+    "@comunica/bus-function-factory" "^4.5.0"
+    "@comunica/utils-expression-evaluator" "^4.5.0"
 
-"@comunica/actor-function-factory-term-is-literal@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-function-factory-term-is-literal/-/actor-function-factory-term-is-literal-4.2.0.tgz"
-  integrity sha512-tZxbZm+3rtGanvb6HekWiMRvkKzDndUvRAPOqXt1ht3SD0fhfHRU8yyGbUaIulvSpPkDxJAYWjiMHdxE0jlhyw==
+"@comunica/actor-function-factory-term-is-literal@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-is-literal/-/actor-function-factory-term-is-literal-4.5.0.tgz#dd37f98fcffad1fc626e604420aea5295f737b4f"
+  integrity sha512-SagBQvOMHm8BiXLoCM2fhHerDXYlfwgnnWUiVbK3M1y9SDvynItc/Wa/BpDbimS/EMmkJxIGjnVDAEQryX7TMw==
   dependencies:
-    "@comunica/bus-function-factory" "^4.2.0"
-    "@comunica/utils-expression-evaluator" "^4.2.0"
+    "@comunica/bus-function-factory" "^4.5.0"
+    "@comunica/utils-expression-evaluator" "^4.5.0"
 
-"@comunica/actor-function-factory-term-is-numeric@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-function-factory-term-is-numeric/-/actor-function-factory-term-is-numeric-4.2.0.tgz"
-  integrity sha512-7UumdEXwqstImhsF10K6EBxUyNf/MQ/DJQL2246lu3ZsBDL+pwUjFOEXpEjZtbvi50210NxESZXyuB2LvuBdTw==
+"@comunica/actor-function-factory-term-is-numeric@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-is-numeric/-/actor-function-factory-term-is-numeric-4.5.0.tgz#0506c11bb6d0da62923f08887b37cd2663bbc03b"
+  integrity sha512-aqt73wM21ROHUgXsMZKFiJX2johJ7j1SUvnPfdCIIeUYTuxCKSjVR6sXNLH7F+u5kcXGS5hJwaYIvl//u3DqMA==
   dependencies:
-    "@comunica/bus-function-factory" "^4.2.0"
-    "@comunica/utils-expression-evaluator" "^4.2.0"
+    "@comunica/bus-function-factory" "^4.5.0"
+    "@comunica/utils-expression-evaluator" "^4.5.0"
 
-"@comunica/actor-function-factory-term-is-triple@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-function-factory-term-is-triple/-/actor-function-factory-term-is-triple-4.2.0.tgz"
-  integrity sha512-fG8wf+ZyOux18/eDncfrNDuYO4b0dAZ8SloG0Yo1X82JrZspMCkknJbFmwxp7S9GJFl/wFFxwa5d//ycEs1VvQ==
+"@comunica/actor-function-factory-term-is-triple@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-is-triple/-/actor-function-factory-term-is-triple-4.5.0.tgz#8812ad055240127e0310214d8d83ad01b251bb65"
+  integrity sha512-0P9zR8o3/zsMYjmPvzX84dHKkQz2ZP5pjfactN57oo+SE5wCX9sb4w4WwN9DZwFifjqzxX3EMMBQR5dR1A7sBQ==
   dependencies:
-    "@comunica/bus-function-factory" "^4.2.0"
-    "@comunica/utils-expression-evaluator" "^4.2.0"
+    "@comunica/bus-function-factory" "^4.5.0"
+    "@comunica/utils-expression-evaluator" "^4.5.0"
 
-"@comunica/actor-function-factory-term-lang@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-function-factory-term-lang/-/actor-function-factory-term-lang-4.2.0.tgz"
-  integrity sha512-+MzyAmSHCeMEqhP6w7NWlZo7FOcHbEkVPFzBAzX1fS9hJOAKSiioKPIo5ubC8jK0vVOsWLSG0xhrRfDWwOtX2g==
+"@comunica/actor-function-factory-term-lang@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-lang/-/actor-function-factory-term-lang-4.5.0.tgz#765810df6a9f4f2a026793a9467bfa69d40832f1"
+  integrity sha512-sS574SUxEtR8WTfM1U9QavjC6+SCRxbgEM9uKxVe7sTu73bs4a+UGM5xSm4GBRSKMi574xcSGDBRF8lZua44sA==
   dependencies:
-    "@comunica/bus-function-factory" "^4.2.0"
-    "@comunica/utils-expression-evaluator" "^4.2.0"
+    "@comunica/bus-function-factory" "^4.5.0"
+    "@comunica/utils-expression-evaluator" "^4.5.0"
 
-"@comunica/actor-function-factory-term-langmatches@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-function-factory-term-langmatches/-/actor-function-factory-term-langmatches-4.2.0.tgz"
-  integrity sha512-TtABO+iJWf1lnyEayumxAFiczmI888lhpk6k20VjEHOgCkjBDEz/6tbQiIiIWtcnC0N63TNoz0O43GmXDwv4zQ==
+"@comunica/actor-function-factory-term-langmatches@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-langmatches/-/actor-function-factory-term-langmatches-4.5.0.tgz#b7008216492ff27268ba76f79ba5c696d998986c"
+  integrity sha512-VKX0DPiM70rXvtlHGBAiqWtRQbL7X8417+amOr7FV7SicC3vZhlRxQoO8VWMMRPtkJWDVbbzt6DQAMIzVt4JBg==
   dependencies:
-    "@comunica/bus-function-factory" "^4.2.0"
-    "@comunica/utils-expression-evaluator" "^4.2.0"
+    "@comunica/bus-function-factory" "^4.5.0"
+    "@comunica/utils-expression-evaluator" "^4.5.0"
 
-"@comunica/actor-function-factory-term-lcase@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-function-factory-term-lcase/-/actor-function-factory-term-lcase-4.2.0.tgz"
-  integrity sha512-wzL8z/m7/gBGY/vMXPj0gfy3g6DtiIgHLY67V0FDPe80qyYqzSE2hmbcEziANTnev9WtoG1B+JVv7u+pDEGCdw==
+"@comunica/actor-function-factory-term-lcase@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-lcase/-/actor-function-factory-term-lcase-4.5.0.tgz#3e44a909153a4c0708e764ff5b9322c68b42e0ec"
+  integrity sha512-AY8HhhGG7zJayAvRtxq/O31Yzz23lCf5P4Z2vjesEP1c0+fOFQJ7Dc6UkoxYHLmvXLtWHTEyNAv8khtEBTfEMQ==
   dependencies:
-    "@comunica/bus-function-factory" "^4.2.0"
-    "@comunica/utils-expression-evaluator" "^4.2.0"
+    "@comunica/bus-function-factory" "^4.5.0"
+    "@comunica/utils-expression-evaluator" "^4.5.0"
 
-"@comunica/actor-function-factory-term-lesser-than-equal@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-function-factory-term-lesser-than-equal/-/actor-function-factory-term-lesser-than-equal-4.2.0.tgz"
-  integrity sha512-I5zylRT2AIghY71BkTQk2PY7eYRfaPSnB+oPz6Xm5bOS7/HbCYraaayXfUVBxSg+VgBo/3ECNKgycKsxcjy2lg==
+"@comunica/actor-function-factory-term-lesser-than-equal@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-lesser-than-equal/-/actor-function-factory-term-lesser-than-equal-4.5.0.tgz#3a81c664c92392791c909d58dfc01cbd43977d8b"
+  integrity sha512-uFT9J4fVwZN6JcCnZrCkWXWkUddrp6amu9gGJrwkV++7pS/CjsDDAXuxYwQqtn+RsOZrsc6kvEX9vptJqdqRag==
   dependencies:
-    "@comunica/bus-function-factory" "^4.2.0"
-    "@comunica/utils-expression-evaluator" "^4.2.0"
+    "@comunica/bus-function-factory" "^4.5.0"
+    "@comunica/utils-expression-evaluator" "^4.5.0"
 
-"@comunica/actor-function-factory-term-lesser-than@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-function-factory-term-lesser-than/-/actor-function-factory-term-lesser-than-4.2.0.tgz"
-  integrity sha512-cIGAJgSTZX1DsAWO/Y+SsyeDEfA9rDN/eXk/PELyaicTJCfRS4Dqji+s8QHBkQLDs9Fhbh7/zLS4g0gCw9IHtQ==
+"@comunica/actor-function-factory-term-lesser-than@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-lesser-than/-/actor-function-factory-term-lesser-than-4.5.0.tgz#7555011bf3f93a00e87c2dfaf31d54d3b931cc6c"
+  integrity sha512-K423u2M02PQxhfbc8O5mUGfYVwFft4IWgIYmIMs2e0KQc8JPHt8ba665ZWoSykkzTyIoR0bffXx83mjwdMa5mw==
   dependencies:
-    "@comunica/bus-function-factory" "^4.2.0"
-    "@comunica/context-entries" "^4.2.0"
-    "@comunica/utils-expression-evaluator" "^4.2.0"
+    "@comunica/bus-function-factory" "^4.5.0"
+    "@comunica/context-entries" "^4.5.0"
+    "@comunica/utils-expression-evaluator" "^4.5.0"
 
-"@comunica/actor-function-factory-term-md5@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-function-factory-term-md5/-/actor-function-factory-term-md5-4.2.0.tgz"
-  integrity sha512-s8DODZorW82KE+7nXrmROtk1UB5TjD9gtaz5wfNTUGUy8XgNLx11L31w6PWjzP2Sj8nRzQWgYjzyfupriGSXBQ==
+"@comunica/actor-function-factory-term-md5@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-md5/-/actor-function-factory-term-md5-4.5.0.tgz#93f7b9c10626e2233dee9b9a403d0fd005f607ac"
+  integrity sha512-gzRiaYDyr1+ecJMGteO8/CSylhvRpgLpKBj4pMh4XOe1REpb9ld7rR8Lm3LzSVczr+DMabbXcPwInF77hf+drQ==
   dependencies:
-    "@comunica/bus-function-factory" "^4.2.0"
-    "@comunica/utils-expression-evaluator" "^4.2.0"
+    "@comunica/bus-function-factory" "^4.5.0"
+    "@comunica/utils-expression-evaluator" "^4.5.0"
     "@types/spark-md5" "^3.0.1"
     spark-md5 "^3.0.1"
 
-"@comunica/actor-function-factory-term-minutes@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-function-factory-term-minutes/-/actor-function-factory-term-minutes-4.2.0.tgz"
-  integrity sha512-q3wZPiblx/V2yvX6joz7kxiwi7fac09cFeX1UuQnGLZPWkUBs1TScznWpp0SS3FpRJ/OYPoRRppAvphqg5rKeQ==
+"@comunica/actor-function-factory-term-minutes@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-minutes/-/actor-function-factory-term-minutes-4.5.0.tgz#2778b3fb31a10314cbc6a9dc7add0b21dd515b41"
+  integrity sha512-PJPr11nOfjPu7JiFZPwsAYNDlKP2dVcjPqmyMVYg0phnPS5QMqZqclAKPjZgK/A6ipWyLly5j9+uB1NiPoAaPg==
   dependencies:
-    "@comunica/bus-function-factory" "^4.2.0"
-    "@comunica/utils-expression-evaluator" "^4.2.0"
+    "@comunica/bus-function-factory" "^4.5.0"
+    "@comunica/utils-expression-evaluator" "^4.5.0"
 
-"@comunica/actor-function-factory-term-month@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-function-factory-term-month/-/actor-function-factory-term-month-4.2.0.tgz"
-  integrity sha512-yknO7g8x/M3ICf5wH3+PsFom94GlQacGfmoctJNVVwtTwJ61UWwZ7ytNvQjKII2W1afUUGQThnnE7/kF8aIVWg==
+"@comunica/actor-function-factory-term-month@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-month/-/actor-function-factory-term-month-4.5.0.tgz#a5111c44556d82e762309b95a34eb33b02e4b47b"
+  integrity sha512-6HFV7p5rRSg8ZEKeAMeY2rpvO+MBI1aEnWkkm8Eb0n9Y9MID8RBDEoWjtim94L430xN+fzbVf2lnKEK0gG/k5g==
   dependencies:
-    "@comunica/bus-function-factory" "^4.2.0"
-    "@comunica/utils-expression-evaluator" "^4.2.0"
+    "@comunica/bus-function-factory" "^4.5.0"
+    "@comunica/utils-expression-evaluator" "^4.5.0"
 
-"@comunica/actor-function-factory-term-multiplication@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-function-factory-term-multiplication/-/actor-function-factory-term-multiplication-4.2.0.tgz"
-  integrity sha512-LyB+ZiLelY8GCMwXsb6Y/+iWbJiJpqnuGYQ18kCTLhj9Hi2pELvjhQGmov2BGQHBkEWskzEFhZjxzqExsr5M4g==
+"@comunica/actor-function-factory-term-multiplication@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-multiplication/-/actor-function-factory-term-multiplication-4.5.0.tgz#3a106965cd69839966437f2ea2359393f1e53735"
+  integrity sha512-cfSOAl8sKhkuJXRpIgz4Avm9ImjP074D3sjVNkptxoJsk+lMI21tbiaa7Kp6b88RV8xlHSMrzzaViX0SWD/rrA==
   dependencies:
-    "@comunica/bus-function-factory" "^4.2.0"
-    "@comunica/utils-expression-evaluator" "^4.2.0"
+    "@comunica/bus-function-factory" "^4.5.0"
+    "@comunica/utils-expression-evaluator" "^4.5.0"
     bignumber.js "^9.1.2"
 
-"@comunica/actor-function-factory-term-not@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-function-factory-term-not/-/actor-function-factory-term-not-4.2.0.tgz"
-  integrity sha512-yJg6h2ZrzWXDNiNHIx7TM71MZufywRcVS6HVqi6KvFTQdWQNbgSXic3Eq81KTCk2stB5P6EkeTXQ8r4caf2tMA==
+"@comunica/actor-function-factory-term-not@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-not/-/actor-function-factory-term-not-4.5.0.tgz#227439d81ebb2fa407a7b7c6fd801afff69fb1e6"
+  integrity sha512-W9Ux+wt2UnjHJVxyLIprGNCWiPJEGSxKBvldRZq4Yaf3O3ZsAShAP5wLzp4+jyI8IX4IFcEaERg1Mek5trl52A==
   dependencies:
-    "@comunica/bus-function-factory" "^4.2.0"
-    "@comunica/utils-expression-evaluator" "^4.2.0"
+    "@comunica/bus-function-factory" "^4.5.0"
+    "@comunica/utils-expression-evaluator" "^4.5.0"
 
-"@comunica/actor-function-factory-term-now@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-function-factory-term-now/-/actor-function-factory-term-now-4.2.0.tgz"
-  integrity sha512-cpcQuxNfpuRF1yYNtbGeyE4wjCtSkQ5H1PZK/DeP3NhxQquaNaOhPx9xd6yHr3VPD9S/0wrksPhH04YKn/rYFg==
+"@comunica/actor-function-factory-term-now@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-now/-/actor-function-factory-term-now-4.5.0.tgz#18e53f0f0c3bc8eca376e6356d6d8ce1c29053a9"
+  integrity sha512-bTnQUTg6tNO2orVMVCwMm+qhP61ye91Deabb5HNiDOaE9s5WVNbyyiWxVRmNx0TobPfveiNE4yRuYpHJNbMRgg==
   dependencies:
-    "@comunica/bus-function-factory" "^4.2.0"
-    "@comunica/context-entries" "^4.2.0"
-    "@comunica/utils-expression-evaluator" "^4.2.0"
+    "@comunica/bus-function-factory" "^4.5.0"
+    "@comunica/context-entries" "^4.5.0"
+    "@comunica/utils-expression-evaluator" "^4.5.0"
 
-"@comunica/actor-function-factory-term-object@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-function-factory-term-object/-/actor-function-factory-term-object-4.2.0.tgz"
-  integrity sha512-iohcDBOicSbyHeJxWYBXdQ4Qu7mT8cZgNfxS5q74MIGJsY6JJtEgar4A6USP4XhmoTNMOryouDgpGHkgOG3LWA==
+"@comunica/actor-function-factory-term-object@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-object/-/actor-function-factory-term-object-4.5.0.tgz#4e28ae18a6f3c62e441dfb32154aec11b923b985"
+  integrity sha512-AkFP8DgitOm94NygOc63Ow10kfU8HgcV0ndUOjwkanBXDsoErwd/cZTu5FSEYUP4XedV+RC7qVKp40m51ENggw==
   dependencies:
-    "@comunica/bus-function-factory" "^4.2.0"
-    "@comunica/utils-expression-evaluator" "^4.2.0"
+    "@comunica/bus-function-factory" "^4.5.0"
+    "@comunica/utils-expression-evaluator" "^4.5.0"
 
-"@comunica/actor-function-factory-term-predicate@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-function-factory-term-predicate/-/actor-function-factory-term-predicate-4.2.0.tgz"
-  integrity sha512-slvANEpFtjuM7d3okf+ooewth4PqmGTLMgOEhmhAkbOZ3z5IiVB0VRwk0puSUje34A7hTW7w72aISfeIcrbYgg==
+"@comunica/actor-function-factory-term-predicate@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-predicate/-/actor-function-factory-term-predicate-4.5.0.tgz#d8770e2604a98d83dd056fcc2e3e58b79094815a"
+  integrity sha512-ceMRBdVHXwWkwZXhE8LgnzacHy6gnzLp95JW1nnEf9Q+/ADE8tpx5OGE+W1tFrCAJbvfkVCRldz6qOXNCqhTEQ==
   dependencies:
-    "@comunica/bus-function-factory" "^4.2.0"
-    "@comunica/utils-expression-evaluator" "^4.2.0"
+    "@comunica/bus-function-factory" "^4.5.0"
+    "@comunica/utils-expression-evaluator" "^4.5.0"
 
-"@comunica/actor-function-factory-term-rand@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-function-factory-term-rand/-/actor-function-factory-term-rand-4.2.0.tgz"
-  integrity sha512-b+KJ+1UOHHDQJQXJFKOeCaqc6xDM1XB1RACsnIFYUeRX/5t2TQhQNSgU5dD7+GmGdL8F8gKVZkqyEXfhlsiJSg==
+"@comunica/actor-function-factory-term-rand@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-rand/-/actor-function-factory-term-rand-4.5.0.tgz#67a767a67f54491e3ebb8f0e5fa97618f3a9db2b"
+  integrity sha512-5ORuC18AVkWtvWYjbFpFtB9Noxcw+rg9EI8KVYmN9oE4zW2s/SV8lz4Ybu4tWU9/IvQmyRSv1gr4MZ1OS+DMxg==
   dependencies:
-    "@comunica/bus-function-factory" "^4.2.0"
-    "@comunica/utils-expression-evaluator" "^4.2.0"
+    "@comunica/bus-function-factory" "^4.5.0"
+    "@comunica/utils-expression-evaluator" "^4.5.0"
 
-"@comunica/actor-function-factory-term-regex@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-function-factory-term-regex/-/actor-function-factory-term-regex-4.2.0.tgz"
-  integrity sha512-yI3sw9SSHnx6JMnKuGrZJ3XY6mljgUpYNJ9g5yVBk2wXdgR+VxvVy02cV8b7KlucdKgGiHnrD/RQRFPVp2d3Aw==
+"@comunica/actor-function-factory-term-regex@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-regex/-/actor-function-factory-term-regex-4.5.0.tgz#393bccff595f998ac55094c021027865916cd004"
+  integrity sha512-HpUlfaDfOJ4PmaJGr4gUE2cpbFG31wcq9E0DNlDi6OlmMyTv1dYBOA0chiC/3bPUJ4JYADpgePu7kruNtEhgwQ==
   dependencies:
-    "@comunica/bus-function-factory" "^4.2.0"
-    "@comunica/utils-expression-evaluator" "^4.2.0"
+    "@comunica/bus-function-factory" "^4.5.0"
+    "@comunica/utils-expression-evaluator" "^4.5.0"
 
-"@comunica/actor-function-factory-term-replace@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-function-factory-term-replace/-/actor-function-factory-term-replace-4.2.0.tgz"
-  integrity sha512-p9PSjEh/NudqHZF8oIibwqcMOHDUiY6joAihOM2z0F0gdGp3o1GhfRYG51+KCF5ggcWd2lByuHteMUc5mE52rQ==
+"@comunica/actor-function-factory-term-replace@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-replace/-/actor-function-factory-term-replace-4.5.0.tgz#f64aae664826a037f2d780da69b9c3fc589fddcb"
+  integrity sha512-eK/u8+MUB9miUlbH3ZpzQrLFdiXEZSLszOioumGyMSJSbBlASJs1CekKQ90Ed6o3X1vZ/hVlEW0gJNzW/1TkbA==
   dependencies:
-    "@comunica/actor-function-factory-term-regex" "^4.2.0"
-    "@comunica/bus-function-factory" "^4.2.0"
-    "@comunica/utils-expression-evaluator" "^4.2.0"
+    "@comunica/actor-function-factory-term-regex" "^4.5.0"
+    "@comunica/bus-function-factory" "^4.5.0"
+    "@comunica/utils-expression-evaluator" "^4.5.0"
 
-"@comunica/actor-function-factory-term-round@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-function-factory-term-round/-/actor-function-factory-term-round-4.2.0.tgz"
-  integrity sha512-H86Go+WYnix3tMO511I2E5vY8VuoFkAm1G8ztBRU1vmEE8CKO2YINQ6xfA0fNpKpf8UVqI1nu3nRQ+02jUdxWg==
+"@comunica/actor-function-factory-term-round@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-round/-/actor-function-factory-term-round-4.5.0.tgz#2b659532f1ece964d0d4deb6047fe84a18e5fdad"
+  integrity sha512-6VWjonN/WZiBpxSOKI4NVvOs0H/O4+zTuhv4JtWwHjyKLkT/nhbNi0UtU/bnMKEsuFH0tSdNMJxfbOXaFzqgMw==
   dependencies:
-    "@comunica/bus-function-factory" "^4.2.0"
-    "@comunica/utils-expression-evaluator" "^4.2.0"
+    "@comunica/bus-function-factory" "^4.5.0"
+    "@comunica/utils-expression-evaluator" "^4.5.0"
 
-"@comunica/actor-function-factory-term-seconds@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-function-factory-term-seconds/-/actor-function-factory-term-seconds-4.2.0.tgz"
-  integrity sha512-xHIlexdhabYlCZXHd18hWpLTSOIQqmRSGNQGn8ZQ78sstn+xFMULX0fo1XAsy578VJxrRlnn08Hl81sdoRfGHA==
+"@comunica/actor-function-factory-term-seconds@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-seconds/-/actor-function-factory-term-seconds-4.5.0.tgz#ee96da31e42c0a5567de8f6efe6cfa61ea6704b5"
+  integrity sha512-kR1W9A3rZCnpgE75itDFVuZxejBKVOOxX0j1rVP96/Y1Fmsovm9sPo4pbTFTMTROuesICAWux7TP1N5avBWFaw==
   dependencies:
-    "@comunica/bus-function-factory" "^4.2.0"
-    "@comunica/utils-expression-evaluator" "^4.2.0"
+    "@comunica/bus-function-factory" "^4.5.0"
+    "@comunica/utils-expression-evaluator" "^4.5.0"
 
-"@comunica/actor-function-factory-term-sha1@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-function-factory-term-sha1/-/actor-function-factory-term-sha1-4.2.0.tgz"
-  integrity sha512-Xc1S8NPlMO+c/kKZvbdt1uTOC/kOfAbfnkAg8Aj4jJrdRO0DZVeMiwOM+V2/vLyazDdvFXpVSGSixR4CbfUadw==
+"@comunica/actor-function-factory-term-sha1@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-sha1/-/actor-function-factory-term-sha1-4.5.0.tgz#869353d0e070a5a1a5a70fb297be5430bac760a1"
+  integrity sha512-ydGrQVq46uCHAWYUpA2cKGtYvITxl5MsWlqRnxlfnDHgZZI2SCP+ck+im6xBEvIHpMX9PnOQBWoEe1qAJ5NW8Q==
   dependencies:
-    "@comunica/bus-function-factory" "^4.2.0"
-    "@comunica/utils-expression-evaluator" "^4.2.0"
+    "@comunica/bus-function-factory" "^4.5.0"
+    "@comunica/utils-expression-evaluator" "^4.5.0"
     hash.js "^1.1.7"
 
-"@comunica/actor-function-factory-term-sha256@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-function-factory-term-sha256/-/actor-function-factory-term-sha256-4.2.0.tgz"
-  integrity sha512-z3yVvZh7G8/yzx6gV8RhrCJjLwmnAjkGe+gkqzTN/Ld2G1oMh1/Mla1GFTBUHjiAZRubFT+OxyGU3Erj9QeRjA==
+"@comunica/actor-function-factory-term-sha256@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-sha256/-/actor-function-factory-term-sha256-4.5.0.tgz#5bdf16912fbbf780840f3b5cdafd2e5b9767e3db"
+  integrity sha512-1fOo26Gc5oBEEJypbashF2KolrQfV7Z8OS6d1/sNA8NA05u1R49OWza3p3w91PAIOToGI5QiiIIgCn1bzpUwmQ==
   dependencies:
-    "@comunica/bus-function-factory" "^4.2.0"
-    "@comunica/utils-expression-evaluator" "^4.2.0"
+    "@comunica/bus-function-factory" "^4.5.0"
+    "@comunica/utils-expression-evaluator" "^4.5.0"
     hash.js "^1.1.7"
 
-"@comunica/actor-function-factory-term-sha384@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-function-factory-term-sha384/-/actor-function-factory-term-sha384-4.2.0.tgz"
-  integrity sha512-eWQOyulKRYIgEuWfZhPNMieH7kVsTmrIAk7s4oylJXtu9Y8CpC09zkj0TT4KRL2ns9Nqosf7EuE/E3C2VjeovA==
+"@comunica/actor-function-factory-term-sha384@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-sha384/-/actor-function-factory-term-sha384-4.5.0.tgz#d7fa09fb65358cde66991065437c358c37385c8b"
+  integrity sha512-2n9XIEU3ZjqWOeJHqzMziJdLouz57BXyGKUV44buOM/m9zZjkuO0oP+VI44YxcltUvxzwZnkZE9HpUDz3IgdBw==
   dependencies:
-    "@comunica/bus-function-factory" "^4.2.0"
-    "@comunica/utils-expression-evaluator" "^4.2.0"
+    "@comunica/bus-function-factory" "^4.5.0"
+    "@comunica/utils-expression-evaluator" "^4.5.0"
     hash.js "^1.1.7"
 
-"@comunica/actor-function-factory-term-sha512@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-function-factory-term-sha512/-/actor-function-factory-term-sha512-4.2.0.tgz"
-  integrity sha512-Ifn1ABCPzFUGAbVjin6gihISrdL1xHSPz877jxFfh49WsnRkAzD22j+yAxS/nncnMzWErDmZJL+fZsbJkbDMGg==
+"@comunica/actor-function-factory-term-sha512@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-sha512/-/actor-function-factory-term-sha512-4.5.0.tgz#9fa37a3873f56e6b43606a418cab78f19ad83b78"
+  integrity sha512-60pOulMI8QmW2KWNfOcfC3LdeqG9RnqMMBV/UGbdDSvQpTWQDxfeGj/qujCTNQz604+NCe9FGn2lz06YIFY2aw==
   dependencies:
-    "@comunica/bus-function-factory" "^4.2.0"
-    "@comunica/utils-expression-evaluator" "^4.2.0"
+    "@comunica/bus-function-factory" "^4.5.0"
+    "@comunica/utils-expression-evaluator" "^4.5.0"
     hash.js "^1.1.7"
 
-"@comunica/actor-function-factory-term-str-after@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-function-factory-term-str-after/-/actor-function-factory-term-str-after-4.2.0.tgz"
-  integrity sha512-uiliB9CAp2kXqft7RKRCtO3HAY/0m4LTw+qKMwue4ncPfv2X13KOT9xVFI0OGQb/Zxo/KwaGu9hA/kSx+2L9og==
+"@comunica/actor-function-factory-term-str-after@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-str-after/-/actor-function-factory-term-str-after-4.5.0.tgz#40163107df8670064d0373f6f2eb656022898ed5"
+  integrity sha512-JnrkLjqr31cF3Cw/ojAcnw0MZrZsLFZR7P6wlWo39DOIYPAvP2ztzaJZYlIeYIJn4+BIqiA5wrOBGGrDhLnwzw==
   dependencies:
-    "@comunica/bus-function-factory" "^4.2.0"
-    "@comunica/utils-expression-evaluator" "^4.2.0"
+    "@comunica/bus-function-factory" "^4.5.0"
+    "@comunica/utils-expression-evaluator" "^4.5.0"
 
-"@comunica/actor-function-factory-term-str-before@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-function-factory-term-str-before/-/actor-function-factory-term-str-before-4.2.0.tgz"
-  integrity sha512-6GDhOUjOuBONP1VHC3xvgpOfiyMZE93ZEWmQQToQkt+HNsRybZkcUJvpjGnib0jqsjSBoegrDdjMuIh/SZUw3A==
+"@comunica/actor-function-factory-term-str-before@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-str-before/-/actor-function-factory-term-str-before-4.5.0.tgz#a00bace89fbc198e15e9185ca506b27bc1004beb"
+  integrity sha512-Usdx/eZBwzMqVz9EFNFivQDL5s+fS6GkQ6aDL7RunGI0eRaLKYpk2lhCULuauQVgdpg3BniMVW6gnwAqgcoJZg==
   dependencies:
-    "@comunica/bus-function-factory" "^4.2.0"
-    "@comunica/utils-expression-evaluator" "^4.2.0"
+    "@comunica/bus-function-factory" "^4.5.0"
+    "@comunica/utils-expression-evaluator" "^4.5.0"
 
-"@comunica/actor-function-factory-term-str-dt@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-function-factory-term-str-dt/-/actor-function-factory-term-str-dt-4.2.0.tgz"
-  integrity sha512-5R9XNitKgqkhIMQk8MOx8c0xoDD0BCKA9tcqcqWmb/lMD6O026tjPVc90yX663AywyL1mJFZKN5U2MgalwaChg==
+"@comunica/actor-function-factory-term-str-dt@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-str-dt/-/actor-function-factory-term-str-dt-4.5.0.tgz#5dd79404c17b1c4054549768437c983501cdbe52"
+  integrity sha512-X+hIJ3RgtEnfvYsxVqk1KDanGI6wN/1Y7HVM7TU+ErtXq1zLLA7V44F0kL4l8eH94BHnXONUL2IvBjTcNx3ocA==
   dependencies:
-    "@comunica/bus-function-factory" "^4.2.0"
-    "@comunica/context-entries" "^4.2.0"
-    "@comunica/types" "^4.2.0"
-    "@comunica/utils-expression-evaluator" "^4.2.0"
+    "@comunica/bus-function-factory" "^4.5.0"
+    "@comunica/context-entries" "^4.5.0"
+    "@comunica/types" "^4.5.0"
+    "@comunica/utils-expression-evaluator" "^4.5.0"
 
-"@comunica/actor-function-factory-term-str-ends@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-function-factory-term-str-ends/-/actor-function-factory-term-str-ends-4.2.0.tgz"
-  integrity sha512-TVVpk0legazg8gNu9rQESmisCFI9VYiEmB7mERnxDXz5kveJ8TLVzkure4BxYVfIqn7dD+MI+/Gnzu9OIAG6Qg==
+"@comunica/actor-function-factory-term-str-ends@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-str-ends/-/actor-function-factory-term-str-ends-4.5.0.tgz#3da47e5879742d12094ae50cf3e944f3fe6a7e8c"
+  integrity sha512-yH54gsUdIXEEgLL1Q0TF8GXM2l27//TipImXk825yBzpSF+MvS4QlrRQ9lAfJjUFeHrUvqLYrC8mLCtnsbHhdA==
   dependencies:
-    "@comunica/bus-function-factory" "^4.2.0"
-    "@comunica/utils-expression-evaluator" "^4.2.0"
+    "@comunica/bus-function-factory" "^4.5.0"
+    "@comunica/utils-expression-evaluator" "^4.5.0"
 
-"@comunica/actor-function-factory-term-str-lang@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-function-factory-term-str-lang/-/actor-function-factory-term-str-lang-4.2.0.tgz"
-  integrity sha512-CX97EePbPS3BET+BAQ+heSoG3IA+KvW9d4KAn39wegCDwPCKkXTJH4hXLZo+fj1x+8Z5+kS9NbnKltQJj5z+lA==
+"@comunica/actor-function-factory-term-str-lang@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-str-lang/-/actor-function-factory-term-str-lang-4.5.0.tgz#680f9e415d973d66c8175d7f814e8c325ec23a3f"
+  integrity sha512-uupsgyA4NjzO7wYsswfuoSVEqtFJreRk02zjggcISUi7TXfDBKiqyzDELNveiSVK7gDUk4vzbbFuVnT35/fJPw==
   dependencies:
-    "@comunica/bus-function-factory" "^4.2.0"
-    "@comunica/utils-expression-evaluator" "^4.2.0"
+    "@comunica/bus-function-factory" "^4.5.0"
+    "@comunica/utils-expression-evaluator" "^4.5.0"
 
-"@comunica/actor-function-factory-term-str-len@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-function-factory-term-str-len/-/actor-function-factory-term-str-len-4.2.0.tgz"
-  integrity sha512-qC33nL8oeL8Zj4Auw+JIeLJkanqqYp6S/bD0V+NTcrEDg/+qha8zMqpYpdUkJu3LKJxQmPr+ytj/Fn/CuKBFnQ==
+"@comunica/actor-function-factory-term-str-len@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-str-len/-/actor-function-factory-term-str-len-4.5.0.tgz#5a4fcd3c6f0968568a153c6c35cb8ea1c8ee4925"
+  integrity sha512-2sr025H9rj7hJIO0evfNYj2Fm6KuaC4PSi2hfIy/DGd7uaWPvf+5d+axfsL/gk48SZPjcGyOgum6tjbm+/iS1Q==
   dependencies:
-    "@comunica/bus-function-factory" "^4.2.0"
-    "@comunica/utils-expression-evaluator" "^4.2.0"
+    "@comunica/bus-function-factory" "^4.5.0"
+    "@comunica/utils-expression-evaluator" "^4.5.0"
 
-"@comunica/actor-function-factory-term-str-starts@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-function-factory-term-str-starts/-/actor-function-factory-term-str-starts-4.2.0.tgz"
-  integrity sha512-eRGaWPJk4ZKrZzvPfmPjqQM8aI5XXZu943ETHXXySJfZHxaiklDZPvA8OU6M2PFYXMp0KAeHnoMoyXwMAXqR4Q==
+"@comunica/actor-function-factory-term-str-starts@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-str-starts/-/actor-function-factory-term-str-starts-4.5.0.tgz#4a7473376b062f3d0dc280a7e19f7d4936ba8c4a"
+  integrity sha512-Qw4jUMM5SQDcdtTip809CLN2LU9nOlK5QsyN2mG7HTHwf4QjnxDXozq2C4fTbUzgYGMTROgQO/wbTPhzMKdgeQ==
   dependencies:
-    "@comunica/bus-function-factory" "^4.2.0"
-    "@comunica/utils-expression-evaluator" "^4.2.0"
+    "@comunica/bus-function-factory" "^4.5.0"
+    "@comunica/utils-expression-evaluator" "^4.5.0"
 
-"@comunica/actor-function-factory-term-str-uuid@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-function-factory-term-str-uuid/-/actor-function-factory-term-str-uuid-4.2.0.tgz"
-  integrity sha512-kk3xyvmmZx/HP9Hdve0MrfuJedg97el/7DLtsfWhF3NzLzdbzZ+aH3bGDIOR8uSDniyBhqkTbeoCTgxfEwsdOg==
+"@comunica/actor-function-factory-term-str-uuid@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-str-uuid/-/actor-function-factory-term-str-uuid-4.5.0.tgz#9af6bbb80591cf664c09dc262c60776f5371147d"
+  integrity sha512-Yj5bsRkQ4omf85L8bMqjRgIa2sd+KVBvMvD04zAie5KcbnH8zMSBG62o4MCteQz5jDGZsyYmX9JeUXhmHA9UZQ==
   dependencies:
-    "@comunica/bus-function-factory" "^4.2.0"
-    "@comunica/utils-expression-evaluator" "^4.2.0"
+    "@comunica/bus-function-factory" "^4.5.0"
+    "@comunica/utils-expression-evaluator" "^4.5.0"
     "@types/uuid" "^10.0.0"
     uuid "^11.0.0"
 
-"@comunica/actor-function-factory-term-str@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-function-factory-term-str/-/actor-function-factory-term-str-4.2.0.tgz"
-  integrity sha512-5cCYssXLuV7V6wCRXxJSTpvWm/EWKK47PV+r8XCH7XsrMY50G5lQYEj9u8dHuXMg6An5vUvJFCJJ4S2vd9T4dQ==
+"@comunica/actor-function-factory-term-str@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-str/-/actor-function-factory-term-str-4.5.0.tgz#0cfa4121e7cf15df447a1c9b7027419a537f3c4a"
+  integrity sha512-E1vrSf+tIL2GX09+ohqY9rjLidFmN33UnarWWOxxkLJCNt6biKBHR/D2eA8r4yADVSn5Ir6DBplns+xZcPE0jw==
   dependencies:
-    "@comunica/bus-function-factory" "^4.2.0"
-    "@comunica/utils-expression-evaluator" "^4.2.0"
+    "@comunica/bus-function-factory" "^4.5.0"
+    "@comunica/utils-expression-evaluator" "^4.5.0"
 
-"@comunica/actor-function-factory-term-sub-str@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-function-factory-term-sub-str/-/actor-function-factory-term-sub-str-4.2.0.tgz"
-  integrity sha512-no0YtISt8oXJo7DaMJ4GR9VW2t82u8Gn0Jw+yKHspL2Up8nK0WRRDPxeRhX6pAKflb/Qa/HFI27pSWbCavPs2g==
+"@comunica/actor-function-factory-term-sub-str@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-sub-str/-/actor-function-factory-term-sub-str-4.5.0.tgz#f8577914048b513761b0f3d2d10f60009704454c"
+  integrity sha512-br0Ihpcpi3D71rWOTC4BvLiIMJT2Qtt8wZEJGNEfFsLV9DfQIO3YhpFuMyPxGZoW5vkWuFVXzmqcK0JuwjLXgQ==
   dependencies:
-    "@comunica/bus-function-factory" "^4.2.0"
-    "@comunica/utils-expression-evaluator" "^4.2.0"
+    "@comunica/bus-function-factory" "^4.5.0"
+    "@comunica/utils-expression-evaluator" "^4.5.0"
 
-"@comunica/actor-function-factory-term-subject@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-function-factory-term-subject/-/actor-function-factory-term-subject-4.2.0.tgz"
-  integrity sha512-bkUyFKy2bunW7geVLroKtI9CudffF723hiZB8MCCopCcHLp75Q8MjxOzrxas+LJgP9KN0EllVUgPMhGUJm80fA==
+"@comunica/actor-function-factory-term-subject@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-subject/-/actor-function-factory-term-subject-4.5.0.tgz#7c87e8d2003b1cb96b3c7b0111e179cda3d24ceb"
+  integrity sha512-9C7qD7BZ9jj+S//aXGvYqNfA/HCPBAPzWz7bBe+eONLnLE/7GjlNj9wspG51gh/gZnJMlUHVLxrLAMR4AxLaWw==
   dependencies:
-    "@comunica/bus-function-factory" "^4.2.0"
-    "@comunica/utils-expression-evaluator" "^4.2.0"
+    "@comunica/bus-function-factory" "^4.5.0"
+    "@comunica/utils-expression-evaluator" "^4.5.0"
 
-"@comunica/actor-function-factory-term-subtraction@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-function-factory-term-subtraction/-/actor-function-factory-term-subtraction-4.2.0.tgz"
-  integrity sha512-ixb2uG5bORM8gU7j7mcEWwIiNHjHpgkQzjq4LgtlNBh5Fndsz+200jmJyocRnGonz1Sc1BR39IvrbDB/doJCsw==
+"@comunica/actor-function-factory-term-subtraction@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-subtraction/-/actor-function-factory-term-subtraction-4.5.0.tgz#cecb80ca7ebb3b0b8ccc7a67d1a5e176588bb3b9"
+  integrity sha512-INkhG5dQZekt3W6tUL4JIjO1ZVHV31OQoAWQv4GEs/a19WM1EMp3oHlHqo8yOqZgnWbBMb9oarOjRYINthaLZg==
   dependencies:
-    "@comunica/bus-function-factory" "^4.2.0"
-    "@comunica/context-entries" "^4.2.0"
-    "@comunica/utils-expression-evaluator" "^4.2.0"
+    "@comunica/bus-function-factory" "^4.5.0"
+    "@comunica/context-entries" "^4.5.0"
+    "@comunica/utils-expression-evaluator" "^4.5.0"
     bignumber.js "^9.1.2"
 
-"@comunica/actor-function-factory-term-timezone@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-function-factory-term-timezone/-/actor-function-factory-term-timezone-4.2.0.tgz"
-  integrity sha512-FG/4XE8i0MPKfuiVfB/08ty4X3LDx+9NSjySP1DKDW5YDNe7HGoUC2OZ0kPuyi9QZENLwV0+2tKrgUK4Hnbu8w==
+"@comunica/actor-function-factory-term-timezone@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-timezone/-/actor-function-factory-term-timezone-4.5.0.tgz#df2a0f56856494ac32ecad81605b0db5ec1df83e"
+  integrity sha512-N44SF5MfzjFhRNDtjJO+E6lfJBX639Ogb2Oc4x2Qh9aj/OUuHuwONEtCwaoUADIThBdDiTTGhlsfwe0tUY3e7A==
   dependencies:
-    "@comunica/bus-function-factory" "^4.2.0"
-    "@comunica/types" "^4.2.0"
-    "@comunica/utils-expression-evaluator" "^4.2.0"
+    "@comunica/bus-function-factory" "^4.5.0"
+    "@comunica/types" "^4.5.0"
+    "@comunica/utils-expression-evaluator" "^4.5.0"
 
-"@comunica/actor-function-factory-term-triple@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-function-factory-term-triple/-/actor-function-factory-term-triple-4.2.0.tgz"
-  integrity sha512-x5IT84sMKK2SGy2hAqMZN04EPP/lzeshEkFR+zYju308A5sCSk23GEnoR3YCtDwtC7HLxgQQIUCiWttgwGPPUQ==
+"@comunica/actor-function-factory-term-triple@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-triple/-/actor-function-factory-term-triple-4.5.0.tgz#541c8a43fa4b88df1d9dca891dcc6dfcbd3a8cbb"
+  integrity sha512-U4yIpuR6n2w9YdRXhrONV34ju8CtVm8jA0pBopnFYK/GwnJqp6YIn00B5AC/WdKDUVZUDgNu9j+XgpwJxsN6pA==
   dependencies:
-    "@comunica/bus-function-factory" "^4.2.0"
-    "@comunica/utils-expression-evaluator" "^4.2.0"
+    "@comunica/bus-function-factory" "^4.5.0"
+    "@comunica/utils-expression-evaluator" "^4.5.0"
 
-"@comunica/actor-function-factory-term-tz@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-function-factory-term-tz/-/actor-function-factory-term-tz-4.2.0.tgz"
-  integrity sha512-CkfWt8pfQ5Qq/LLfor+dn0IfCFpcNfNF/FWDjJaUYsIyqRJvHeqFRTtZNPSCt3xnUskn1WCm99Se7Wi6gckeww==
+"@comunica/actor-function-factory-term-tz@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-tz/-/actor-function-factory-term-tz-4.5.0.tgz#54a1de25433f8b0abc2cebb039fcde309aac5530"
+  integrity sha512-wliS6iY6eDbezKYs6CsVoRqvM6ZVNxKRubEexJYyVPy/DF/KHi2Un0iWQGYu+DM6rRQ5gD/kSjmO5PUjaSvtpg==
   dependencies:
-    "@comunica/bus-function-factory" "^4.2.0"
-    "@comunica/utils-expression-evaluator" "^4.2.0"
+    "@comunica/bus-function-factory" "^4.5.0"
+    "@comunica/utils-expression-evaluator" "^4.5.0"
 
-"@comunica/actor-function-factory-term-ucase@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-function-factory-term-ucase/-/actor-function-factory-term-ucase-4.2.0.tgz"
-  integrity sha512-pBm0gs/PxHrT9joFLsv6C6I/AktEOvAJvvD2XBa4zVE39eNaatouAxzT3xyGVx8mNn3BbjKNA3rBHsnffIRHuA==
+"@comunica/actor-function-factory-term-ucase@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-ucase/-/actor-function-factory-term-ucase-4.5.0.tgz#e80ff67377b74e69325450ccca7054a4be0d74e9"
+  integrity sha512-ygsPFyHpE1vZQvBdLiFsSMrQDw7XVl8KDlWMl0Ntj7w6UZt+DWHAfXzxn94fr2OfBrqguqRc8MLQTsX5IjK+Mw==
   dependencies:
-    "@comunica/bus-function-factory" "^4.2.0"
-    "@comunica/utils-expression-evaluator" "^4.2.0"
+    "@comunica/bus-function-factory" "^4.5.0"
+    "@comunica/utils-expression-evaluator" "^4.5.0"
 
-"@comunica/actor-function-factory-term-unary-minus@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-function-factory-term-unary-minus/-/actor-function-factory-term-unary-minus-4.2.0.tgz"
-  integrity sha512-SAQRAKFXLf3qcCy0bGx6pTncB18PmQtNWU6UPxejsSXhI+yKD/z/4jvSxLFPVrhnveVv0yClC+zw/okc0aM8lg==
+"@comunica/actor-function-factory-term-unary-minus@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-unary-minus/-/actor-function-factory-term-unary-minus-4.5.0.tgz#b27d79c986790fec39689d58051c568e7bc890c7"
+  integrity sha512-f3FsopxQIIIiBQtAHcW4KjW3/RAxAjgNPse2BumY6igUjY8vkYPiqRDMdQkl+iV0tLprGYu0BXyj95F23X/wcA==
   dependencies:
-    "@comunica/bus-function-factory" "^4.2.0"
-    "@comunica/utils-expression-evaluator" "^4.2.0"
+    "@comunica/bus-function-factory" "^4.5.0"
+    "@comunica/utils-expression-evaluator" "^4.5.0"
 
-"@comunica/actor-function-factory-term-unary-plus@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-function-factory-term-unary-plus/-/actor-function-factory-term-unary-plus-4.2.0.tgz"
-  integrity sha512-srkypDUAtIuux/ePalBzoSYnnCGz8Se83bzaurDsUWix336/4E7kkCXnW3EulVDCY1h9oytcSzBFlxLdJm+IwA==
+"@comunica/actor-function-factory-term-unary-plus@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-unary-plus/-/actor-function-factory-term-unary-plus-4.5.0.tgz#bc479108d5f8853fca16aa28668524e107da46a2"
+  integrity sha512-CvJhzQE/TyyVgvbkSEyiLX0NWAeiH1cOkpWTCqazpjRoTsyvrmNQnrdO/c8yPOyylRMZ/sA7Glad8KyBVdTXqg==
   dependencies:
-    "@comunica/bus-function-factory" "^4.2.0"
-    "@comunica/utils-expression-evaluator" "^4.2.0"
+    "@comunica/bus-function-factory" "^4.5.0"
+    "@comunica/utils-expression-evaluator" "^4.5.0"
 
-"@comunica/actor-function-factory-term-uuid@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-function-factory-term-uuid/-/actor-function-factory-term-uuid-4.2.0.tgz"
-  integrity sha512-YWIHuRqVR3uCfaEVPiPWpTJ5cgeU5Gorj/YVsDbwW6Q3soSF7Haet4FbkLzRFmcR8py2Hv4MwLEx/693Csm7Pw==
+"@comunica/actor-function-factory-term-uuid@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-uuid/-/actor-function-factory-term-uuid-4.5.0.tgz#4640775398e9fc83ecc0fea651549c742411b983"
+  integrity sha512-AHDwJR0DxiQexuYLH6EhOirMYcoOOuGW8KhbmCnBilVsx8juZF42l/xiTPbXXEE7QlHGiJImGxkUZF4mcidX9Q==
   dependencies:
-    "@comunica/bus-function-factory" "^4.2.0"
-    "@comunica/utils-expression-evaluator" "^4.2.0"
+    "@comunica/bus-function-factory" "^4.5.0"
+    "@comunica/utils-expression-evaluator" "^4.5.0"
     "@types/uuid" "^10.0.0"
     uuid "^11.0.0"
 
-"@comunica/actor-function-factory-term-xsd-to-boolean@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-function-factory-term-xsd-to-boolean/-/actor-function-factory-term-xsd-to-boolean-4.2.0.tgz"
-  integrity sha512-Gs/vX1eol7kE1hWst/alPovrA0Nash6nUwq0Z/no83mxIHE9upG9jTgGCymJh6VlaYdzcugh1XuDOjqo3+HL6A==
+"@comunica/actor-function-factory-term-xsd-to-boolean@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-xsd-to-boolean/-/actor-function-factory-term-xsd-to-boolean-4.5.0.tgz#448884f51f83a20f7c9f95284e7d927f6be37fdc"
+  integrity sha512-W6uIE3lRGwOpeiuxV7DclRMchm4l2Pnjb8AimAkI8DTt1Q/hEsO3MmO06Fx098OZZCpMk5kV89up92VOKaZTaw==
   dependencies:
-    "@comunica/bus-function-factory" "^4.2.0"
-    "@comunica/types" "^4.2.0"
-    "@comunica/utils-expression-evaluator" "^4.2.0"
+    "@comunica/bus-function-factory" "^4.5.0"
+    "@comunica/types" "^4.5.0"
+    "@comunica/utils-expression-evaluator" "^4.5.0"
 
-"@comunica/actor-function-factory-term-xsd-to-date@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-function-factory-term-xsd-to-date/-/actor-function-factory-term-xsd-to-date-4.2.0.tgz"
-  integrity sha512-ujnLgY+c6jwDHaJsfhQNAXGh28i8eYTsrDsRnvu+oO3fCw04WPhmJh+mQpRjtxIUvDRNXVlvMgvEbCqjyjl6fA==
+"@comunica/actor-function-factory-term-xsd-to-date@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-xsd-to-date/-/actor-function-factory-term-xsd-to-date-4.5.0.tgz#5c0255e60a3371283e70b5c455e757d6ff94a032"
+  integrity sha512-mItiMbvoz63VgmkSYWTvqf9w9OnPXzhpe4WYSV7vKnMTmwPflCAszM6glIiN+UXKNhYFBeqXIxrRZ/fFJPu4Ag==
   dependencies:
-    "@comunica/bus-function-factory" "^4.2.0"
-    "@comunica/utils-expression-evaluator" "^4.2.0"
+    "@comunica/bus-function-factory" "^4.5.0"
+    "@comunica/utils-expression-evaluator" "^4.5.0"
 
-"@comunica/actor-function-factory-term-xsd-to-datetime@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-function-factory-term-xsd-to-datetime/-/actor-function-factory-term-xsd-to-datetime-4.2.0.tgz"
-  integrity sha512-bfvjIP2HanUBJvNIioLVDU21AXWhxWv0BqdWkxCPQ/cTlX9GQ7NJBIrIuKQ/HoJG3RkbSRXwh0FziB9FTjaAvw==
+"@comunica/actor-function-factory-term-xsd-to-datetime@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-xsd-to-datetime/-/actor-function-factory-term-xsd-to-datetime-4.5.0.tgz#efb6b8f9cf2bded699c64e44a6022f32921a14c5"
+  integrity sha512-U54xs8vL9lkpHyJBwZA4Ed/zC6twOGPl05ApFomsyw4JYEoF0T9MyGQwJgwrDRz6NLaNdbrjtrC3BN/sk9XIdA==
   dependencies:
-    "@comunica/bus-function-factory" "^4.2.0"
-    "@comunica/types" "^4.2.0"
-    "@comunica/utils-expression-evaluator" "^4.2.0"
+    "@comunica/bus-function-factory" "^4.5.0"
+    "@comunica/types" "^4.5.0"
+    "@comunica/utils-expression-evaluator" "^4.5.0"
 
-"@comunica/actor-function-factory-term-xsd-to-day-time-duration@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-function-factory-term-xsd-to-day-time-duration/-/actor-function-factory-term-xsd-to-day-time-duration-4.2.0.tgz"
-  integrity sha512-n66L7DkLDTUbVWT1ad9FM+llHuhT35Ypc9/3lgJcAZRT9EOfGkBH2t/4K8250NwSTKa+Z0lUC4kD6hdhKN4Nzw==
+"@comunica/actor-function-factory-term-xsd-to-day-time-duration@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-xsd-to-day-time-duration/-/actor-function-factory-term-xsd-to-day-time-duration-4.5.0.tgz#e78ebfb70613ec56f803fbb318bfc25119968e3d"
+  integrity sha512-9LDlkfdjpeLf2sJCCTK4JfPUqAfZ5WC3DDb3JiKeSWn0a63o1bUuvznEZniqZPJ0XPDJ3uYd7oXRlWGHP8TCKg==
   dependencies:
-    "@comunica/bus-function-factory" "^4.2.0"
-    "@comunica/types" "^4.2.0"
-    "@comunica/utils-expression-evaluator" "^4.2.0"
+    "@comunica/bus-function-factory" "^4.5.0"
+    "@comunica/types" "^4.5.0"
+    "@comunica/utils-expression-evaluator" "^4.5.0"
 
-"@comunica/actor-function-factory-term-xsd-to-decimal@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-function-factory-term-xsd-to-decimal/-/actor-function-factory-term-xsd-to-decimal-4.2.0.tgz"
-  integrity sha512-i2rKCbn27NFJJbQ44N0WEWQX8I5IfyG4gELu1ZkFhefEst8gXs79Mm6BiVIJv0gWHSeCcsO1hBKuOiUvXDZl9g==
+"@comunica/actor-function-factory-term-xsd-to-decimal@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-xsd-to-decimal/-/actor-function-factory-term-xsd-to-decimal-4.5.0.tgz#36bc3ea112d399bd7bd7c0f06ba1738e68960a7c"
+  integrity sha512-J4mhhGWpkm7K+vJTzxoG7Skon/PdasA2Tl1OUOYboU1SBgaEsIovoIxsDqdVV6HU7O4mHli0ZXH9HM5KVM+GXw==
   dependencies:
-    "@comunica/bus-function-factory" "^4.2.0"
-    "@comunica/utils-expression-evaluator" "^4.2.0"
+    "@comunica/bus-function-factory" "^4.5.0"
+    "@comunica/utils-expression-evaluator" "^4.5.0"
 
-"@comunica/actor-function-factory-term-xsd-to-double@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-function-factory-term-xsd-to-double/-/actor-function-factory-term-xsd-to-double-4.2.0.tgz"
-  integrity sha512-rqLUOQgW36e4Brr7ZWW59m16ERCr28UOiNX6gxatoT8TICO6gKZvxgsxB+cZPEpCrLYmlpxdbwoH4Qkd7Tu5WA==
+"@comunica/actor-function-factory-term-xsd-to-double@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-xsd-to-double/-/actor-function-factory-term-xsd-to-double-4.5.0.tgz#3ff3bd355a18505f310cd02fba80d065a25333ac"
+  integrity sha512-CsoZVOz4FqEGlyRvFDwhtFELL8hSRysiDD78b67esqEWMYWVPfS34/SaRjgN335tkIFiCM9xEq0vA0I2kLlsnw==
   dependencies:
-    "@comunica/bus-function-factory" "^4.2.0"
-    "@comunica/utils-expression-evaluator" "^4.2.0"
+    "@comunica/bus-function-factory" "^4.5.0"
+    "@comunica/utils-expression-evaluator" "^4.5.0"
 
-"@comunica/actor-function-factory-term-xsd-to-duration@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-function-factory-term-xsd-to-duration/-/actor-function-factory-term-xsd-to-duration-4.2.0.tgz"
-  integrity sha512-aarePSIbPwA5Ei93dAM0kowKxnvaSd5FdaZIqI6gAZMmo/nXOM8yrxWq0yhkgBtrfgXU4Aiph8w9aKIG8tZwcg==
+"@comunica/actor-function-factory-term-xsd-to-duration@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-xsd-to-duration/-/actor-function-factory-term-xsd-to-duration-4.5.0.tgz#128a25214297786b42e36d511218bf67e6be884b"
+  integrity sha512-djMWp2ZXz9ffY3JYivsgCH+tJQLia53P0/sqLXuCeJoPsg3QpKoSpwy9wIBkAcaLatAhn6jQJAZTeEVWPNlY+w==
   dependencies:
-    "@comunica/bus-function-factory" "^4.2.0"
-    "@comunica/types" "^4.2.0"
-    "@comunica/utils-expression-evaluator" "^4.2.0"
+    "@comunica/bus-function-factory" "^4.5.0"
+    "@comunica/types" "^4.5.0"
+    "@comunica/utils-expression-evaluator" "^4.5.0"
 
-"@comunica/actor-function-factory-term-xsd-to-float@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-function-factory-term-xsd-to-float/-/actor-function-factory-term-xsd-to-float-4.2.0.tgz"
-  integrity sha512-d+Kz4BZ3aVRCtRW5ubF+CAwNiub6UsEHeIIi0ck0YVUvHKn2lf8QP5WaeLhzrFlv/Bebal9mYQRrVsp0k3Cy1g==
+"@comunica/actor-function-factory-term-xsd-to-float@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-xsd-to-float/-/actor-function-factory-term-xsd-to-float-4.5.0.tgz#6c659bf269a5ca7ba403fbf2c5360d23cdee935a"
+  integrity sha512-F/BpWl3AEZeSoTe9TF3xd3sgI8g6F4q6+hekSQcp7LWLChn4ln+Bl4N+ZRocxIFJevFjGMnnjtoOi25iOhVx6A==
   dependencies:
-    "@comunica/bus-function-factory" "^4.2.0"
-    "@comunica/utils-expression-evaluator" "^4.2.0"
+    "@comunica/bus-function-factory" "^4.5.0"
+    "@comunica/utils-expression-evaluator" "^4.5.0"
 
-"@comunica/actor-function-factory-term-xsd-to-integer@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-function-factory-term-xsd-to-integer/-/actor-function-factory-term-xsd-to-integer-4.2.0.tgz"
-  integrity sha512-+iKBKVZNrsTVpD9KnoSlGA2h+GswWfTCaAFbhr0dgqNMHWSv7wBkZSUFGFzZ7Bpf4+bvRkfawDPT7xyUR3/kIw==
+"@comunica/actor-function-factory-term-xsd-to-integer@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-xsd-to-integer/-/actor-function-factory-term-xsd-to-integer-4.5.0.tgz#839ff7983ebf596fd1c164c49313874a0ed5c242"
+  integrity sha512-diT42cLv4L8ZrlvL5UxQ50EXyZj+Id94RJUZjewmnFb13NWrfwjKKS6bdtFV+rNtiVPsvVOgzXyJEws6tHwjUA==
   dependencies:
-    "@comunica/bus-function-factory" "^4.2.0"
-    "@comunica/utils-expression-evaluator" "^4.2.0"
+    "@comunica/bus-function-factory" "^4.5.0"
+    "@comunica/utils-expression-evaluator" "^4.5.0"
 
-"@comunica/actor-function-factory-term-xsd-to-string@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-function-factory-term-xsd-to-string/-/actor-function-factory-term-xsd-to-string-4.2.0.tgz"
-  integrity sha512-HKIvv3fZUtRR3z9Xqlu1pxxcVhopLNgwNH7cgKG8zdvFrQ2VJYToz1FvU9kCM2lq1TYLMOykj9rd1JTtKSbn5A==
+"@comunica/actor-function-factory-term-xsd-to-string@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-xsd-to-string/-/actor-function-factory-term-xsd-to-string-4.5.0.tgz#5dd7828d7841d47107049db17c485c5aa90077bc"
+  integrity sha512-WMKc1Y+leNhUxUUxlgur+Xbq9oHhqI/VUbkPlqcEYRGHH792d5D652a2yND8SbxpF7gdsPpoFYpBmmAwipsWQw==
   dependencies:
-    "@comunica/bus-function-factory" "^4.2.0"
-    "@comunica/utils-expression-evaluator" "^4.2.0"
+    "@comunica/bus-function-factory" "^4.5.0"
+    "@comunica/utils-expression-evaluator" "^4.5.0"
 
-"@comunica/actor-function-factory-term-xsd-to-time@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-function-factory-term-xsd-to-time/-/actor-function-factory-term-xsd-to-time-4.2.0.tgz"
-  integrity sha512-AOW8thLYfdqu9cQh17Bivg5ewriB9fyxaumtX5hON3ZedzcqAOTZMPf/x3DC4WkRfd3WkoYnT9S9AZG+Bn9XAg==
+"@comunica/actor-function-factory-term-xsd-to-time@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-xsd-to-time/-/actor-function-factory-term-xsd-to-time-4.5.0.tgz#4fe0f0377a452b3c2c4f11bbf004eba69f8d04f4"
+  integrity sha512-5C8e71T6FN0Wt1K0C2P2ooC1uBFid7UBkeGhB+GZvbiGcYe3jRJgTACgCGhONuqgIqNvrRuS0lbS7/eKp1dC+A==
   dependencies:
-    "@comunica/bus-function-factory" "^4.2.0"
-    "@comunica/types" "^4.2.0"
-    "@comunica/utils-expression-evaluator" "^4.2.0"
+    "@comunica/bus-function-factory" "^4.5.0"
+    "@comunica/types" "^4.5.0"
+    "@comunica/utils-expression-evaluator" "^4.5.0"
 
-"@comunica/actor-function-factory-term-xsd-to-year-month-duration@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-function-factory-term-xsd-to-year-month-duration/-/actor-function-factory-term-xsd-to-year-month-duration-4.2.0.tgz"
-  integrity sha512-l20dDlL0VbUpDoSQdU47CYKLP5MdFWqh3ULkD0VR4eDqwSSclL31JR0scplbrWcda5jRGhGhBp01YQ13tyVfXw==
+"@comunica/actor-function-factory-term-xsd-to-year-month-duration@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-xsd-to-year-month-duration/-/actor-function-factory-term-xsd-to-year-month-duration-4.5.0.tgz#5c72ce18430745baede9a6fbdb2a26fc96efb1fd"
+  integrity sha512-+wKVAq7emP25PgjyDZeBWF5hlOJ3SNOtMRM0lfU3cHgigxKs91BELss0JSdHwz7oxTwuxLMogAeA/sknMIvC7g==
   dependencies:
-    "@comunica/bus-function-factory" "^4.2.0"
-    "@comunica/types" "^4.2.0"
-    "@comunica/utils-expression-evaluator" "^4.2.0"
+    "@comunica/bus-function-factory" "^4.5.0"
+    "@comunica/types" "^4.5.0"
+    "@comunica/utils-expression-evaluator" "^4.5.0"
 
-"@comunica/actor-function-factory-term-year@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-function-factory-term-year/-/actor-function-factory-term-year-4.2.0.tgz"
-  integrity sha512-Wfk3uKc+SnQEi3yjBFYeogQxBsojFAC4Ogwg2gjq5DI29nXiYWV3356tCHpscgUUfjo3nh2F8PecUBDCGmTOXw==
+"@comunica/actor-function-factory-term-year@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-year/-/actor-function-factory-term-year-4.5.0.tgz#cda6a2e465137fe10aa840e7a8d442adf670b8a0"
+  integrity sha512-o5Em71Rj3w+YnDbDE5Rkjzlc/enXPFxnFFesAHx8BXwqTK1Lqr2x2izYI1mZvjsy4czwtY7t3Qa9OKNc/AdJJQ==
   dependencies:
-    "@comunica/bus-function-factory" "^4.2.0"
-    "@comunica/utils-expression-evaluator" "^4.2.0"
+    "@comunica/bus-function-factory" "^4.5.0"
+    "@comunica/utils-expression-evaluator" "^4.5.0"
 
-"@comunica/actor-hash-bindings-murmur@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-hash-bindings-murmur/-/actor-hash-bindings-murmur-4.2.0.tgz"
-  integrity sha512-gEip+3zcO6NKgf0N9ti+Lx+a9CYsWQ4gNZX22GvFSRtMroqlF915Q0nkqUjOc1XHZN7OwAbYUF8Ioxwz9gEJxw==
+"@comunica/actor-hash-bindings-murmur@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-hash-bindings-murmur/-/actor-hash-bindings-murmur-4.5.0.tgz#fffc8f4155a3376f206dc16ca15fc3f26a5aa2ed"
+  integrity sha512-bebfR1rwPT+TPgT07P7cwblDlP8/gVPIALZMIqU0w9IbH54kZcFsnc2OQLUCar1Aq7EZUkny/lY2UjcHagObcg==
   dependencies:
-    "@comunica/bus-hash-bindings" "^4.2.0"
-    "@comunica/core" "^4.2.0"
+    "@comunica/bus-hash-bindings" "^4.5.0"
+    "@comunica/core" "^4.5.0"
     "@types/imurmurhash" "^0.1.4"
     imurmurhash "^0.1.4"
 
-"@comunica/actor-hash-quads-murmur@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-hash-quads-murmur/-/actor-hash-quads-murmur-4.2.0.tgz"
-  integrity sha512-kv+hAro+VPtWp+HhT0IBRL1qAQtC7xZ78wzKiarjrOOMpfoXtvBZ4LvW4N+A8toUGALoSkAqDP1U3he+Lo7ouA==
+"@comunica/actor-hash-quads-murmur@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-hash-quads-murmur/-/actor-hash-quads-murmur-4.5.0.tgz#b4aac019156c4c9c7762073866165b9180357dab"
+  integrity sha512-3A3aNcY23HWKoz+5BFyZXNoLYsuiRh9WGYJ+zzZkMOuNopUr/z5+JoYXbQKbbd8iQeKctdCzi9eE4XMU8emUSg==
   dependencies:
-    "@comunica/bus-hash-quads" "^4.2.0"
-    "@comunica/core" "^4.2.0"
+    "@comunica/bus-hash-quads" "^4.5.0"
+    "@comunica/core" "^4.5.0"
     "@types/imurmurhash" "^0.1.4"
     imurmurhash "^0.1.4"
 
@@ -2356,1154 +2362,1168 @@
     "@comunica/mediatortype-time" "^2.10.0"
     "@comunica/types" "^2.10.0"
 
-"@comunica/actor-http-proxy@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-http-proxy/-/actor-http-proxy-4.2.0.tgz"
-  integrity sha512-aKJEv7mkMJiMJRTxsqPyUfjczoKDT9u/0wIWzSdW215hdW5ITAla08fD+/yIqKAD/Nz9bdZo3CSLwIMrtENmEQ==
+"@comunica/actor-http-proxy@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-http-proxy/-/actor-http-proxy-4.5.0.tgz#a4d4c20abd74887efd2047c13c154f626f6d761c"
+  integrity sha512-M5UQ+/IqXFNXLu9qSFNeeph/vaP349HQozqZzOY+HTO4TNWSIcB/XO6HgE3SC7r4G+KV+s9WbHwQO/8PxshBPQ==
   dependencies:
-    "@comunica/bus-http" "^4.2.0"
-    "@comunica/context-entries" "^4.2.0"
-    "@comunica/core" "^4.2.0"
-    "@comunica/mediatortype-time" "^4.2.0"
-    "@comunica/types" "^4.2.0"
+    "@comunica/bus-http" "^4.5.0"
+    "@comunica/context-entries" "^4.5.0"
+    "@comunica/core" "^4.5.0"
+    "@comunica/mediatortype-time" "^4.5.0"
+    "@comunica/types" "^4.5.0"
 
-"@comunica/actor-init-query@^4.3.0":
-  version "4.3.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-init-query/-/actor-init-query-4.3.0.tgz"
-  integrity sha512-Owzar4cwV3FLZGaeyIEItZNHOjgtRtiFcDjnvVWiFmsHTccgAxzBmfJ5Tecw28bCcH6XfT6FE30pLScTOkYM7g==
+"@comunica/actor-init-query@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-init-query/-/actor-init-query-4.5.0.tgz#7e45d40c8745aadd5eef24f054f693f265dd572f"
+  integrity sha512-BC+5k0qRxIyl4j00tbqiwKSoOHBkcApMVvXfzYGnK/KgJC8Xj/cPivf3+64Nn4oMgm5kJbp5VW9v7A4+6PB25w==
   dependencies:
-    "@comunica/actor-http-proxy" "^4.2.0"
-    "@comunica/bus-http-invalidate" "^4.2.0"
-    "@comunica/bus-init" "^4.2.0"
-    "@comunica/bus-query-process" "^4.2.0"
-    "@comunica/bus-query-result-serialize" "^4.2.0"
-    "@comunica/context-entries" "^4.2.0"
-    "@comunica/core" "^4.2.0"
-    "@comunica/logger-pretty" "^4.2.0"
-    "@comunica/runner" "^4.2.0"
-    "@comunica/types" "^4.2.0"
+    "@comunica/actor-http-proxy" "^4.5.0"
+    "@comunica/bus-http-invalidate" "^4.5.0"
+    "@comunica/bus-init" "^4.5.0"
+    "@comunica/bus-query-process" "^4.5.0"
+    "@comunica/bus-query-result-serialize" "^4.5.0"
+    "@comunica/context-entries" "^4.5.0"
+    "@comunica/core" "^4.5.0"
+    "@comunica/logger-pretty" "^4.5.0"
+    "@comunica/runner" "^4.5.0"
+    "@comunica/types" "^4.5.0"
     "@rdfjs/types" "*"
     "@types/yargs" "^17.0.24"
     asynciterator "^3.9.0"
     negotiate "^1.0.1"
     rdf-quad "^1.5.0"
     readable-stream "^4.5.2"
+    sparqlalgebrajs "^5.0.2"
     yargs "^17.7.2"
   optionalDependencies:
     process "^0.11.10"
 
-"@comunica/actor-optimize-query-operation-assign-sources-exhaustive@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-assign-sources-exhaustive/-/actor-optimize-query-operation-assign-sources-exhaustive-4.2.0.tgz"
-  integrity sha512-vaUqWbkQkYX2h66SSqr8wtJ++qdvP7OSLS1JN4J+6C/Q/YxrkvWWEbvOMrwziZ0xhsVBwDWLhb0VH+qN1shmMA==
+"@comunica/actor-optimize-query-operation-assign-sources-exhaustive@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-optimize-query-operation-assign-sources-exhaustive/-/actor-optimize-query-operation-assign-sources-exhaustive-4.5.0.tgz#047d8aba831d4f906676b117b885daa6d57d6ff4"
+  integrity sha512-FPw1xidcpP1b6hVJ2zM3ib6wvHEoVnHEuh59jIgRV6Iz5idraCK3EVagYCxSWo9Xj0NR48/6DUVMjVWl7JMnFA==
   dependencies:
-    "@comunica/bus-optimize-query-operation" "^4.2.0"
-    "@comunica/bus-rdf-update-quads" "^4.2.0"
-    "@comunica/context-entries" "^4.2.0"
-    "@comunica/core" "^4.2.0"
-    "@comunica/types" "^4.2.0"
-    "@comunica/utils-query-operation" "^4.2.0"
-    sparqlalgebrajs "^4.3.8"
+    "@comunica/bus-optimize-query-operation" "^4.5.0"
+    "@comunica/bus-rdf-update-quads" "^4.5.0"
+    "@comunica/context-entries" "^4.5.0"
+    "@comunica/core" "^4.5.0"
+    "@comunica/types" "^4.5.0"
+    "@comunica/utils-query-operation" "^4.5.0"
+    sparqlalgebrajs "^5.0.2"
 
-"@comunica/actor-optimize-query-operation-bgp-to-join@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-bgp-to-join/-/actor-optimize-query-operation-bgp-to-join-4.2.0.tgz"
-  integrity sha512-Up+9nLzFmEynCr6jlglhd36plEA5nL/oLOVyIgiYrn66Vav/Hcago8rYI39yhOKEEJgOhEOfcfeBT1zUzwQ8hQ==
+"@comunica/actor-optimize-query-operation-bgp-to-join@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-optimize-query-operation-bgp-to-join/-/actor-optimize-query-operation-bgp-to-join-4.5.0.tgz#6151bf0ad765b91c786d67156fc66aeec33c2686"
+  integrity sha512-1raQz4vjZ8MUCAhh4EYcj+6aLnb292NJoSc+jTBC+u5rtJ4gmFqNDyCJxjoI/QbxU9Ioy2Hlj4WxMq7M6F816g==
   dependencies:
-    "@comunica/bus-optimize-query-operation" "^4.2.0"
-    "@comunica/context-entries" "^4.2.0"
-    "@comunica/core" "^4.2.0"
-    sparqlalgebrajs "^4.3.8"
+    "@comunica/bus-optimize-query-operation" "^4.5.0"
+    "@comunica/context-entries" "^4.5.0"
+    "@comunica/core" "^4.5.0"
+    sparqlalgebrajs "^5.0.2"
 
-"@comunica/actor-optimize-query-operation-construct-distinct@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-construct-distinct/-/actor-optimize-query-operation-construct-distinct-4.2.0.tgz"
-  integrity sha512-60yaqok3WcLEtW0Z0JKZe1yqQWUl48IXNlusBWT3FizdKNYmk49dxVSRcqLThzVNog0zyxFh8N33CYef4ivdwg==
+"@comunica/actor-optimize-query-operation-construct-distinct@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-optimize-query-operation-construct-distinct/-/actor-optimize-query-operation-construct-distinct-4.5.0.tgz#9f4aab1f9750a210443e65849a4711f6953bc35d"
+  integrity sha512-1phqt7HRuGMf6DzBYxlwJG8gw0KTyfFomhc4Uvr3QZrzRJ9Z41NgDTkSd+OGhbxwFm+aJ5O51VSi0FRK5K/Rvw==
   dependencies:
-    "@comunica/bus-optimize-query-operation" "^4.2.0"
-    "@comunica/context-entries" "^4.2.0"
-    "@comunica/core" "^4.2.0"
-    sparqlalgebrajs "^4.3.8"
+    "@comunica/bus-optimize-query-operation" "^4.5.0"
+    "@comunica/context-entries" "^4.5.0"
+    "@comunica/core" "^4.5.0"
+    sparqlalgebrajs "^5.0.2"
 
-"@comunica/actor-optimize-query-operation-describe-to-constructs-subject@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-describe-to-constructs-subject/-/actor-optimize-query-operation-describe-to-constructs-subject-4.2.0.tgz"
-  integrity sha512-PGrxXovxydcVc1ZgK9i98IOLRH2+wXNlWDYAy9HeqtkPZwoAB66D413fCNBa+PkeB8wMudBmKuJpGpWi1kYidA==
+"@comunica/actor-optimize-query-operation-describe-to-constructs-subject@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-optimize-query-operation-describe-to-constructs-subject/-/actor-optimize-query-operation-describe-to-constructs-subject-4.5.0.tgz#0befde10ef8c3f7efa76e0eb5dd8f681542befef"
+  integrity sha512-bPN82pm7InpjtNvrehl4qaYAu5G8gz2pCzviPo3rHi3syYKMDDXHSW51IpkE904YAysuKbgX4hPZ17WENh4Wpg==
   dependencies:
-    "@comunica/bus-optimize-query-operation" "^4.2.0"
-    "@comunica/context-entries" "^4.2.0"
-    "@comunica/core" "^4.2.0"
-    sparqlalgebrajs "^4.3.8"
+    "@comunica/bus-optimize-query-operation" "^4.5.0"
+    "@comunica/context-entries" "^4.5.0"
+    "@comunica/core" "^4.5.0"
+    sparqlalgebrajs "^5.0.2"
 
-"@comunica/actor-optimize-query-operation-filter-pushdown@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-filter-pushdown/-/actor-optimize-query-operation-filter-pushdown-4.2.0.tgz"
-  integrity sha512-FQqWSl24B0yrw7fqufLNXXGLND3Ags0bsn5qDfhI970TlZjg6ZMNM8LwxxCc97qjyHcD+s1BA7IVQghu4dbALg==
+"@comunica/actor-optimize-query-operation-filter-pushdown@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-optimize-query-operation-filter-pushdown/-/actor-optimize-query-operation-filter-pushdown-4.5.0.tgz#82ff080aab8d4f987b694af64ff653640c81a47b"
+  integrity sha512-2U2uSbaJPCy8pngkJ/c4QKBHObzulOndFO1c2lrdfeMuyq3usUEcxBvoWufeKWhdit88Re+wHJyPY+ZYw5T7hg==
   dependencies:
-    "@comunica/bus-optimize-query-operation" "^4.2.0"
-    "@comunica/context-entries" "^4.2.0"
-    "@comunica/core" "^4.2.0"
-    "@comunica/types" "^4.2.0"
-    "@comunica/utils-query-operation" "^4.2.0"
+    "@comunica/bus-optimize-query-operation" "^4.5.0"
+    "@comunica/context-entries" "^4.5.0"
+    "@comunica/core" "^4.5.0"
+    "@comunica/types" "^4.5.0"
+    "@comunica/utils-query-operation" "^4.5.0"
     "@rdfjs/types" "*"
     rdf-terms "^1.11.0"
-    sparqlalgebrajs "^4.3.8"
+    sparqlalgebrajs "^5.0.2"
 
-"@comunica/actor-optimize-query-operation-group-sources@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-group-sources/-/actor-optimize-query-operation-group-sources-4.2.0.tgz"
-  integrity sha512-a8rBZrlCOhuS8p4LEzgZaGEnmHWkGORAQWUxVurgoQv1tdmSfYVx9tnkk0MSPFt9psBAcSizs7IcZbZTkABZpw==
+"@comunica/actor-optimize-query-operation-group-sources@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-optimize-query-operation-group-sources/-/actor-optimize-query-operation-group-sources-4.5.0.tgz#1ef0ea43e8ec628af0a512840723c8fcb229542f"
+  integrity sha512-IsRPmnSRzKzW/YnKlRQt06qs+ytn1ML50MYwq1siUS8GpCHlBsb+uhYPDb3+1gr/+TYPZro7PzGS4Gn7pdzfAg==
   dependencies:
-    "@comunica/bus-optimize-query-operation" "^4.2.0"
-    "@comunica/context-entries" "^4.2.0"
-    "@comunica/core" "^4.2.0"
-    "@comunica/types" "^4.2.0"
-    "@comunica/utils-query-operation" "^4.2.0"
-    sparqlalgebrajs "^4.3.8"
+    "@comunica/bus-optimize-query-operation" "^4.5.0"
+    "@comunica/context-entries" "^4.5.0"
+    "@comunica/core" "^4.5.0"
+    "@comunica/types" "^4.5.0"
+    "@comunica/utils-query-operation" "^4.5.0"
+    sparqlalgebrajs "^5.0.2"
 
-"@comunica/actor-optimize-query-operation-join-bgp@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-join-bgp/-/actor-optimize-query-operation-join-bgp-4.2.0.tgz"
-  integrity sha512-NU6dmRJh48vPMcNF2gtp2iGQexHD3VmOITti3M+SfHdmLrsDKH15aMoKboISPvM0X5ZJxSuaZvOB/detmqrucw==
+"@comunica/actor-optimize-query-operation-join-bgp@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-optimize-query-operation-join-bgp/-/actor-optimize-query-operation-join-bgp-4.5.0.tgz#254bb8202e67bca4077e7a853d96c3bdcac36de9"
+  integrity sha512-/rl5ig8O2GVTrH0Ux2CjAjyTvv7XvH4nYOjuQwZx05YmsPb6rEzzE7RAGoln4qZNG9TY4X0cKwxQcXmyTJMDGQ==
   dependencies:
-    "@comunica/bus-optimize-query-operation" "^4.2.0"
-    "@comunica/context-entries" "^4.2.0"
-    "@comunica/core" "^4.2.0"
-    "@comunica/types" "^4.2.0"
-    sparqlalgebrajs "^4.3.8"
+    "@comunica/bus-optimize-query-operation" "^4.5.0"
+    "@comunica/context-entries" "^4.5.0"
+    "@comunica/core" "^4.5.0"
+    "@comunica/types" "^4.5.0"
+    sparqlalgebrajs "^5.0.2"
 
-"@comunica/actor-optimize-query-operation-join-connected@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-join-connected/-/actor-optimize-query-operation-join-connected-4.2.0.tgz"
-  integrity sha512-/CmLxByNqOlI4bFmaLMicNDtwX4p3zVgzPm5zOVgs2XygRqWqZTBWKUwxWAocMb8fDQsVYhgZGZ/NVVAEvolAQ==
+"@comunica/actor-optimize-query-operation-join-connected@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-optimize-query-operation-join-connected/-/actor-optimize-query-operation-join-connected-4.5.0.tgz#f6fff2cab910a8ee5a11ad5602f6ee09f66e286e"
+  integrity sha512-wJ0obFZHNaQSlyJCwWlfm/8OqNvHSLdXWlfAm3ZWeeDg7QGBDMZjdoHG5uNSYRsYzxv5GGMduTs1C2kymgfkqA==
   dependencies:
-    "@comunica/bus-optimize-query-operation" "^4.2.0"
-    "@comunica/context-entries" "^4.2.0"
-    "@comunica/core" "^4.2.0"
-    "@comunica/types" "^4.2.0"
-    sparqlalgebrajs "^4.3.8"
+    "@comunica/bus-optimize-query-operation" "^4.5.0"
+    "@comunica/context-entries" "^4.5.0"
+    "@comunica/core" "^4.5.0"
+    "@comunica/types" "^4.5.0"
+    sparqlalgebrajs "^5.0.2"
 
-"@comunica/actor-optimize-query-operation-prune-empty-source-operations@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-prune-empty-source-operations/-/actor-optimize-query-operation-prune-empty-source-operations-4.2.0.tgz"
-  integrity sha512-UvFIZCqQRAFtkMPvlKhZMwGAPSKoxh4+AFqzJVjwGg56HQCWMfvW4WKCqUJaDcmNzCrYRSZThzhNwQNvqS6+AA==
+"@comunica/actor-optimize-query-operation-leftjoin-expression-pushdown@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-optimize-query-operation-leftjoin-expression-pushdown/-/actor-optimize-query-operation-leftjoin-expression-pushdown-4.5.0.tgz#5a3e88057d7152dceaf916a15d6a8c39653d54a4"
+  integrity sha512-j8aHL24PNXhpdDuLNmxUK5Y2JRZDELKZK12vCosAkh9YBcvKRM6liGm8IErfMWqLIk8W9SGac80MP04CCiaAKw==
   dependencies:
-    "@comunica/bus-optimize-query-operation" "^4.2.0"
-    "@comunica/context-entries" "^4.2.0"
-    "@comunica/core" "^4.2.0"
-    "@comunica/types" "^4.2.0"
-    "@comunica/utils-query-operation" "^4.2.0"
-    sparqlalgebrajs "^4.3.8"
+    "@comunica/bus-optimize-query-operation" "^4.5.0"
+    "@comunica/context-entries" "^4.5.0"
+    "@comunica/core" "^4.5.0"
+    "@comunica/types" "^4.5.0"
+    "@comunica/utils-query-operation" "^4.5.0"
+    "@rdfjs/types" "*"
+    sparqlalgebrajs "^5.0.2"
 
-"@comunica/actor-optimize-query-operation-rewrite-add@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-rewrite-add/-/actor-optimize-query-operation-rewrite-add-4.2.0.tgz"
-  integrity sha512-EdRtrH4A6owpQnabonKSQ2B4OiteUJM45iX5vJ/8lQQxr4Z1JJqZ8ub1m7oKXZG8SaH/qKSVNsVudaEfMeATuQ==
+"@comunica/actor-optimize-query-operation-prune-empty-source-operations@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-optimize-query-operation-prune-empty-source-operations/-/actor-optimize-query-operation-prune-empty-source-operations-4.5.0.tgz#24c619f859c7521c38b7f307d32914cf58a8f8d9"
+  integrity sha512-xyLHO3ZP62QAviQcAuluZuNQThyu0x0qT8uSy3EcwdLAaaAasZFf0TYric+cMMFeVk/lkbi250ksnx8HOLDuQw==
   dependencies:
-    "@comunica/bus-optimize-query-operation" "^4.2.0"
-    "@comunica/context-entries" "^4.2.0"
-    "@comunica/core" "^4.2.0"
-    "@comunica/types" "^4.2.0"
+    "@comunica/bus-optimize-query-operation" "^4.5.0"
+    "@comunica/context-entries" "^4.5.0"
+    "@comunica/core" "^4.5.0"
+    "@comunica/types" "^4.5.0"
+    "@comunica/utils-query-operation" "^4.5.0"
+    sparqlalgebrajs "^5.0.2"
+
+"@comunica/actor-optimize-query-operation-rewrite-add@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-optimize-query-operation-rewrite-add/-/actor-optimize-query-operation-rewrite-add-4.5.0.tgz#6c68e2a0f5c9e86c17f5db7af47d890288073741"
+  integrity sha512-n9MgkIpjQ0OswV7tmaKGPruq/WaeOeHzjPt4uf7zoLBGna5UsUWzuL/hnQyIH69zAEDhzyHy2COCefLMKkIyvw==
+  dependencies:
+    "@comunica/bus-optimize-query-operation" "^4.5.0"
+    "@comunica/context-entries" "^4.5.0"
+    "@comunica/core" "^4.5.0"
+    "@comunica/types" "^4.5.0"
     "@rdfjs/types" "*"
     rdf-data-factory "^1.1.2"
-    sparqlalgebrajs "^4.3.8"
+    sparqlalgebrajs "^5.0.2"
 
-"@comunica/actor-optimize-query-operation-rewrite-copy@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-rewrite-copy/-/actor-optimize-query-operation-rewrite-copy-4.2.0.tgz"
-  integrity sha512-O8gpFC5GiW2L/iVtK/XGh//KT/A7xx9FKbMsN6ICyNSzG1fNrHa2+fxg4PTuhA6DVRr1WZzUHlqmO3CEF0Nt3A==
+"@comunica/actor-optimize-query-operation-rewrite-copy@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-optimize-query-operation-rewrite-copy/-/actor-optimize-query-operation-rewrite-copy-4.5.0.tgz#2c6d4c84ba6e9f5ed58b5623c54bc2f3de8c1a3d"
+  integrity sha512-dlzn9XlJmgGS32xKiuP++/9qAEPWgXDZ9j1dOBscIzVfsbcwx6zdHbQ6qB0vFM7Ged88CIGS4waCSE/S3gExdg==
   dependencies:
-    "@comunica/bus-optimize-query-operation" "^4.2.0"
-    "@comunica/context-entries" "^4.2.0"
-    "@comunica/core" "^4.2.0"
-    "@comunica/types" "^4.2.0"
-    sparqlalgebrajs "^4.3.8"
+    "@comunica/bus-optimize-query-operation" "^4.5.0"
+    "@comunica/context-entries" "^4.5.0"
+    "@comunica/core" "^4.5.0"
+    "@comunica/types" "^4.5.0"
+    sparqlalgebrajs "^5.0.2"
 
-"@comunica/actor-optimize-query-operation-rewrite-move@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-rewrite-move/-/actor-optimize-query-operation-rewrite-move-4.2.0.tgz"
-  integrity sha512-L6DgmdDTXTewnEX1yDuxlW/4wTA80AhXMI7JfEBqQSKnjGyZLNswPHkUf8lt1muDN/7Y/qICuCBKvJW8HBxQjg==
+"@comunica/actor-optimize-query-operation-rewrite-move@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-optimize-query-operation-rewrite-move/-/actor-optimize-query-operation-rewrite-move-4.5.0.tgz#2ddfebe7b005abd48e8de235108291605344fd78"
+  integrity sha512-ITtO/5XpTewCvDuCISmtX2NGampMCGpHf6s3ew/g2YBEVSeTDhqgA73isHA847Q8cfxOESwChGFCP4CuiHv91w==
   dependencies:
-    "@comunica/bus-optimize-query-operation" "^4.2.0"
-    "@comunica/context-entries" "^4.2.0"
-    "@comunica/core" "^4.2.0"
-    "@comunica/types" "^4.2.0"
-    sparqlalgebrajs "^4.3.8"
+    "@comunica/bus-optimize-query-operation" "^4.5.0"
+    "@comunica/context-entries" "^4.5.0"
+    "@comunica/core" "^4.5.0"
+    "@comunica/types" "^4.5.0"
+    sparqlalgebrajs "^5.0.2"
 
-"@comunica/actor-query-operation-ask@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-query-operation-ask/-/actor-query-operation-ask-4.2.0.tgz"
-  integrity sha512-hBf+LRjK8+LZ+ZREbM30XcN/M6wibBF5C7pNyh/piIuQknYaB2rbsr4N5ALXYPmOWfj2jDKT7r+wtZcR0QWTIw==
+"@comunica/actor-query-operation-ask@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-ask/-/actor-query-operation-ask-4.5.0.tgz#0a10f62a3a2071a79d799541f101fd3632820efa"
+  integrity sha512-dqO3ztOtLlxtwuG/cSsFcEb3W0hHR9mzS3MlXb+GH5u8n1Phidk8s1mfMQKoYdyTfTTnxAVSMcolHDN9VOl18g==
   dependencies:
-    "@comunica/bus-query-operation" "^4.2.0"
-    "@comunica/core" "^4.2.0"
-    "@comunica/types" "^4.2.0"
-    "@comunica/utils-query-operation" "^4.2.0"
-    sparqlalgebrajs "^4.3.8"
+    "@comunica/bus-query-operation" "^4.5.0"
+    "@comunica/core" "^4.5.0"
+    "@comunica/types" "^4.5.0"
+    "@comunica/utils-query-operation" "^4.5.0"
+    sparqlalgebrajs "^5.0.2"
 
-"@comunica/actor-query-operation-bgp-join@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-query-operation-bgp-join/-/actor-query-operation-bgp-join-4.2.0.tgz"
-  integrity sha512-rMnpsQ8YMRkUDkLfxiNvaxZRu4AImN4gE+onke2ZA1N0Fc7JAXj6Jk3eXz4HakyTqoKVXYJE/Gz82Wi2bmX+0Q==
+"@comunica/actor-query-operation-bgp-join@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-bgp-join/-/actor-query-operation-bgp-join-4.5.0.tgz#b8ee31e5518f6fee4395eeb15251f99d2ae8a539"
+  integrity sha512-/LR/RjHoBk+YBO/FPx+nd63b6pA9OHEMzrR3U5aejIHZ4X3vCiHxcTiGWLx8LffZVKLamsL1NeWnsAa3g4t5jg==
   dependencies:
-    "@comunica/bus-query-operation" "^4.2.0"
-    "@comunica/context-entries" "^4.2.0"
-    "@comunica/core" "^4.2.0"
-    "@comunica/types" "^4.2.0"
-    sparqlalgebrajs "^4.3.8"
+    "@comunica/bus-query-operation" "^4.5.0"
+    "@comunica/context-entries" "^4.5.0"
+    "@comunica/core" "^4.5.0"
+    "@comunica/types" "^4.5.0"
+    sparqlalgebrajs "^5.0.2"
 
-"@comunica/actor-query-operation-construct@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-query-operation-construct/-/actor-query-operation-construct-4.2.0.tgz"
-  integrity sha512-7T6BGfeToMsbzsUr0ZZpYlpkv8KpPS9KFFQp7bQZ/VhsSxBtPCwEIGF5tLhe75LMn28g0vzSJXdisBgQ3RM7ww==
+"@comunica/actor-query-operation-construct@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-construct/-/actor-query-operation-construct-4.5.0.tgz#7784f1b603c8d9bebad45114be16e7ea2e0c6c61"
+  integrity sha512-IIVkna7LL+MDGgQbmCAlXkXDGUu2r+hiuu7nY2RVqA9uNqgos1hHwbK2+UWA3rvyCzI/ECIANXX2PInm3ieXvQ==
   dependencies:
-    "@comunica/bus-query-operation" "^4.2.0"
-    "@comunica/context-entries" "^4.2.0"
-    "@comunica/core" "^4.2.0"
-    "@comunica/types" "^4.2.0"
-    "@comunica/utils-query-operation" "^4.2.0"
+    "@comunica/bus-query-operation" "^4.5.0"
+    "@comunica/context-entries" "^4.5.0"
+    "@comunica/core" "^4.5.0"
+    "@comunica/types" "^4.5.0"
+    "@comunica/utils-query-operation" "^4.5.0"
     "@rdfjs/types" "*"
     asynciterator "^3.9.0"
     rdf-terms "^1.11.0"
-    sparqlalgebrajs "^4.3.8"
+    sparqlalgebrajs "^5.0.2"
 
-"@comunica/actor-query-operation-distinct-identity@^4.3.0":
-  version "4.3.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-query-operation-distinct-identity/-/actor-query-operation-distinct-identity-4.3.0.tgz"
-  integrity sha512-bI5c/ohY0NqBHF3ShibqAt4triFEGPX5lSzhNcB0yoHS8G+jj61QQxmiw1CxTKur+akOlAhg1XipyouZuEIYUA==
+"@comunica/actor-query-operation-distinct-identity@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-distinct-identity/-/actor-query-operation-distinct-identity-4.5.0.tgz#2646d5fe02b09d1e0e694dca9beab5da8965902a"
+  integrity sha512-WRhvsT2UpHcgKWRuiWGeu7wX+ITjpfRw2++pPOizL/Wt4EFQQBQNxrPasrUce33jVws1QxS6zlSY+bGzUmeljw==
   dependencies:
-    "@comunica/bus-query-operation" "^4.2.0"
-    "@comunica/core" "^4.2.0"
-    "@comunica/types" "^4.2.0"
-    "@comunica/utils-query-operation" "^4.2.0"
+    "@comunica/bus-query-operation" "^4.5.0"
+    "@comunica/core" "^4.5.0"
+    "@comunica/types" "^4.5.0"
+    "@comunica/utils-query-operation" "^4.5.0"
     "@rdfjs/types" "*"
     asynciterator "^3.9.0"
     rdf-string "^2.0.1"
-    sparqlalgebrajs "^4.3.8"
+    sparqlalgebrajs "^5.0.2"
 
-"@comunica/actor-query-operation-extend@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-query-operation-extend/-/actor-query-operation-extend-4.2.0.tgz"
-  integrity sha512-CveBkiwmrZdewxUqqipROXZfmQTQud0A68Vvy5OOrvC6maM9KC2zHxWIdgNkFNoqsB0jcb3+s8hGIqql/9oW4A==
+"@comunica/actor-query-operation-extend@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-extend/-/actor-query-operation-extend-4.5.0.tgz#dda53d252261baf113e113528dc2108e48363d4f"
+  integrity sha512-dbpTn3EyTch8Aw57KEKCKHCFMKaSLd+KuakGxrTxSiAjbjBJL/ZL4vhGZDpx0xI1IKA8PVFtgsLuUk7IpnP59Q==
   dependencies:
-    "@comunica/bus-expression-evaluator-factory" "^4.2.0"
-    "@comunica/bus-query-operation" "^4.2.0"
-    "@comunica/core" "^4.2.0"
-    "@comunica/types" "^4.2.0"
-    "@comunica/utils-bindings-factory" "^4.2.0"
-    "@comunica/utils-expression-evaluator" "^4.2.0"
-    "@comunica/utils-query-operation" "^4.2.0"
-    sparqlalgebrajs "^4.3.8"
+    "@comunica/bus-expression-evaluator-factory" "^4.5.0"
+    "@comunica/bus-query-operation" "^4.5.0"
+    "@comunica/core" "^4.5.0"
+    "@comunica/types" "^4.5.0"
+    "@comunica/utils-bindings-factory" "^4.5.0"
+    "@comunica/utils-expression-evaluator" "^4.5.0"
+    "@comunica/utils-query-operation" "^4.5.0"
+    sparqlalgebrajs "^5.0.2"
 
-"@comunica/actor-query-operation-filter@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-query-operation-filter/-/actor-query-operation-filter-4.2.0.tgz"
-  integrity sha512-k1TBwCjEG55uWjUZ6IZhQnJ+nlm+vGvOLqAI4BkWulgymxYsqAiIrdrgc2aJzrOv4H7q1J6s/i/ICIcPePvUlA==
+"@comunica/actor-query-operation-filter@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-filter/-/actor-query-operation-filter-4.5.0.tgz#12d0b691f59b370256ad7e4befbf3424111000cc"
+  integrity sha512-4kWfCh+s3X/cab/2z/ZW54ah9gAfUiZAmy+DgXNqtj6ty+zBC5ZFKCFbe+O7orvZOrfDD1kwZmvdAR3GO7RrBg==
   dependencies:
-    "@comunica/bus-expression-evaluator-factory" "^4.2.0"
-    "@comunica/bus-query-operation" "^4.2.0"
-    "@comunica/core" "^4.2.0"
-    "@comunica/types" "^4.2.0"
-    "@comunica/utils-bindings-factory" "^4.2.0"
-    "@comunica/utils-expression-evaluator" "^4.2.0"
-    "@comunica/utils-query-operation" "^4.2.0"
-    sparqlalgebrajs "^4.3.8"
+    "@comunica/bus-expression-evaluator-factory" "^4.5.0"
+    "@comunica/bus-query-operation" "^4.5.0"
+    "@comunica/core" "^4.5.0"
+    "@comunica/types" "^4.5.0"
+    "@comunica/utils-bindings-factory" "^4.5.0"
+    "@comunica/utils-expression-evaluator" "^4.5.0"
+    "@comunica/utils-query-operation" "^4.5.0"
+    sparqlalgebrajs "^5.0.2"
 
-"@comunica/actor-query-operation-from-quad@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-query-operation-from-quad/-/actor-query-operation-from-quad-4.2.0.tgz"
-  integrity sha512-E84C1YZE0l1AdKFyjLfiU+PpAmQ294GUE6OqPj9nDvRB4J4U7+iRsSpubyoTiupmmiR25AOjjQcus08cPwWezw==
+"@comunica/actor-query-operation-from-quad@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-from-quad/-/actor-query-operation-from-quad-4.5.0.tgz#f5f73f5b3132087f8a5e15b14f321e40e86a6941"
+  integrity sha512-CGRDCTWYc7hi05/d2GUVTNqF2sekcloTuU+uCrqnPMR9g6//KAq7n7QjBC/OZQj7q3454rjnhUxHf1ahTJZS/A==
   dependencies:
-    "@comunica/bus-query-operation" "^4.2.0"
-    "@comunica/context-entries" "^4.2.0"
-    "@comunica/core" "^4.2.0"
-    "@comunica/types" "^4.2.0"
+    "@comunica/bus-query-operation" "^4.5.0"
+    "@comunica/context-entries" "^4.5.0"
+    "@comunica/core" "^4.5.0"
+    "@comunica/types" "^4.5.0"
     "@rdfjs/types" "*"
-    sparqlalgebrajs "^4.3.8"
+    sparqlalgebrajs "^5.0.2"
 
-"@comunica/actor-query-operation-group@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-query-operation-group/-/actor-query-operation-group-4.2.0.tgz"
-  integrity sha512-CeeRHzTZCcekwiEIc2mmGGRK0ZwxNthEpE1Wf3lPX4xdoftzdwD/1xi4+V2A5ewOzIqGi/3kQ0H0DfJtPxs5jw==
+"@comunica/actor-query-operation-group@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-group/-/actor-query-operation-group-4.5.0.tgz#646e985f428dde7dd1418cecaf9f3971ad9fabd9"
+  integrity sha512-6OSCo3ssBuri0Euf6E9IFbZH7/DP0RSJre549jruLIEAed+XTreStpI9Unx1IOKAOI2X5Xv2cfLfuGubH3CRBg==
   dependencies:
-    "@comunica/bus-bindings-aggregator-factory" "^4.2.0"
-    "@comunica/bus-merge-bindings-context" "^4.2.0"
-    "@comunica/bus-query-operation" "^4.2.0"
-    "@comunica/context-entries" "^4.2.0"
-    "@comunica/core" "^4.2.0"
-    "@comunica/types" "^4.2.0"
-    "@comunica/utils-bindings-factory" "^4.2.0"
-    "@comunica/utils-query-operation" "^4.2.0"
+    "@comunica/bus-bindings-aggregator-factory" "^4.5.0"
+    "@comunica/bus-merge-bindings-context" "^4.5.0"
+    "@comunica/bus-query-operation" "^4.5.0"
+    "@comunica/context-entries" "^4.5.0"
+    "@comunica/core" "^4.5.0"
+    "@comunica/types" "^4.5.0"
+    "@comunica/utils-bindings-factory" "^4.5.0"
+    "@comunica/utils-query-operation" "^4.5.0"
     "@rdfjs/types" "*"
     asynciterator "^3.9.0"
-    sparqlalgebrajs "^4.3.8"
+    sparqlalgebrajs "^5.0.2"
 
-"@comunica/actor-query-operation-join@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-query-operation-join/-/actor-query-operation-join-4.2.0.tgz"
-  integrity sha512-16RKWhBUEr7EKxjv4KAirT22NMaBT7WTzehMAFrQbbHqjzL/idwTTKrWXN0d3rxv/oA/a4hvK8vM1910GP+sBQ==
+"@comunica/actor-query-operation-join@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-join/-/actor-query-operation-join-4.5.0.tgz#4b55b977c59a05ed05f228297364dd3f49921b69"
+  integrity sha512-q2u/PxmP7LLdqpIv4teKDrxTjcqH89aRf34X63nU++8TvEzml/786/EMLmVYshgrWsNShbw9afrmwB6DWNCcpA==
   dependencies:
-    "@comunica/bus-query-operation" "^4.2.0"
-    "@comunica/bus-rdf-join" "^4.2.0"
-    "@comunica/core" "^4.2.0"
-    "@comunica/types" "^4.2.0"
-    "@comunica/utils-metadata" "^4.2.0"
-    "@comunica/utils-query-operation" "^4.2.0"
+    "@comunica/bus-query-operation" "^4.5.0"
+    "@comunica/bus-rdf-join" "^4.5.0"
+    "@comunica/core" "^4.5.0"
+    "@comunica/types" "^4.5.0"
+    "@comunica/utils-metadata" "^4.5.0"
+    "@comunica/utils-query-operation" "^4.5.0"
     "@rdfjs/types" "*"
     asynciterator "^3.9.0"
     rdf-data-factory "^1.1.2"
-    sparqlalgebrajs "^4.3.8"
+    sparqlalgebrajs "^5.0.2"
 
-"@comunica/actor-query-operation-leftjoin@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-query-operation-leftjoin/-/actor-query-operation-leftjoin-4.2.0.tgz"
-  integrity sha512-Nml0hVwOrWn28fIo48DJdIfZrGXx8/MwsZcYr8EmptbC996NgwLvcnZ3nXuFtO/oOOO076QHtZmsu4cRaNEhKA==
+"@comunica/actor-query-operation-leftjoin@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-leftjoin/-/actor-query-operation-leftjoin-4.5.0.tgz#0e45ab095d435024f3852c744eba864ba7f0742d"
+  integrity sha512-F240YX+ILF1QFW30oGK7bnapo5gkwHWFPkX6UME9ogjdq6AeosM3boevtwsUVp3ykz3irsExdJDIU24QtvYhuA==
   dependencies:
-    "@comunica/bus-expression-evaluator-factory" "^4.2.0"
-    "@comunica/bus-query-operation" "^4.2.0"
-    "@comunica/bus-rdf-join" "^4.2.0"
-    "@comunica/core" "^4.2.0"
-    "@comunica/types" "^4.2.0"
-    "@comunica/utils-bindings-factory" "^4.2.0"
-    "@comunica/utils-expression-evaluator" "^4.2.0"
-    "@comunica/utils-query-operation" "^4.2.0"
-    sparqlalgebrajs "^4.3.8"
+    "@comunica/bus-query-operation" "^4.5.0"
+    "@comunica/bus-rdf-join" "^4.5.0"
+    "@comunica/context-entries" "^4.5.0"
+    "@comunica/core" "^4.5.0"
+    "@comunica/types" "^4.5.0"
+    "@comunica/utils-query-operation" "^4.5.0"
+    sparqlalgebrajs "^5.0.2"
 
-"@comunica/actor-query-operation-minus@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-query-operation-minus/-/actor-query-operation-minus-4.2.0.tgz"
-  integrity sha512-zrQlIBimqJcIDZ0VAIC7ZvEdtVm/JFjxp8AUPrUp8XKdhZAzr5g2D9pu8/CaXR3+hWbbFFhYTa3MiWm+dTcNBQ==
+"@comunica/actor-query-operation-minus@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-minus/-/actor-query-operation-minus-4.5.0.tgz#51fda2359c4fe4c8a260546a66b6e0cb5f8df5b5"
+  integrity sha512-8UqLHadZHp0jr2LujjtlKYFdKGZdG24PoKEJOBZpxAgdOFd6QirBFR5TA5QlIjm1o77yzLzPLSokjvlYswYW6g==
   dependencies:
-    "@comunica/bus-query-operation" "^4.2.0"
-    "@comunica/bus-rdf-join" "^4.2.0"
-    "@comunica/core" "^4.2.0"
-    "@comunica/types" "^4.2.0"
-    "@comunica/utils-query-operation" "^4.2.0"
-    sparqlalgebrajs "^4.3.8"
+    "@comunica/bus-query-operation" "^4.5.0"
+    "@comunica/bus-rdf-join" "^4.5.0"
+    "@comunica/core" "^4.5.0"
+    "@comunica/types" "^4.5.0"
+    "@comunica/utils-query-operation" "^4.5.0"
+    sparqlalgebrajs "^5.0.2"
 
-"@comunica/actor-query-operation-nop@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-query-operation-nop/-/actor-query-operation-nop-4.2.0.tgz"
-  integrity sha512-eSfNCVFsL1CDXjxZUQVQoDlKM/5IPABmc/IzXrYLxwJPtq/TfWeFQ9DW0RG3WzBwY0DZB1DdeShHeTuGbfE4mw==
+"@comunica/actor-query-operation-nop@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-nop/-/actor-query-operation-nop-4.5.0.tgz#6d56d620ab8a47318ea93a12c99d5302198deef7"
+  integrity sha512-Qh3ZK0YkcH0FcAf8U5U22076ZWDSH37m9vbm1yYPdn/ag+G9TXf63VxcYpLcFQJFB7LM6b+6LNQezMfFXiqoYg==
   dependencies:
-    "@comunica/bus-merge-bindings-context" "^4.2.0"
-    "@comunica/bus-query-operation" "^4.2.0"
-    "@comunica/context-entries" "^4.2.0"
-    "@comunica/core" "^4.2.0"
-    "@comunica/types" "^4.2.0"
-    "@comunica/utils-bindings-factory" "^4.2.0"
-    "@comunica/utils-metadata" "^4.2.0"
+    "@comunica/bus-merge-bindings-context" "^4.5.0"
+    "@comunica/bus-query-operation" "^4.5.0"
+    "@comunica/context-entries" "^4.5.0"
+    "@comunica/core" "^4.5.0"
+    "@comunica/types" "^4.5.0"
+    "@comunica/utils-bindings-factory" "^4.5.0"
+    "@comunica/utils-metadata" "^4.5.0"
     "@rdfjs/types" "*"
     asynciterator "^3.9.0"
-    sparqlalgebrajs "^4.3.8"
+    sparqlalgebrajs "^5.0.2"
 
-"@comunica/actor-query-operation-orderby@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-query-operation-orderby/-/actor-query-operation-orderby-4.2.0.tgz"
-  integrity sha512-rNTzYbg/5tHDM8qMbD1Atys3mDzkjLzkDQoTNqU/7jUkp/DmwuokrPNx98apI0AKW7a2oN1nf6rm81fgBht23g==
+"@comunica/actor-query-operation-orderby@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-orderby/-/actor-query-operation-orderby-4.5.0.tgz#7db3b870b909d095be9de325553ba6ed2d541f02"
+  integrity sha512-s28lZK5M9XewM5wl+RfuqwWwcBYpIMnpEPRD6cco5bbP6m9gXZAo8KHYsDfdfBKiOfWDxIcP3QpDJZajmy5KKg==
   dependencies:
-    "@comunica/bus-expression-evaluator-factory" "^4.2.0"
-    "@comunica/bus-query-operation" "^4.2.0"
-    "@comunica/bus-term-comparator-factory" "^4.2.0"
-    "@comunica/core" "^4.2.0"
-    "@comunica/types" "^4.2.0"
-    "@comunica/utils-expression-evaluator" "^4.2.0"
-    "@comunica/utils-query-operation" "^4.2.0"
+    "@comunica/bus-expression-evaluator-factory" "^4.5.0"
+    "@comunica/bus-query-operation" "^4.5.0"
+    "@comunica/bus-term-comparator-factory" "^4.5.0"
+    "@comunica/core" "^4.5.0"
+    "@comunica/types" "^4.5.0"
+    "@comunica/utils-expression-evaluator" "^4.5.0"
+    "@comunica/utils-query-operation" "^4.5.0"
     asynciterator "^3.9.0"
-    sparqlalgebrajs "^4.3.8"
+    sparqlalgebrajs "^5.0.2"
 
-"@comunica/actor-query-operation-path-alt@^4.3.0":
-  version "4.3.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-query-operation-path-alt/-/actor-query-operation-path-alt-4.3.0.tgz"
-  integrity sha512-dV1Sr0yUfrxcUaBazPmoC3y2dYpVZKTRmuLmZUaT/Fq8K07r8XBgRD+kTe4vUJoUhPqyAr+IwbD+Jyng/RCcUw==
+"@comunica/actor-query-operation-path-alt@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-path-alt/-/actor-query-operation-path-alt-4.5.0.tgz#805342e26bd8f5350e2e9096981b0d0bc43a8bfb"
+  integrity sha512-bgM5/lE6C/no1g5XZZi8CL46SURZtgmernDsd10wQdzXYZzlNcxO8yu1C/HozTyKsIlRpv8FTWgh2a0jbsJlJg==
   dependencies:
-    "@comunica/actor-abstract-path" "^4.3.0"
-    "@comunica/actor-query-operation-union" "^4.2.0"
-    "@comunica/bus-query-operation" "^4.2.0"
-    "@comunica/bus-rdf-metadata-accumulate" "^4.2.0"
-    "@comunica/context-entries" "^4.2.0"
-    "@comunica/types" "^4.2.0"
-    "@comunica/utils-query-operation" "^4.2.0"
+    "@comunica/actor-abstract-path" "^4.5.0"
+    "@comunica/actor-query-operation-union" "^4.5.0"
+    "@comunica/bus-query-operation" "^4.5.0"
+    "@comunica/bus-rdf-metadata-accumulate" "^4.5.0"
+    "@comunica/context-entries" "^4.5.0"
+    "@comunica/types" "^4.5.0"
+    "@comunica/utils-query-operation" "^4.5.0"
     asynciterator "^3.9.0"
-    sparqlalgebrajs "^4.3.8"
+    sparqlalgebrajs "^5.0.2"
 
-"@comunica/actor-query-operation-path-inv@^4.3.0":
-  version "4.3.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-query-operation-path-inv/-/actor-query-operation-path-inv-4.3.0.tgz"
-  integrity sha512-2J/njrqsz6siuu+uuWOVLyvV1VVWPHAw3+Fp/DZyhyCP4nTUqNk0FFxKT7ftrE7gYUrNm83gqu3pFFtRZcW5uQ==
+"@comunica/actor-query-operation-path-inv@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-path-inv/-/actor-query-operation-path-inv-4.5.0.tgz#e7f2b8293e79b82a7e0930e6c0584dbd6bf2ed49"
+  integrity sha512-s30h/6aEzzDxgCjy9fz/RVGakiSAD0+GAGvMmMF3zqhpM70lD6dwaMQSwxAH/7IQiEjR7VlrrYPMTI0ljK+9OA==
   dependencies:
-    "@comunica/actor-abstract-path" "^4.3.0"
-    "@comunica/bus-query-operation" "^4.2.0"
-    "@comunica/context-entries" "^4.2.0"
-    "@comunica/types" "^4.2.0"
-    sparqlalgebrajs "^4.3.8"
+    "@comunica/actor-abstract-path" "^4.5.0"
+    "@comunica/bus-query-operation" "^4.5.0"
+    "@comunica/context-entries" "^4.5.0"
+    "@comunica/types" "^4.5.0"
+    sparqlalgebrajs "^5.0.2"
 
-"@comunica/actor-query-operation-path-link@^4.3.0":
-  version "4.3.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-query-operation-path-link/-/actor-query-operation-path-link-4.3.0.tgz"
-  integrity sha512-ZDQO+hIGY2ba0cXqcU7ekqu3g/EBudkmMZuq1Yq99o/ZpAJF8gVuco0a33mFSbjExf1PzkVcNzAglnFnGvi1TQ==
+"@comunica/actor-query-operation-path-link@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-path-link/-/actor-query-operation-path-link-4.5.0.tgz#ffa6e46473bc63ed75ee9f036348e52b8fe089c7"
+  integrity sha512-Pyu1KpBOvOPTFD/tQ8JcXNzA+TnJVTggZSIsfCdzXJePx5zVglXT74cHLAMP0MS4QI709JrNYDveUWBYxJrcVA==
   dependencies:
-    "@comunica/actor-abstract-path" "^4.3.0"
-    "@comunica/bus-query-operation" "^4.2.0"
-    "@comunica/context-entries" "^4.2.0"
-    "@comunica/types" "^4.2.0"
-    sparqlalgebrajs "^4.3.8"
+    "@comunica/actor-abstract-path" "^4.5.0"
+    "@comunica/bus-query-operation" "^4.5.0"
+    "@comunica/context-entries" "^4.5.0"
+    "@comunica/types" "^4.5.0"
+    sparqlalgebrajs "^5.0.2"
 
-"@comunica/actor-query-operation-path-nps@^4.3.0":
-  version "4.3.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-query-operation-path-nps/-/actor-query-operation-path-nps-4.3.0.tgz"
-  integrity sha512-6lBc1m8hN3KdBLO8sPKXUFlxK3NWxlnzIyyVd95Gc5EMjMJAH/ez4MBh0wHjkdvTMv27JjdTo001QjV/jGJsgg==
+"@comunica/actor-query-operation-path-nps@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-path-nps/-/actor-query-operation-path-nps-4.5.0.tgz#b8e295a712616a82ec5e45d4ed957428a9da2502"
+  integrity sha512-gziMhls637aQyt86J0uRfGYZlvRuOH5fPExocoqmALh34bi08/hqGUnuPBRqYX7dBnqgIz5daInqhBGaWpvyxQ==
   dependencies:
-    "@comunica/actor-abstract-path" "^4.3.0"
-    "@comunica/bus-query-operation" "^4.2.0"
-    "@comunica/context-entries" "^4.2.0"
-    "@comunica/types" "^4.2.0"
-    "@comunica/utils-query-operation" "^4.2.0"
-    sparqlalgebrajs "^4.3.8"
+    "@comunica/actor-abstract-path" "^4.5.0"
+    "@comunica/bus-query-operation" "^4.5.0"
+    "@comunica/context-entries" "^4.5.0"
+    "@comunica/types" "^4.5.0"
+    "@comunica/utils-query-operation" "^4.5.0"
+    sparqlalgebrajs "^5.0.2"
 
-"@comunica/actor-query-operation-path-one-or-more@^4.3.0":
-  version "4.3.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-query-operation-path-one-or-more/-/actor-query-operation-path-one-or-more-4.3.0.tgz"
-  integrity sha512-Y5XIVjb5UndYrDJdg+vZbaDNH7FvUeHncoiJRqVH5TiiBvL/b1XElc+RIvYO00gUPfUmEjsKKgqhD8xQFc9LsQ==
+"@comunica/actor-query-operation-path-one-or-more@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-path-one-or-more/-/actor-query-operation-path-one-or-more-4.5.0.tgz#09721aca13c9bd14eb85029d4873024ecf001908"
+  integrity sha512-4Q/WcptuCR7asWzZShupvzfcR6KPsdISdYdguvDnDC2wkiI8DJKkPxek5fCHth78twWqP93WZnkKto3pfM2Dkw==
   dependencies:
-    "@comunica/actor-abstract-path" "^4.3.0"
-    "@comunica/bus-merge-bindings-context" "^4.2.0"
-    "@comunica/bus-query-operation" "^4.2.0"
-    "@comunica/context-entries" "^4.2.0"
-    "@comunica/types" "^4.2.0"
-    "@comunica/utils-bindings-factory" "^4.2.0"
-    "@comunica/utils-query-operation" "^4.2.0"
+    "@comunica/actor-abstract-path" "^4.5.0"
+    "@comunica/bus-merge-bindings-context" "^4.5.0"
+    "@comunica/bus-query-operation" "^4.5.0"
+    "@comunica/context-entries" "^4.5.0"
+    "@comunica/types" "^4.5.0"
+    "@comunica/utils-bindings-factory" "^4.5.0"
+    "@comunica/utils-query-operation" "^4.5.0"
     asynciterator "^3.9.0"
-    sparqlalgebrajs "^4.3.8"
+    sparqlalgebrajs "^5.0.2"
 
-"@comunica/actor-query-operation-path-seq@^4.3.0":
-  version "4.3.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-query-operation-path-seq/-/actor-query-operation-path-seq-4.3.0.tgz"
-  integrity sha512-Dh4KNlxTK9QpdFyTGTDqGeNczCFpeXEFa0KrtK6Dv9fdaSLkVA+KuZBnXpfCroii0Qq7j0KaU9H2E5ZMHu1C9Q==
+"@comunica/actor-query-operation-path-seq@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-path-seq/-/actor-query-operation-path-seq-4.5.0.tgz#4b0db6df0e88a5505014fb03c94744000dccd962"
+  integrity sha512-uzvJZWEQ15VpdiVvhcS4eDmQREHIDnyG4/eBsSsh64d/sBTAlnF+jTh10OF7UIBD1IpGwL3u10DoV8Xz9dhOLA==
   dependencies:
-    "@comunica/actor-abstract-path" "^4.3.0"
-    "@comunica/bus-query-operation" "^4.2.0"
-    "@comunica/bus-rdf-join" "^4.2.0"
-    "@comunica/context-entries" "^4.2.0"
-    "@comunica/types" "^4.2.0"
-    "@comunica/utils-query-operation" "^4.2.0"
-    sparqlalgebrajs "^4.3.8"
+    "@comunica/actor-abstract-path" "^4.5.0"
+    "@comunica/bus-query-operation" "^4.5.0"
+    "@comunica/bus-rdf-join" "^4.5.0"
+    "@comunica/context-entries" "^4.5.0"
+    "@comunica/types" "^4.5.0"
+    "@comunica/utils-query-operation" "^4.5.0"
+    sparqlalgebrajs "^5.0.2"
 
-"@comunica/actor-query-operation-path-zero-or-more@^4.3.0":
-  version "4.3.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-query-operation-path-zero-or-more/-/actor-query-operation-path-zero-or-more-4.3.0.tgz"
-  integrity sha512-owpabDsH6fxU9htVUqXLzn8G2v19P37uOAbrvsD0kRd1HpJdNKkn3lPzrQgPR3u8eMnSvFCzX2CQb0eUmJQ1ZQ==
+"@comunica/actor-query-operation-path-zero-or-more@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-path-zero-or-more/-/actor-query-operation-path-zero-or-more-4.5.0.tgz#040f3be3f06894ad4538db917d6cedc3d4747c6f"
+  integrity sha512-8HIBnqBgDEZTiiok9/Biyka24YWfDVLlJntJRX2i+qm20LLCzKqfqM8LyfmuY9xCxLzRHfZplwUMt9p1FbxcBQ==
   dependencies:
-    "@comunica/actor-abstract-path" "^4.3.0"
-    "@comunica/bus-merge-bindings-context" "^4.2.0"
-    "@comunica/bus-query-operation" "^4.2.0"
-    "@comunica/context-entries" "^4.2.0"
-    "@comunica/types" "^4.2.0"
-    "@comunica/utils-bindings-factory" "^4.2.0"
-    "@comunica/utils-query-operation" "^4.2.0"
+    "@comunica/actor-abstract-path" "^4.5.0"
+    "@comunica/bus-merge-bindings-context" "^4.5.0"
+    "@comunica/bus-query-operation" "^4.5.0"
+    "@comunica/context-entries" "^4.5.0"
+    "@comunica/types" "^4.5.0"
+    "@comunica/utils-bindings-factory" "^4.5.0"
+    "@comunica/utils-query-operation" "^4.5.0"
     asynciterator "^3.9.0"
     rdf-string "^1.6.1"
-    sparqlalgebrajs "^4.3.8"
+    sparqlalgebrajs "^5.0.2"
 
-"@comunica/actor-query-operation-path-zero-or-one@^4.3.0":
-  version "4.3.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-query-operation-path-zero-or-one/-/actor-query-operation-path-zero-or-one-4.3.0.tgz"
-  integrity sha512-wiFxVkTjI3/3EkdV/bqdf5U9qd+X+HOQEElozh+6ztflYaErNR/aUvoPL3W3hrR3R+0pOZYWdS35wj1xOhhrJg==
+"@comunica/actor-query-operation-path-zero-or-one@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-path-zero-or-one/-/actor-query-operation-path-zero-or-one-4.5.0.tgz#6cabc8a826f19262ef4473f1519822a875e76bc9"
+  integrity sha512-V22P9WtJDLzLsWot/CLmJc9v566LmCoNApFGxAL9TgZeIKyZsKVESMb/TEI/GkXBuMxjAyCTh2cRm2ORztiH8g==
   dependencies:
-    "@comunica/actor-abstract-path" "^4.3.0"
-    "@comunica/bus-merge-bindings-context" "^4.2.0"
-    "@comunica/bus-query-operation" "^4.2.0"
-    "@comunica/context-entries" "^4.2.0"
-    "@comunica/types" "^4.2.0"
-    "@comunica/utils-bindings-factory" "^4.2.0"
-    "@comunica/utils-metadata" "^4.2.0"
-    "@comunica/utils-query-operation" "^4.2.0"
+    "@comunica/actor-abstract-path" "^4.5.0"
+    "@comunica/bus-merge-bindings-context" "^4.5.0"
+    "@comunica/bus-query-operation" "^4.5.0"
+    "@comunica/context-entries" "^4.5.0"
+    "@comunica/types" "^4.5.0"
+    "@comunica/utils-bindings-factory" "^4.5.0"
+    "@comunica/utils-metadata" "^4.5.0"
+    "@comunica/utils-query-operation" "^4.5.0"
     asynciterator "^3.9.0"
-    sparqlalgebrajs "^4.3.8"
+    sparqlalgebrajs "^5.0.2"
 
-"@comunica/actor-query-operation-project@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-query-operation-project/-/actor-query-operation-project-4.2.0.tgz"
-  integrity sha512-n2Pw5VR0/fsOiOoOqapO4i+Be77ZFBlwAIvz6kpIYjICH5xYnPKckiI/WxB8OGKx1pfn0psHBNxZMmAGmc0zzQ==
+"@comunica/actor-query-operation-project@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-project/-/actor-query-operation-project-4.5.0.tgz#633778b65bbbe61e3cdb8913bb2e9e5317bcefe0"
+  integrity sha512-8tFqMnM2gaEzewE25PTm4UQMZ4kUUoOrbFS7OM65Vns3Jvw8cYwYCoYAT98L0gHMGG5z0UTYoOHMc+PdjBRuGw==
   dependencies:
-    "@comunica/bus-query-operation" "^4.2.0"
-    "@comunica/context-entries" "^4.2.0"
-    "@comunica/core" "^4.2.0"
-    "@comunica/types" "^4.2.0"
+    "@comunica/bus-query-operation" "^4.5.0"
+    "@comunica/context-entries" "^4.5.0"
+    "@comunica/core" "^4.5.0"
+    "@comunica/types" "^4.5.0"
     "@comunica/utils-data-factory" "^4.0.1"
-    "@comunica/utils-query-operation" "^4.2.0"
+    "@comunica/utils-query-operation" "^4.5.0"
     "@rdfjs/types" "*"
-    sparqlalgebrajs "^4.3.8"
+    sparqlalgebrajs "^5.0.2"
 
-"@comunica/actor-query-operation-reduced-hash@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-query-operation-reduced-hash/-/actor-query-operation-reduced-hash-4.2.0.tgz"
-  integrity sha512-KwDvW3cihGdqOGczs5ati9TtmlzXhV2Wu3krJ7PjeiqFTl3qhP5DLITJAgZfKFkqXH+pJoBRtFPIQsn0A4MAKA==
+"@comunica/actor-query-operation-reduced-hash@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-reduced-hash/-/actor-query-operation-reduced-hash-4.5.0.tgz#70117e27ac92bfa5a866151ea65ddf9406f8c1f1"
+  integrity sha512-yaA/jF4y2vxzS/mjK8UEGMWZtDx3joPPbbcidVACW02HzpXHpNGYUfb2OZOK1LnnaJayms9lJd2kfU78UThRsw==
   dependencies:
-    "@comunica/bus-hash-bindings" "^4.2.0"
-    "@comunica/bus-query-operation" "^4.2.0"
-    "@comunica/core" "^4.2.0"
-    "@comunica/types" "^4.2.0"
-    "@comunica/utils-query-operation" "^4.2.0"
+    "@comunica/bus-hash-bindings" "^4.5.0"
+    "@comunica/bus-query-operation" "^4.5.0"
+    "@comunica/core" "^4.5.0"
+    "@comunica/types" "^4.5.0"
+    "@comunica/utils-query-operation" "^4.5.0"
     "@rdfjs/types" "*"
     lru-cache "^10.0.0"
-    sparqlalgebrajs "^4.3.8"
+    sparqlalgebrajs "^5.0.2"
 
-"@comunica/actor-query-operation-service@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-query-operation-service/-/actor-query-operation-service-4.2.0.tgz"
-  integrity sha512-z61je/Ptj0ENZAWsP+1ghdNr2Y3mSHwr31nu6RQ0/QjCjaWXHYT2dXwHO0j0icrOgdfjgFHwRCkrPEpypnsJtw==
+"@comunica/actor-query-operation-service@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-service/-/actor-query-operation-service-4.5.0.tgz#b3fc18aa5fa0b6ede7605fa2f355e79f658209da"
+  integrity sha512-YuivydtZj4R+zbzQQgp1NTCLoXgP/sfquIY006LW4pQ8iyuY8nnCgH5lbmizHkuxGSmQn/Ii2HZOTMMaa3W3qA==
   dependencies:
-    "@comunica/bus-merge-bindings-context" "^4.2.0"
-    "@comunica/bus-query-operation" "^4.2.0"
-    "@comunica/bus-query-source-identify" "^4.2.0"
-    "@comunica/context-entries" "^4.2.0"
-    "@comunica/core" "^4.2.0"
-    "@comunica/types" "^4.2.0"
-    "@comunica/utils-bindings-factory" "^4.2.0"
-    "@comunica/utils-metadata" "^4.2.0"
-    "@comunica/utils-query-operation" "^4.2.0"
+    "@comunica/bus-http-invalidate" "^4.5.0"
+    "@comunica/bus-merge-bindings-context" "^4.5.0"
+    "@comunica/bus-query-operation" "^4.5.0"
+    "@comunica/bus-query-source-identify" "^4.5.0"
+    "@comunica/context-entries" "^4.5.0"
+    "@comunica/core" "^4.5.0"
+    "@comunica/types" "^4.5.0"
+    "@comunica/utils-bindings-factory" "^4.5.0"
+    "@comunica/utils-metadata" "^4.5.0"
+    "@comunica/utils-query-operation" "^4.5.0"
     asynciterator "^3.9.0"
-    sparqlalgebrajs "^4.3.8"
+    lru-cache "^10.0.0"
+    sparqlalgebrajs "^5.0.2"
 
-"@comunica/actor-query-operation-slice@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-query-operation-slice/-/actor-query-operation-slice-4.2.0.tgz"
-  integrity sha512-sgVq8cHLFfn6pG5Vkj1EfdVl3ngvgOx8Pr3v9VM4vu1y/ZM7AbkBhP2MW06kjFIUnHcD/A1Si0ZnzGjPpm2+XA==
+"@comunica/actor-query-operation-slice@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-slice/-/actor-query-operation-slice-4.5.0.tgz#24c2175a4a0024a2e4740c3e211cb5c31212baca"
+  integrity sha512-SWBFYpFwu1Ns53BypSR61YuypYcwifsyxvJ2s4mjg5EHBc+myUXf/eoeXl1TFYKWZsUp6xOvCZCLcxsMMM4OTg==
   dependencies:
-    "@comunica/bus-query-operation" "^4.2.0"
-    "@comunica/context-entries" "^4.2.0"
-    "@comunica/core" "^4.2.0"
-    "@comunica/types" "^4.2.0"
-    sparqlalgebrajs "^4.3.8"
+    "@comunica/bus-query-operation" "^4.5.0"
+    "@comunica/context-entries" "^4.5.0"
+    "@comunica/core" "^4.5.0"
+    "@comunica/types" "^4.5.0"
+    sparqlalgebrajs "^5.0.2"
 
-"@comunica/actor-query-operation-source@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-query-operation-source/-/actor-query-operation-source-4.2.0.tgz"
-  integrity sha512-GQGaNYMzOwFbyl/7H7WSCBHKtoneJFrmSjIz7dtXMKG7M2wM3Q3KGqkKqZpNaPFiO6unEEzAa81WFxFNx8PaXw==
+"@comunica/actor-query-operation-source@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-source/-/actor-query-operation-source-4.5.0.tgz#fd6dc954727e8dc3be2f91016c6ca2ace30d6af2"
+  integrity sha512-N7Ncs92KOYQ0uKBc0P3hZ9/7yHwchnazH+wq/Gufm/WsWPt13YppB43rSJHzo0tBkVMvI8MbZvkLj3t46/wYAg==
   dependencies:
-    "@comunica/bus-query-operation" "^4.2.0"
-    "@comunica/context-entries" "^4.2.0"
-    "@comunica/core" "^4.2.0"
-    "@comunica/types" "^4.2.0"
-    "@comunica/utils-metadata" "^4.2.0"
-    "@comunica/utils-query-operation" "^4.2.0"
-    sparqlalgebrajs "^4.3.8"
+    "@comunica/bus-query-operation" "^4.5.0"
+    "@comunica/context-entries" "^4.5.0"
+    "@comunica/core" "^4.5.0"
+    "@comunica/types" "^4.5.0"
+    "@comunica/utils-metadata" "^4.5.0"
+    "@comunica/utils-query-operation" "^4.5.0"
+    sparqlalgebrajs "^5.0.2"
 
-"@comunica/actor-query-operation-union@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-query-operation-union/-/actor-query-operation-union-4.2.0.tgz"
-  integrity sha512-C8i0DgYje6gcG4QfeHQReIQlcq2mXDfhORoKIY7+cwhrS0Ei+q/LfvlzuPMLXavDI5/p/6nedtfzkLgLgJOPTg==
+"@comunica/actor-query-operation-union@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-union/-/actor-query-operation-union-4.5.0.tgz#c832878f44ea52884a9712e5d843a0337fa5c0d7"
+  integrity sha512-cKBEYMc84lXREjj9ta30idl4wYKQnSXS1P3tpyuUcc0AmGFVWA6+VzJEgKzvH6Mpbe/PGA8nhTqDZJVLi1XRXw==
   dependencies:
-    "@comunica/bus-query-operation" "^4.2.0"
-    "@comunica/bus-rdf-metadata-accumulate" "^4.2.0"
-    "@comunica/core" "^4.2.0"
-    "@comunica/types" "^4.2.0"
-    "@comunica/utils-metadata" "^4.2.0"
-    "@comunica/utils-query-operation" "^4.2.0"
+    "@comunica/bus-query-operation" "^4.5.0"
+    "@comunica/bus-rdf-metadata-accumulate" "^4.5.0"
+    "@comunica/core" "^4.5.0"
+    "@comunica/types" "^4.5.0"
+    "@comunica/utils-metadata" "^4.5.0"
+    "@comunica/utils-query-operation" "^4.5.0"
     asynciterator "^3.9.0"
-    sparqlalgebrajs "^4.3.8"
+    sparqlalgebrajs "^5.0.2"
 
-"@comunica/actor-query-operation-update-clear@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-query-operation-update-clear/-/actor-query-operation-update-clear-4.2.0.tgz"
-  integrity sha512-p2GNZ+zwSvPCg5bkimFYk+ZMQ15OXbMniIr48ARCOhA4EoGhBLYUVZ0c90n7gbRudSliFDHQZWB8yjDnLvOevQ==
+"@comunica/actor-query-operation-update-clear@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-update-clear/-/actor-query-operation-update-clear-4.5.0.tgz#f903a4cf30728017a31687a7e4154f8baa48606f"
+  integrity sha512-R6x13rE4JU/QlDoBQXAJadtYePWB82UTGT0r3xgNaXgRaODWgaSPXadPvxRLoI9HSX0DQrJiIXaNXH0EDdGtFQ==
   dependencies:
-    "@comunica/bus-query-operation" "^4.2.0"
-    "@comunica/bus-rdf-update-quads" "^4.2.0"
-    "@comunica/context-entries" "^4.2.0"
-    "@comunica/core" "^4.2.0"
-    "@comunica/types" "^4.2.0"
-    "@comunica/utils-query-operation" "^4.2.0"
+    "@comunica/bus-query-operation" "^4.5.0"
+    "@comunica/bus-rdf-update-quads" "^4.5.0"
+    "@comunica/context-entries" "^4.5.0"
+    "@comunica/core" "^4.5.0"
+    "@comunica/types" "^4.5.0"
+    "@comunica/utils-query-operation" "^4.5.0"
     "@rdfjs/types" "*"
-    sparqlalgebrajs "^4.3.8"
+    sparqlalgebrajs "^5.0.2"
 
-"@comunica/actor-query-operation-update-compositeupdate@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-query-operation-update-compositeupdate/-/actor-query-operation-update-compositeupdate-4.2.0.tgz"
-  integrity sha512-nIw0u2yGw7b/HfRFFsZKG72IRiYZyjzh7MS9B6D+ikfm+h4By0vgja5POX6Hqy6a1UqfYxhUO2/AfZS0Ya8Q0Q==
+"@comunica/actor-query-operation-update-compositeupdate@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-update-compositeupdate/-/actor-query-operation-update-compositeupdate-4.5.0.tgz#c7b0a227e0961050a05a58f50ccd2d7120783991"
+  integrity sha512-/7hwBvrHUl9f2arb2Z4KOOyTjFNdSAspLofGmMVeM9f8TkPH96gDMRw1+RM4qcuTLEbdJn+efc7YzVJrVmwSDQ==
   dependencies:
-    "@comunica/bus-query-operation" "^4.2.0"
-    "@comunica/core" "^4.2.0"
-    "@comunica/types" "^4.2.0"
-    "@comunica/utils-query-operation" "^4.2.0"
-    sparqlalgebrajs "^4.3.8"
+    "@comunica/bus-query-operation" "^4.5.0"
+    "@comunica/core" "^4.5.0"
+    "@comunica/types" "^4.5.0"
+    "@comunica/utils-query-operation" "^4.5.0"
+    sparqlalgebrajs "^5.0.2"
 
-"@comunica/actor-query-operation-update-create@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-query-operation-update-create/-/actor-query-operation-update-create-4.2.0.tgz"
-  integrity sha512-sqXj6Czpeyh1iQZLmxs0N8wYUnv0b7HCD/DOH3aUU64zE73BdJEcvn8DaySvwtEtXGg09ZAsBGKyEkXnEfqUdA==
+"@comunica/actor-query-operation-update-create@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-update-create/-/actor-query-operation-update-create-4.5.0.tgz#e4c38d589f15d59af23eaf31f5dc1d290f230943"
+  integrity sha512-BphWTXX81Bpv8hq74eIkPWOi2K8/45UvM2ayQp3RblSlD1fu0GcWnxcoexLFFw1aM4Xd8sCvgRtq2k0HwhgdoA==
   dependencies:
-    "@comunica/bus-query-operation" "^4.2.0"
-    "@comunica/bus-rdf-update-quads" "^4.2.0"
-    "@comunica/core" "^4.2.0"
-    "@comunica/types" "^4.2.0"
-    "@comunica/utils-query-operation" "^4.2.0"
-    sparqlalgebrajs "^4.3.8"
+    "@comunica/bus-query-operation" "^4.5.0"
+    "@comunica/bus-rdf-update-quads" "^4.5.0"
+    "@comunica/core" "^4.5.0"
+    "@comunica/types" "^4.5.0"
+    "@comunica/utils-query-operation" "^4.5.0"
+    sparqlalgebrajs "^5.0.2"
 
-"@comunica/actor-query-operation-update-deleteinsert@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-query-operation-update-deleteinsert/-/actor-query-operation-update-deleteinsert-4.2.0.tgz"
-  integrity sha512-MfDjCRBs2WtPq9Pz0tTtHMrgIvqqSo8ARsrRmArTl5zidwtOJONACqMaUFPfC+NrxmNGCLfKgKj4qGwYFm8Oew==
+"@comunica/actor-query-operation-update-deleteinsert@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-update-deleteinsert/-/actor-query-operation-update-deleteinsert-4.5.0.tgz#c0c35027891e405289cd4b8b84f832480a42e3f2"
+  integrity sha512-spJ3Rpj/FAM8tAo35ggFyFWamOfBfHZBT/eMH3CKLJ5qXEJcB9JvjxD/kmW79aMhsPSqlOqyTQ7p3g7OcQd0Jg==
   dependencies:
-    "@comunica/actor-query-operation-construct" "^4.2.0"
-    "@comunica/bus-merge-bindings-context" "^4.2.0"
-    "@comunica/bus-query-operation" "^4.2.0"
-    "@comunica/bus-rdf-update-quads" "^4.2.0"
-    "@comunica/context-entries" "^4.2.0"
-    "@comunica/core" "^4.2.0"
-    "@comunica/types" "^4.2.0"
-    "@comunica/utils-bindings-factory" "^4.2.0"
-    "@comunica/utils-query-operation" "^4.2.0"
+    "@comunica/actor-query-operation-construct" "^4.5.0"
+    "@comunica/bus-merge-bindings-context" "^4.5.0"
+    "@comunica/bus-query-operation" "^4.5.0"
+    "@comunica/bus-rdf-update-quads" "^4.5.0"
+    "@comunica/context-entries" "^4.5.0"
+    "@comunica/core" "^4.5.0"
+    "@comunica/types" "^4.5.0"
+    "@comunica/utils-bindings-factory" "^4.5.0"
+    "@comunica/utils-query-operation" "^4.5.0"
     "@rdfjs/types" "*"
     asynciterator "^3.9.0"
-    sparqlalgebrajs "^4.3.8"
+    sparqlalgebrajs "^5.0.2"
 
-"@comunica/actor-query-operation-update-drop@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-query-operation-update-drop/-/actor-query-operation-update-drop-4.2.0.tgz"
-  integrity sha512-UgQss1jjZ+yLGvSWChIYf2nGghDFfFd+7JMTnqeU0HMjD41V6EAQJ6axxOcdP2zQ6cI2oNjGCj9SUfh/rMNlcg==
+"@comunica/actor-query-operation-update-drop@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-update-drop/-/actor-query-operation-update-drop-4.5.0.tgz#4797e9e39fc042cf52f0145d61f7c33420ebb157"
+  integrity sha512-jVDTwPANfoH6iUzuO2RvVoDZ0tVpyShWANwEpvvfWRocj/oy55p3tF/1CUj/I/6IVXsiBs32xivnGeP2Aurzkg==
   dependencies:
-    "@comunica/bus-query-operation" "^4.2.0"
-    "@comunica/bus-rdf-update-quads" "^4.2.0"
-    "@comunica/context-entries" "^4.2.0"
-    "@comunica/core" "^4.2.0"
-    "@comunica/types" "^4.2.0"
-    "@comunica/utils-query-operation" "^4.2.0"
+    "@comunica/bus-query-operation" "^4.5.0"
+    "@comunica/bus-rdf-update-quads" "^4.5.0"
+    "@comunica/context-entries" "^4.5.0"
+    "@comunica/core" "^4.5.0"
+    "@comunica/types" "^4.5.0"
+    "@comunica/utils-query-operation" "^4.5.0"
     "@rdfjs/types" "*"
-    sparqlalgebrajs "^4.3.8"
+    sparqlalgebrajs "^5.0.2"
 
-"@comunica/actor-query-operation-update-load@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-query-operation-update-load/-/actor-query-operation-update-load-4.2.0.tgz"
-  integrity sha512-3cARwBT5caRVYyxP6h62e34ZG4O7vzm9q9MUL4CA8XB95wO6gwGxsi3AW19IctkI/3YBlLgf0h4JNZOZCzCSMg==
+"@comunica/actor-query-operation-update-load@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-update-load/-/actor-query-operation-update-load-4.5.0.tgz#6ee250903a03c7ec853005149f12cf41badfdf9d"
+  integrity sha512-ZNQkrhLwUjjLdrkYE83SafnhtSt0LEiAE+cS+soRZwl9GLoIPqfRyE8+r6hPHVKtBefLkTQC01dBC53vb84cTA==
   dependencies:
-    "@comunica/bus-query-operation" "^4.2.0"
-    "@comunica/bus-query-source-identify" "^4.2.0"
-    "@comunica/bus-rdf-update-quads" "^4.2.0"
-    "@comunica/context-entries" "^4.2.0"
-    "@comunica/core" "^4.2.0"
-    "@comunica/types" "^4.2.0"
-    "@comunica/utils-query-operation" "^4.2.0"
-    sparqlalgebrajs "^4.3.8"
+    "@comunica/bus-query-operation" "^4.5.0"
+    "@comunica/bus-query-source-identify" "^4.5.0"
+    "@comunica/bus-rdf-update-quads" "^4.5.0"
+    "@comunica/context-entries" "^4.5.0"
+    "@comunica/core" "^4.5.0"
+    "@comunica/types" "^4.5.0"
+    "@comunica/utils-query-operation" "^4.5.0"
+    sparqlalgebrajs "^5.0.2"
 
-"@comunica/actor-query-operation-values@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-query-operation-values/-/actor-query-operation-values-4.2.0.tgz"
-  integrity sha512-7O1Nf+HbrpgW2cFD98Tg3AEA9+wB9kZc032lbL20fane4dvLBRP9tKeDx9hZGSjzBELcvizvy97/uSL1iM92kA==
+"@comunica/actor-query-operation-values@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-values/-/actor-query-operation-values-4.5.0.tgz#ebd6f4517cee200303066548b0d6b1f349afaad8"
+  integrity sha512-3RTTA2drfC3gr4VtomTMhhXuJGjmZW5NiiX/QhKLwkxEzVp8JYDP8KTtaMG+HWvNzoXNnLgFjY+69SCVUNfk8Q==
   dependencies:
-    "@comunica/bus-merge-bindings-context" "^4.2.0"
-    "@comunica/bus-query-operation" "^4.2.0"
-    "@comunica/context-entries" "^4.2.0"
-    "@comunica/core" "^4.2.0"
-    "@comunica/types" "^4.2.0"
-    "@comunica/utils-bindings-factory" "^4.2.0"
-    "@comunica/utils-metadata" "^4.2.0"
+    "@comunica/bus-merge-bindings-context" "^4.5.0"
+    "@comunica/bus-query-operation" "^4.5.0"
+    "@comunica/context-entries" "^4.5.0"
+    "@comunica/core" "^4.5.0"
+    "@comunica/types" "^4.5.0"
+    "@comunica/utils-bindings-factory" "^4.5.0"
+    "@comunica/utils-metadata" "^4.5.0"
     asynciterator "^3.9.0"
-    sparqlalgebrajs "^4.3.8"
+    sparqlalgebrajs "^5.0.2"
 
-"@comunica/actor-query-parse-graphql@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-query-parse-graphql/-/actor-query-parse-graphql-4.2.0.tgz"
-  integrity sha512-FeSRB9QRsaPM8vjbid3bujDfH7qVxbP8uCUftXidfQUP2vME8iDwgzLk8avzPHqHvs9dpDbWfrxJr+9pOtJZlw==
+"@comunica/actor-query-parse-graphql@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-parse-graphql/-/actor-query-parse-graphql-4.5.0.tgz#1eeaac71470fa0f0e6595df6b36d871ff1f074e4"
+  integrity sha512-QrHrKC1V3dEE/nXg3Q69rzuAH6BXCPD2DQTj4mWwmZ0ATvuM4+PYmXc3ZZK9Cp06cK+TsRHRlKYUUmEpXKfN0Q==
   dependencies:
-    "@comunica/bus-query-parse" "^4.2.0"
-    "@comunica/context-entries" "^4.2.0"
-    "@comunica/core" "^4.2.0"
+    "@comunica/bus-query-parse" "^4.5.0"
+    "@comunica/context-entries" "^4.5.0"
+    "@comunica/core" "^4.5.0"
     graphql-to-sparql "^4.0.0"
 
-"@comunica/actor-query-parse-sparql@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-query-parse-sparql/-/actor-query-parse-sparql-4.2.0.tgz"
-  integrity sha512-0GhkECBFFMJ5uipXpQro3IY32HyzQMk/9bRp/MLWBJODatZZFG62CSFdOAHdezebQY9BKgdIYDrSEhrdSm8OSQ==
+"@comunica/actor-query-parse-sparql@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-parse-sparql/-/actor-query-parse-sparql-4.5.0.tgz#ee6ed1e87a947d49c564ef83532bf9dc74fef966"
+  integrity sha512-cteTjZAipUsC44z67yyCWe+4FMxBAFv1tNAe2omaqDMo8nLZJ2qnN9wj4ZqOVQuyHSGLeg5V7umc5O1m4FgFKg==
   dependencies:
-    "@comunica/bus-query-parse" "^4.2.0"
-    "@comunica/context-entries" "^4.2.0"
-    "@comunica/core" "^4.2.0"
-    "@comunica/types" "^4.2.0"
+    "@comunica/bus-query-parse" "^4.5.0"
+    "@comunica/context-entries" "^4.5.0"
+    "@comunica/core" "^4.5.0"
+    "@comunica/types" "^4.5.0"
     "@types/sparqljs" "^3.1.3"
-    sparqlalgebrajs "^4.3.8"
+    sparqlalgebrajs "^5.0.2"
     sparqljs "^3.7.1"
 
-"@comunica/actor-query-process-explain-logical@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-query-process-explain-logical/-/actor-query-process-explain-logical-4.2.0.tgz"
-  integrity sha512-t5yxb9w47XwGcW3VsqXKIH2Q9FRSiD2Pm1iqJuYzWn1krq1he5qr0T3ovuEF01RUbNlIwczoQ7z+J0XSNZn2uQ==
+"@comunica/actor-query-process-explain-logical@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-process-explain-logical/-/actor-query-process-explain-logical-4.5.0.tgz#67685fb3972a1d3b0a135fd0e16552f9f81f2cdc"
+  integrity sha512-K27GBFBzK0m/ipgmas+l+OiqgoJ5LcTmJrdIFpkZQIXiYgHhlY9uFePjsjUL9liu+VZryJ5/0qGf+6fQkM0m3w==
   dependencies:
-    "@comunica/bus-query-process" "^4.2.0"
-    "@comunica/context-entries" "^4.2.0"
-    "@comunica/core" "^4.2.0"
+    "@comunica/bus-query-process" "^4.5.0"
+    "@comunica/context-entries" "^4.5.0"
+    "@comunica/core" "^4.5.0"
 
-"@comunica/actor-query-process-explain-parsed@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-query-process-explain-parsed/-/actor-query-process-explain-parsed-4.2.0.tgz"
-  integrity sha512-ulMfTK7MzblrTAq4ebKis/U9N6HM/upZeOS7l8ZOeBJZQMBhJC11efhbNw4foOtzVg0b1e2kmEbKUMuMvdQ51w==
+"@comunica/actor-query-process-explain-parsed@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-process-explain-parsed/-/actor-query-process-explain-parsed-4.5.0.tgz#6f9b90ca7c3c74657939f1ba9a3b8a144766c846"
+  integrity sha512-DN7kDINTtONVYoehMcz8f5QmNkYvg7C2NnjkcrDM4SUgOzPWps75o301HtjOmj8IwKAo9APUOjOIVO1K3BiPvg==
   dependencies:
-    "@comunica/bus-query-process" "^4.2.0"
-    "@comunica/context-entries" "^4.2.0"
-    "@comunica/core" "^4.2.0"
+    "@comunica/bus-query-process" "^4.5.0"
+    "@comunica/context-entries" "^4.5.0"
+    "@comunica/core" "^4.5.0"
 
-"@comunica/actor-query-process-explain-physical@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-query-process-explain-physical/-/actor-query-process-explain-physical-4.2.0.tgz"
-  integrity sha512-LN9NHE41zqwgGAtef05hz5sI5rE1QeEntE1PYB3e3qFlzP5gZqK4T0U2/5fbn9DSDmfjnxq1qdCrD+VKSrW6Zw==
+"@comunica/actor-query-process-explain-physical@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-process-explain-physical/-/actor-query-process-explain-physical-4.5.0.tgz#a03fa895c1a23ce626f756dd5ad26f2714b9a1af"
+  integrity sha512-+wdQrBgg1a4josJbYQc2SluqX2BTZC0zvQ/HXouIsEiGv4G6ribpVmnxXUQ7Io6gdTRfqohmoxQatm3A+eJSWQ==
   dependencies:
-    "@comunica/bus-query-process" "^4.2.0"
-    "@comunica/context-entries" "^4.2.0"
-    "@comunica/core" "^4.2.0"
-    "@comunica/types" "^4.2.0"
+    "@comunica/bus-query-process" "^4.5.0"
+    "@comunica/context-entries" "^4.5.0"
+    "@comunica/core" "^4.5.0"
+    "@comunica/types" "^4.5.0"
     "@rdfjs/types" "*"
     rdf-string "^1.6.3"
 
-"@comunica/actor-query-process-sequential@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-query-process-sequential/-/actor-query-process-sequential-4.2.0.tgz"
-  integrity sha512-Xf7nOqOIN2Xt62OKD048CgsPp/F3bL4Vhmhp8Rvk1YR3jvuZU57q34yo+JKiEj733rToDFT33x9TU8aV3kPyUA==
+"@comunica/actor-query-process-sequential@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-process-sequential/-/actor-query-process-sequential-4.5.0.tgz#1cb5a10efaded890cfc5c402e40706f612139fb9"
+  integrity sha512-3MlrVQfY7iz0V17jnlZzeJLav1AtawnXZTEK3Jvsnl7lQrzYJ0rEvvGCeAJ6LCrhHmE9cMI0KtghQnKO1zxuDg==
   dependencies:
-    "@comunica/bus-context-preprocess" "^4.2.0"
-    "@comunica/bus-merge-bindings-context" "^4.2.0"
-    "@comunica/bus-optimize-query-operation" "^4.2.0"
-    "@comunica/bus-query-operation" "^4.2.0"
-    "@comunica/bus-query-parse" "^4.2.0"
-    "@comunica/bus-query-process" "^4.2.0"
-    "@comunica/context-entries" "^4.2.0"
-    "@comunica/core" "^4.2.0"
-    "@comunica/types" "^4.2.0"
-    "@comunica/utils-bindings-factory" "^4.2.0"
-    "@comunica/utils-query-operation" "^4.2.0"
+    "@comunica/bus-context-preprocess" "^4.5.0"
+    "@comunica/bus-merge-bindings-context" "^4.5.0"
+    "@comunica/bus-optimize-query-operation" "^4.5.0"
+    "@comunica/bus-query-operation" "^4.5.0"
+    "@comunica/bus-query-parse" "^4.5.0"
+    "@comunica/bus-query-process" "^4.5.0"
+    "@comunica/context-entries" "^4.5.0"
+    "@comunica/core" "^4.5.0"
+    "@comunica/types" "^4.5.0"
+    "@comunica/utils-bindings-factory" "^4.5.0"
+    "@comunica/utils-query-operation" "^4.5.0"
     "@rdfjs/types" "*"
-    sparqlalgebrajs "^4.3.8"
+    sparqlalgebrajs "^5.0.2"
 
-"@comunica/actor-query-result-serialize-json@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-query-result-serialize-json/-/actor-query-result-serialize-json-4.2.0.tgz"
-  integrity sha512-lNZppKPfQnunl55ZwD3w4GgUTyfvjUbsttHSOv3PZQY1UJzZFRLsjEtwmvA8ei3HdoW3l+BtOW/+Yo9XqnTDgA==
+"@comunica/actor-query-result-serialize-json@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-result-serialize-json/-/actor-query-result-serialize-json-4.5.0.tgz#1ce37148eba097fd323d53ada69c1ba2bc6d0502"
+  integrity sha512-96wFPpRM+kWUw3cIu+j8LtWxTQcUYDuNPvgnXwi+b9HGJzhNA6VFdLG37S/gbXDkg0yQsSU+06JGGYAm/WcM+Q==
   dependencies:
-    "@comunica/bus-query-result-serialize" "^4.2.0"
-    "@comunica/core" "^4.2.0"
-    "@comunica/types" "^4.2.0"
+    "@comunica/bus-query-result-serialize" "^4.5.0"
+    "@comunica/core" "^4.5.0"
+    "@comunica/types" "^4.5.0"
     asynciterator "^3.9.0"
     rdf-string "^1.6.1"
     readable-stream "^4.5.2"
 
-"@comunica/actor-query-result-serialize-rdf@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-query-result-serialize-rdf/-/actor-query-result-serialize-rdf-4.2.0.tgz"
-  integrity sha512-49pqd44G6NyTIdobJ91dXIIoWuvPBKmWIgSw8FkCdUZ1Ik0/EHoX1wlwLKsyPMXlPT/EToNDwJFbr6sJr3otDw==
+"@comunica/actor-query-result-serialize-rdf@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-result-serialize-rdf/-/actor-query-result-serialize-rdf-4.5.0.tgz#1c3a7c05a71362f8c9164bbc98c2b83b352425b2"
+  integrity sha512-vGALjgZFg/m2F5lsJj3BgQ6HTFECpybtuTCnTqm6mBgVkdtZrqAouwyoxtk9Y8wge4fdW0PA9YZx/03gvX7dDw==
   dependencies:
-    "@comunica/bus-query-result-serialize" "^4.2.0"
-    "@comunica/bus-rdf-serialize" "^4.2.0"
-    "@comunica/core" "^4.2.0"
-    "@comunica/types" "^4.2.0"
+    "@comunica/bus-query-result-serialize" "^4.5.0"
+    "@comunica/bus-rdf-serialize" "^4.5.0"
+    "@comunica/core" "^4.5.0"
+    "@comunica/types" "^4.5.0"
 
-"@comunica/actor-query-result-serialize-simple@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-query-result-serialize-simple/-/actor-query-result-serialize-simple-4.2.0.tgz"
-  integrity sha512-HZARqPt4ulKQXN7xha/nk0hy8uXqp0ZHzxEXHK8seP+f+RmvuyG1jrd1NqAQEiHH1Hzfma0y01RfWT9EKpBVbg==
+"@comunica/actor-query-result-serialize-simple@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-result-serialize-simple/-/actor-query-result-serialize-simple-4.5.0.tgz#7dc2d6fefacdb475bd4cf20769eb3434e7f04ee0"
+  integrity sha512-u4QpJJb0LY+weDqWdK1iIEb5OTPOLdA091su2yViXoYjkh2g9Wq+YIqCoA6H/D6hGYQMZ/OEIT95xq3P+ARmNw==
   dependencies:
-    "@comunica/bus-query-result-serialize" "^4.2.0"
-    "@comunica/core" "^4.2.0"
-    "@comunica/types" "^4.2.0"
+    "@comunica/bus-query-result-serialize" "^4.5.0"
+    "@comunica/core" "^4.5.0"
+    "@comunica/types" "^4.5.0"
     "@rdfjs/types" "*"
     asynciterator "^3.9.0"
     rdf-string "^1.6.3"
     readable-stream "^4.5.2"
 
-"@comunica/actor-query-result-serialize-sparql-csv@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-query-result-serialize-sparql-csv/-/actor-query-result-serialize-sparql-csv-4.2.0.tgz"
-  integrity sha512-5MEDXYFCafMxEznvs4zdO1dlDmVYm/E7babzyiLCfYn05rgJigH4F1cuWwa5Gld91HDqjnw2buaSb65Bng31bg==
+"@comunica/actor-query-result-serialize-sparql-csv@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-result-serialize-sparql-csv/-/actor-query-result-serialize-sparql-csv-4.5.0.tgz#fb2e58c39513960f6460bfccd29ef65bf9eda520"
+  integrity sha512-jzc/v6oFxwzL5dKeMWHTnIkFRmmL7Go+9yMqRde9LoBwY2J0VV28ThbNZi1xDmEapnAC+LgkHXqOHMZLyA3SAQ==
   dependencies:
-    "@comunica/bus-query-result-serialize" "^4.2.0"
-    "@comunica/core" "^4.2.0"
-    "@comunica/types" "^4.2.0"
+    "@comunica/bus-query-result-serialize" "^4.5.0"
+    "@comunica/core" "^4.5.0"
+    "@comunica/types" "^4.5.0"
     "@rdfjs/types" "*"
     readable-stream "^4.5.2"
 
-"@comunica/actor-query-result-serialize-sparql-json@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-query-result-serialize-sparql-json/-/actor-query-result-serialize-sparql-json-4.2.0.tgz"
-  integrity sha512-/+fVwbv9bld6VmuIrYQtaTu7mAmEKBU+k2Wk/zw1I0Yc9Ay3Jbx8q9KKsxmrToQuGGnAncc64cc1+J9bvjAacA==
+"@comunica/actor-query-result-serialize-sparql-json@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-result-serialize-sparql-json/-/actor-query-result-serialize-sparql-json-4.5.0.tgz#16edfee2dc94944899f5883fc1869b609fcd00d1"
+  integrity sha512-oirUBOL7tWsSQmJHF1MpSBNfNbm2phKTCLA/x8BeL2kJQnpHHQFtVlEXEk2IXEbFYzt0gfQPG+nFdTR3r5GMgA==
   dependencies:
-    "@comunica/bus-http" "^4.2.0"
-    "@comunica/bus-http-invalidate" "^4.2.0"
-    "@comunica/bus-query-result-serialize" "^4.2.0"
-    "@comunica/core" "^4.2.0"
-    "@comunica/types" "^4.2.0"
+    "@comunica/bus-http" "^4.5.0"
+    "@comunica/bus-http-invalidate" "^4.5.0"
+    "@comunica/bus-query-result-serialize" "^4.5.0"
+    "@comunica/core" "^4.5.0"
+    "@comunica/types" "^4.5.0"
     "@rdfjs/types" "*"
     asynciterator "^3.9.0"
     readable-stream "^4.5.2"
 
-"@comunica/actor-query-result-serialize-sparql-tsv@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-query-result-serialize-sparql-tsv/-/actor-query-result-serialize-sparql-tsv-4.2.0.tgz"
-  integrity sha512-GuZCywyB/190Vcke4+PHIewa/trAvuxKBOGO40sqWABychFd9jg/516myofyrp0+US9xECH1lpW/Xio7I67xQA==
+"@comunica/actor-query-result-serialize-sparql-tsv@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-result-serialize-sparql-tsv/-/actor-query-result-serialize-sparql-tsv-4.5.0.tgz#2dbac195a05a1c5f51f4709d13ec422b419c12cf"
+  integrity sha512-B5hMN/eFuSjIIIJRQu7JDLMb1M5cnUFTJi2nQRfhAXaIIKdrI0bGdbNCy9E/jV7cRZatc/2HtbJzw0S8MHs7kQ==
   dependencies:
-    "@comunica/bus-query-result-serialize" "^4.2.0"
-    "@comunica/core" "^4.2.0"
-    "@comunica/types" "^4.2.0"
+    "@comunica/bus-query-result-serialize" "^4.5.0"
+    "@comunica/core" "^4.5.0"
+    "@comunica/types" "^4.5.0"
     "@rdfjs/types" "*"
     rdf-string-ttl "^1.3.2"
     readable-stream "^4.5.2"
 
-"@comunica/actor-query-result-serialize-sparql-xml@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-query-result-serialize-sparql-xml/-/actor-query-result-serialize-sparql-xml-4.2.0.tgz"
-  integrity sha512-lfmpqm1kvEfkaIpttScuDLrgCCbA0jofEytWxJ+F2PTL41YGMIpXayKeTciMNrwJsPiFzHh8q0fbrM+XzJUyeA==
+"@comunica/actor-query-result-serialize-sparql-xml@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-result-serialize-sparql-xml/-/actor-query-result-serialize-sparql-xml-4.5.0.tgz#af502a2e7a164e546ed0eac29a5db337a510c2ec"
+  integrity sha512-GjudXtfxPD6lbbLWE1CE0imrI6oK6s0tGO7SAvcm0lAc9IDpPShZd1kbIm6uB/Wv4dx6Jf6cEFosZF4pgULXhw==
   dependencies:
-    "@comunica/bus-query-result-serialize" "^4.2.0"
-    "@comunica/core" "^4.2.0"
-    "@comunica/types" "^4.2.0"
+    "@comunica/bus-query-result-serialize" "^4.5.0"
+    "@comunica/core" "^4.5.0"
+    "@comunica/types" "^4.5.0"
     "@rdfjs/types" "*"
     asynciterator "^3.9.0"
     readable-stream "^4.5.2"
 
-"@comunica/actor-query-result-serialize-stats@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-query-result-serialize-stats/-/actor-query-result-serialize-stats-4.2.0.tgz"
-  integrity sha512-GodmxZUuHmtxrWeHAidJUPygUusC4tRw8f2HOPHdyq7mV7OyU7Xq2RRmnXpK5yjjX+hOdZ9F+R4/qVBxc7rpjA==
+"@comunica/actor-query-result-serialize-stats@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-result-serialize-stats/-/actor-query-result-serialize-stats-4.5.0.tgz#acfc9d9d860c998543d4f861ccd3144e25c94afb"
+  integrity sha512-owY6YZ+k/mq/UCGmrgWuQbNDR9kKzUPb4rkp0jlzBeGTmYEhCJNFCMrdKyGMLoonlSdP+lfNWKMEEnPZfrBQEg==
   dependencies:
-    "@comunica/bus-http" "^4.2.0"
-    "@comunica/bus-http-invalidate" "^4.2.0"
-    "@comunica/bus-query-result-serialize" "^4.2.0"
-    "@comunica/context-entries" "^4.2.0"
-    "@comunica/core" "^4.2.0"
-    "@comunica/types" "^4.2.0"
+    "@comunica/bus-http" "^4.5.0"
+    "@comunica/bus-http-invalidate" "^4.5.0"
+    "@comunica/bus-query-result-serialize" "^4.5.0"
+    "@comunica/context-entries" "^4.5.0"
+    "@comunica/core" "^4.5.0"
+    "@comunica/types" "^4.5.0"
     asynciterator "^3.9.0"
     readable-stream "^4.5.2"
 
-"@comunica/actor-query-result-serialize-table@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-query-result-serialize-table/-/actor-query-result-serialize-table-4.2.0.tgz"
-  integrity sha512-1LatUBVmQsTBik7V75REVIwJBPfm8fwqllFO8MttItfWHLco9mwFOUz/WMUOgdQ2qTOl63i5A0okZS7cjKlCsQ==
+"@comunica/actor-query-result-serialize-table@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-result-serialize-table/-/actor-query-result-serialize-table-4.5.0.tgz#c0a63405357e7c7f6672fcb1dcdfdad1ad37b2ff"
+  integrity sha512-HFKYQdytI3UziHMj+qNV82tGj+CY3ZwLvFgymMEPMRvOC2vpc70uO9E5Cn4rAAUgsE6QZkFcv7UOio207E0Oew==
   dependencies:
-    "@comunica/bus-query-result-serialize" "^4.2.0"
-    "@comunica/context-entries" "^4.2.0"
-    "@comunica/core" "^4.2.0"
-    "@comunica/types" "^4.2.0"
+    "@comunica/bus-query-result-serialize" "^4.5.0"
+    "@comunica/context-entries" "^4.5.0"
+    "@comunica/core" "^4.5.0"
+    "@comunica/types" "^4.5.0"
     "@rdfjs/types" "*"
     rdf-string "^1.6.3"
     rdf-terms "^1.11.0"
     readable-stream "^4.5.2"
 
-"@comunica/actor-query-result-serialize-tree@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-query-result-serialize-tree/-/actor-query-result-serialize-tree-4.2.0.tgz"
-  integrity sha512-joejwtHdvNTVKJ/E7kLTd/qXhFT+qSpNjK2N2F0IB+aIZ9Ru0RZYwDsafuJvcgK3y8E4RE6hp3qa3YaBVz32BA==
+"@comunica/actor-query-result-serialize-tree@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-result-serialize-tree/-/actor-query-result-serialize-tree-4.5.0.tgz#8ae1fc9675c122bd41e81270901f9a36c206113f"
+  integrity sha512-Rl2QzL2oJ51Rumk0VNgRroCZsaBCa5bHK16HZAq70+cJ0G3vignpt9s+AJ/wzVZP/xnsHLDVWbQB5pbCL2eWgA==
   dependencies:
-    "@comunica/bus-query-result-serialize" "^4.2.0"
-    "@comunica/context-entries" "^4.2.0"
-    "@comunica/core" "^4.2.0"
-    "@comunica/types" "^4.2.0"
+    "@comunica/bus-query-result-serialize" "^4.5.0"
+    "@comunica/context-entries" "^4.5.0"
+    "@comunica/core" "^4.5.0"
+    "@comunica/types" "^4.5.0"
     readable-stream "^4.5.2"
     sparqljson-to-tree "^3.0.1"
 
-"@comunica/actor-query-source-identify-hypermedia-sparql@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-query-source-identify-hypermedia-sparql/-/actor-query-source-identify-hypermedia-sparql-4.2.0.tgz"
-  integrity sha512-tvm1VCevvT5ijbLftzY44zJAyN51RB/2ESvfLoMVhz/j0k5zLRa8cHdT2cYIllW6USSF7K5yKP/Uq/rFC4YTkQ==
+"@comunica/actor-query-source-identify-hypermedia-sparql@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-source-identify-hypermedia-sparql/-/actor-query-source-identify-hypermedia-sparql-4.5.0.tgz#68226d63a3e5a0f725888fb000be423d16f69a41"
+  integrity sha512-u2QhEzfZJ/RXuqjJHnTxxYuC1vcRIMRchSzAc7ny8t/blLHJAmseD4R9/J6GIBirGfION6zX9z505zUh9Jkgmg==
   dependencies:
-    "@comunica/bus-http" "^4.2.0"
-    "@comunica/bus-merge-bindings-context" "^4.2.0"
-    "@comunica/bus-query-source-identify-hypermedia" "^4.2.0"
-    "@comunica/context-entries" "^4.2.0"
-    "@comunica/core" "^4.2.0"
-    "@comunica/types" "^4.2.0"
-    "@comunica/utils-bindings-factory" "^4.2.0"
-    "@comunica/utils-metadata" "^4.2.0"
-    "@comunica/utils-query-operation" "^4.2.0"
+    "@comunica/bus-http" "^4.5.0"
+    "@comunica/bus-merge-bindings-context" "^4.5.0"
+    "@comunica/bus-query-source-identify-hypermedia" "^4.5.0"
+    "@comunica/context-entries" "^4.5.0"
+    "@comunica/core" "^4.5.0"
+    "@comunica/types" "^4.5.0"
+    "@comunica/utils-bindings-factory" "^4.5.0"
+    "@comunica/utils-metadata" "^4.5.0"
+    "@comunica/utils-query-operation" "^4.5.0"
     "@rdfjs/types" "*"
     asynciterator "^3.9.0"
-    fetch-sparql-endpoint "^5.1.0"
+    fetch-sparql-endpoint "^6.2.0"
     lru-cache "^10.0.0"
     rdf-terms "^1.11.0"
-    sparqlalgebrajs "^4.3.8"
+    sparqlalgebrajs "^5.0.2"
 
-"@comunica/actor-query-source-identify-hypermedia@^4.3.0":
-  version "4.3.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-query-source-identify-hypermedia/-/actor-query-source-identify-hypermedia-4.3.0.tgz"
-  integrity sha512-37TU19ky9jRbB8wozs/Ru5I1cEb3MfZEnUAYtFoG+q0412PHSDOsKTzMy+eUO01jc+uO04gIYy9fQyNqo97GzQ==
+"@comunica/actor-query-source-identify-hypermedia@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-source-identify-hypermedia/-/actor-query-source-identify-hypermedia-4.5.0.tgz#de9c955958ba83848b8fb1cb3aa7d3a7269c4605"
+  integrity sha512-M+T6wJ5XuQaYvxTzPMN6gnT/AEhJPF+SDIb0XomiJBRM5KtYNvURYF7HYlxRlW2UMM13SLXAoEYiOJU1cn7itA==
   dependencies:
-    "@comunica/actor-query-source-identify-rdfjs" "^4.3.0"
-    "@comunica/bus-dereference-rdf" "^4.2.0"
-    "@comunica/bus-merge-bindings-context" "^4.2.0"
-    "@comunica/bus-query-source-identify" "^4.2.0"
-    "@comunica/bus-query-source-identify-hypermedia" "^4.2.0"
-    "@comunica/bus-rdf-metadata" "^4.2.0"
-    "@comunica/bus-rdf-metadata-accumulate" "^4.2.0"
-    "@comunica/bus-rdf-metadata-extract" "^4.2.0"
-    "@comunica/bus-rdf-resolve-hypermedia-links" "^4.2.0"
-    "@comunica/bus-rdf-resolve-hypermedia-links-queue" "^4.2.0"
-    "@comunica/context-entries" "^4.2.0"
-    "@comunica/core" "^4.2.0"
-    "@comunica/types" "^4.2.0"
-    "@comunica/utils-bindings-factory" "^4.2.0"
-    "@comunica/utils-iterator" "^4.0.1"
-    "@comunica/utils-metadata" "^4.2.0"
+    "@comunica/actor-query-source-identify-rdfjs" "^4.5.0"
+    "@comunica/bus-dereference-rdf" "^4.5.0"
+    "@comunica/bus-merge-bindings-context" "^4.5.0"
+    "@comunica/bus-query-source-identify" "^4.5.0"
+    "@comunica/bus-query-source-identify-hypermedia" "^4.5.0"
+    "@comunica/bus-rdf-metadata" "^4.5.0"
+    "@comunica/bus-rdf-metadata-accumulate" "^4.5.0"
+    "@comunica/bus-rdf-metadata-extract" "^4.5.0"
+    "@comunica/bus-rdf-resolve-hypermedia-links" "^4.5.0"
+    "@comunica/bus-rdf-resolve-hypermedia-links-queue" "^4.5.0"
+    "@comunica/context-entries" "^4.5.0"
+    "@comunica/core" "^4.5.0"
+    "@comunica/types" "^4.5.0"
+    "@comunica/utils-bindings-factory" "^4.5.0"
+    "@comunica/utils-iterator" "^4.5.0"
+    "@comunica/utils-metadata" "^4.5.0"
     "@rdfjs/types" "*"
     asynciterator "^3.9.0"
     lru-cache "^10.0.0"
     rdf-streaming-store "^2.1.1"
     readable-stream "^4.5.2"
-    sparqlalgebrajs "^4.3.8"
+    sparqlalgebrajs "^5.0.2"
 
-"@comunica/actor-query-source-identify-rdfjs@^4.3.0":
-  version "4.3.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-query-source-identify-rdfjs/-/actor-query-source-identify-rdfjs-4.3.0.tgz"
-  integrity sha512-M7v99gdlPH8F71Ceh2+/Zb1kv25dcTqdlsNPdy6CynbMMlPV4RCrSIogEslqUUIo3Ru+L3kasksNT+ILie5YeA==
+"@comunica/actor-query-source-identify-rdfjs@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-source-identify-rdfjs/-/actor-query-source-identify-rdfjs-4.5.0.tgz#356fd1b75761f966eb993981be1fd4a3fab4cf31"
+  integrity sha512-OODcg3Sz0TAkClTlhHout6hAgikbtm/19rycJeOo6QbsM2dUohnKrk5pXNvlTfCqIj2qsvqcnD5YTuIRjYhYiQ==
   dependencies:
-    "@comunica/bus-merge-bindings-context" "^4.2.0"
-    "@comunica/bus-query-source-identify" "^4.2.0"
-    "@comunica/context-entries" "^4.2.0"
-    "@comunica/core" "^4.2.0"
-    "@comunica/types" "^4.2.0"
-    "@comunica/utils-bindings-factory" "^4.2.0"
-    "@comunica/utils-metadata" "^4.2.0"
+    "@comunica/bus-merge-bindings-context" "^4.5.0"
+    "@comunica/bus-query-source-identify" "^4.5.0"
+    "@comunica/context-entries" "^4.5.0"
+    "@comunica/core" "^4.5.0"
+    "@comunica/types" "^4.5.0"
+    "@comunica/utils-bindings-factory" "^4.5.0"
+    "@comunica/utils-metadata" "^4.5.0"
     "@rdfjs/types" "*"
     asynciterator "^3.9.0"
     rdf-terms "^1.11.0"
-    sparqlalgebrajs "^4.3.8"
+    sparqlalgebrajs "^5.0.2"
 
-"@comunica/actor-rdf-join-entries-sort-cardinality@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-rdf-join-entries-sort-cardinality/-/actor-rdf-join-entries-sort-cardinality-4.2.0.tgz"
-  integrity sha512-Y2OXmFLA8aWMrfJBL8wDHw5xpfRCBh4ce9A3hCw6CfIpBmkLYvFd5RZyJ9XiUBJNvsEIQAOw6sYp++XUjPHKxQ==
+"@comunica/actor-rdf-join-entries-sort-cardinality@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-join-entries-sort-cardinality/-/actor-rdf-join-entries-sort-cardinality-4.5.0.tgz#ed7fec37655b75d8432481c56c81d41c3fce768a"
+  integrity sha512-Tk4AxcP0BdC9e5LJQqcCx1IvrVeeIbRYlin6u//s70MG4QZesFdFl3kNRPWo7PK2M40XT2yO3j5tSNrkj4TpxQ==
   dependencies:
-    "@comunica/bus-rdf-join-entries-sort" "^4.2.0"
-    "@comunica/core" "^4.2.0"
+    "@comunica/bus-rdf-join-entries-sort" "^4.5.0"
+    "@comunica/core" "^4.5.0"
 
-"@comunica/actor-rdf-join-inner-hash@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-rdf-join-inner-hash/-/actor-rdf-join-inner-hash-4.2.0.tgz"
-  integrity sha512-2Ukb+0UaZFGHLaffdz9SXr6XG3FF92O8jLWbmuQ7C/L6ZdvQkuv22w8277xVHQArGKAWwoQTx/6i7oHT6FxWsw==
+"@comunica/actor-rdf-join-inner-hash@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-join-inner-hash/-/actor-rdf-join-inner-hash-4.5.0.tgz#eabbeebaa573e08ba0dd90d3fc5f8d6e5195f5dc"
+  integrity sha512-goMj2HrfZp2rP30F+Ea/n8E8qYbhPHv+qG335RAX1NB1/QuIzhhKf5BP5fYVfEu55lhFAy2WpNn/eDYfXEj2Lw==
   dependencies:
-    "@comunica/bus-hash-bindings" "^4.2.0"
-    "@comunica/bus-rdf-join" "^4.2.0"
-    "@comunica/core" "^4.2.0"
-    "@comunica/mediatortype-join-coefficients" "^4.2.0"
-    "@comunica/types" "^4.2.0"
-    "@comunica/utils-bindings-index" "^4.2.0"
-    "@comunica/utils-iterator" "^4.0.1"
+    "@comunica/bus-hash-bindings" "^4.5.0"
+    "@comunica/bus-rdf-join" "^4.5.0"
+    "@comunica/core" "^4.5.0"
+    "@comunica/mediatortype-join-coefficients" "^4.5.0"
+    "@comunica/types" "^4.5.0"
+    "@comunica/utils-bindings-index" "^4.5.0"
+    "@comunica/utils-iterator" "^4.5.0"
     asynciterator "^3.9.0"
     asyncjoin "^1.2.4"
     rdf-string "^1.6.3"
 
-"@comunica/actor-rdf-join-inner-multi-bind-source@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-rdf-join-inner-multi-bind-source/-/actor-rdf-join-inner-multi-bind-source-4.2.0.tgz"
-  integrity sha512-JWePTa56cJZVX8LJRchh4/B8b1iqwoT8iAxxKo3MX0rECQDJlP0ApZsuHgQ2hsuUl0pwsdFaYPpo5h8k5MvrdQ==
+"@comunica/actor-rdf-join-inner-multi-bind-source@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-join-inner-multi-bind-source/-/actor-rdf-join-inner-multi-bind-source-4.5.0.tgz#f3708a3ec828f91d45c805fb521e3fa21acb0651"
+  integrity sha512-pnd/r9YW21yxxmJIq8GEz3AB6Qrmvxj9zh04xOw8407Kicxf9iZ2jFm1z5rtrE3fVX4gh206wwKNo5dopOp9Qw==
   dependencies:
-    "@comunica/bus-rdf-join" "^4.2.0"
-    "@comunica/bus-rdf-join-entries-sort" "^4.2.0"
-    "@comunica/context-entries" "^4.2.0"
-    "@comunica/core" "^4.2.0"
-    "@comunica/mediatortype-join-coefficients" "^4.2.0"
-    "@comunica/types" "^4.2.0"
-    "@comunica/utils-iterator" "^4.0.1"
-    "@comunica/utils-query-operation" "^4.2.0"
+    "@comunica/bus-rdf-join" "^4.5.0"
+    "@comunica/bus-rdf-join-entries-sort" "^4.5.0"
+    "@comunica/context-entries" "^4.5.0"
+    "@comunica/core" "^4.5.0"
+    "@comunica/mediatortype-join-coefficients" "^4.5.0"
+    "@comunica/types" "^4.5.0"
+    "@comunica/utils-iterator" "^4.5.0"
+    "@comunica/utils-query-operation" "^4.5.0"
     asynciterator "^3.9.0"
-    sparqlalgebrajs "^4.3.8"
+    sparqlalgebrajs "^5.0.2"
 
-"@comunica/actor-rdf-join-inner-multi-bind@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-rdf-join-inner-multi-bind/-/actor-rdf-join-inner-multi-bind-4.2.0.tgz"
-  integrity sha512-ugn3Cs+hv5IgtrAR6j0XxwcN/vPHhN7cQF9+RoAq4/PT8J/oW5aKsaQXcjAi/DFtzhNWTzi58NDuJYPFySfCuQ==
+"@comunica/actor-rdf-join-inner-multi-bind@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-join-inner-multi-bind/-/actor-rdf-join-inner-multi-bind-4.5.0.tgz#ec154ed73c6cceb28590ac1c56d752102fdf0b51"
+  integrity sha512-jCJyQ0E8G589V5Is3fK6W4LpPwKdOv3jC7MtAPdbRzq57l9aY7kYc0n0U4lC7mGSjyPMAcvCQJCE8MMqYyFmeQ==
   dependencies:
-    "@comunica/bus-merge-bindings-context" "^4.2.0"
-    "@comunica/bus-query-operation" "^4.2.0"
-    "@comunica/bus-rdf-join" "^4.2.0"
-    "@comunica/bus-rdf-join-entries-sort" "^4.2.0"
-    "@comunica/context-entries" "^4.2.0"
-    "@comunica/core" "^4.2.0"
-    "@comunica/mediatortype-join-coefficients" "^4.2.0"
-    "@comunica/types" "^4.2.0"
-    "@comunica/utils-bindings-factory" "^4.2.0"
-    "@comunica/utils-query-operation" "^4.2.0"
+    "@comunica/bus-merge-bindings-context" "^4.5.0"
+    "@comunica/bus-query-operation" "^4.5.0"
+    "@comunica/bus-rdf-join" "^4.5.0"
+    "@comunica/bus-rdf-join-entries-sort" "^4.5.0"
+    "@comunica/context-entries" "^4.5.0"
+    "@comunica/core" "^4.5.0"
+    "@comunica/mediatortype-join-coefficients" "^4.5.0"
+    "@comunica/types" "^4.5.0"
+    "@comunica/utils-bindings-factory" "^4.5.0"
+    "@comunica/utils-query-operation" "^4.5.0"
     asynciterator "^3.9.0"
-    sparqlalgebrajs "^4.3.8"
+    sparqlalgebrajs "^5.0.2"
 
-"@comunica/actor-rdf-join-inner-multi-empty@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-rdf-join-inner-multi-empty/-/actor-rdf-join-inner-multi-empty-4.2.0.tgz"
-  integrity sha512-T6udTTZaaq07lTDKwhkgM1yDPCzDJTtX6FQapti5ohBsArajlDCJGUK1hK4R3YvKPagdTOeYWQMuUscaU+TinA==
+"@comunica/actor-rdf-join-inner-multi-empty@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-join-inner-multi-empty/-/actor-rdf-join-inner-multi-empty-4.5.0.tgz#41054901e59994069e4b94c25391dc89be0c1912"
+  integrity sha512-f9FDa00yqmxIn9n0YSc+JxyJGHR/TKQTlkc4A/lkBbHauD+o0LoryGIm/88mK4ZEDG0ebz2s1znmspCEyhol6Q==
   dependencies:
-    "@comunica/bus-rdf-join" "^4.2.0"
-    "@comunica/context-entries" "^4.2.0"
-    "@comunica/core" "^4.2.0"
-    "@comunica/mediatortype-join-coefficients" "^4.2.0"
-    "@comunica/types" "^4.2.0"
-    "@comunica/utils-metadata" "^4.2.0"
+    "@comunica/bus-rdf-join" "^4.5.0"
+    "@comunica/context-entries" "^4.5.0"
+    "@comunica/core" "^4.5.0"
+    "@comunica/mediatortype-join-coefficients" "^4.5.0"
+    "@comunica/types" "^4.5.0"
+    "@comunica/utils-metadata" "^4.5.0"
     "@rdfjs/types" "*"
     asynciterator "^3.9.0"
 
-"@comunica/actor-rdf-join-inner-multi-smallest-filter-bindings@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-rdf-join-inner-multi-smallest-filter-bindings/-/actor-rdf-join-inner-multi-smallest-filter-bindings-4.2.0.tgz"
-  integrity sha512-LvryRsWY05yIqK5YQNp1r0yi6b34BLm/qhj8LckzuN9IuPdbpPYKGGZVMfleLtxnM5mSV0hTjlRGcONohma28g==
+"@comunica/actor-rdf-join-inner-multi-smallest-filter-bindings@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-join-inner-multi-smallest-filter-bindings/-/actor-rdf-join-inner-multi-smallest-filter-bindings-4.5.0.tgz#320cf784f5e4db2bfd1ac88aa063324eec7ac18d"
+  integrity sha512-i04prUsnBsdgPvL847NeZihXiE5Pn5mdcYO4i/LDsPoOoD2vcodm2WvfVl8bFI69FJIIyuf/VlfQOFKNp+9JbA==
   dependencies:
-    "@comunica/bus-rdf-join" "^4.2.0"
-    "@comunica/bus-rdf-join-entries-sort" "^4.2.0"
-    "@comunica/context-entries" "^4.2.0"
-    "@comunica/core" "^4.2.0"
-    "@comunica/mediatortype-join-coefficients" "^4.2.0"
-    "@comunica/types" "^4.2.0"
-    "@comunica/utils-bindings-factory" "^4.2.0"
-    "@comunica/utils-iterator" "^4.0.1"
-    "@comunica/utils-query-operation" "^4.2.0"
+    "@comunica/bus-rdf-join" "^4.5.0"
+    "@comunica/bus-rdf-join-entries-sort" "^4.5.0"
+    "@comunica/context-entries" "^4.5.0"
+    "@comunica/core" "^4.5.0"
+    "@comunica/mediatortype-join-coefficients" "^4.5.0"
+    "@comunica/types" "^4.5.0"
+    "@comunica/utils-bindings-factory" "^4.5.0"
+    "@comunica/utils-iterator" "^4.5.0"
+    "@comunica/utils-query-operation" "^4.5.0"
     asynciterator "^3.9.0"
-    sparqlalgebrajs "^4.3.8"
+    sparqlalgebrajs "^5.0.2"
 
-"@comunica/actor-rdf-join-inner-multi-smallest@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-rdf-join-inner-multi-smallest/-/actor-rdf-join-inner-multi-smallest-4.2.0.tgz"
-  integrity sha512-/x8/BwIlexd88EfkoGFME3WjQPqPtblnqYz+JKQbAEefCzn3U98uCnqVX7DnyG+4xtXwEewuMsQ9tunc4U73zw==
+"@comunica/actor-rdf-join-inner-multi-smallest@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-join-inner-multi-smallest/-/actor-rdf-join-inner-multi-smallest-4.5.0.tgz#c01681739cd241217ef89905d8986b968081ff7d"
+  integrity sha512-X9cVWpImkX7ovYxaRMS5w/Y6z7izvAvglcl6Rn4qnL/u3tsgFEcvVb+nMkGjH3+Dk5yef+oThCvVhc5nb7t9mw==
   dependencies:
-    "@comunica/bus-rdf-join" "^4.2.0"
-    "@comunica/bus-rdf-join-entries-sort" "^4.2.0"
-    "@comunica/context-entries" "^4.2.0"
-    "@comunica/core" "^4.2.0"
-    "@comunica/mediatortype-join-coefficients" "^4.2.0"
-    "@comunica/types" "^4.2.0"
-    "@comunica/utils-query-operation" "^4.2.0"
-    sparqlalgebrajs "^4.3.8"
+    "@comunica/bus-rdf-join" "^4.5.0"
+    "@comunica/bus-rdf-join-entries-sort" "^4.5.0"
+    "@comunica/context-entries" "^4.5.0"
+    "@comunica/core" "^4.5.0"
+    "@comunica/mediatortype-join-coefficients" "^4.5.0"
+    "@comunica/types" "^4.5.0"
+    "@comunica/utils-query-operation" "^4.5.0"
+    sparqlalgebrajs "^5.0.2"
 
-"@comunica/actor-rdf-join-inner-nestedloop@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-rdf-join-inner-nestedloop/-/actor-rdf-join-inner-nestedloop-4.2.0.tgz"
-  integrity sha512-tFEnYSuuFM92KVp261ufESq4cAeZr+iyeQIzy80DwGJ52SPi3yaHhNrd+KdVx88bdHzeS2ixV7YPKBiOs2WvxQ==
+"@comunica/actor-rdf-join-inner-nestedloop@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-join-inner-nestedloop/-/actor-rdf-join-inner-nestedloop-4.5.0.tgz#ffc4d1fd4450b35a83fa7aa888a3f094887c859a"
+  integrity sha512-+u8peRhrLHmTSyMHkKN4Ky0OmUAVteu9WDHagtflNChhGL1OGMZuO1tw+hu8YCrK0/fWCd3ujgr9i5u4Y49iog==
   dependencies:
-    "@comunica/bus-rdf-join" "^4.2.0"
-    "@comunica/core" "^4.2.0"
-    "@comunica/mediatortype-join-coefficients" "^4.2.0"
+    "@comunica/bus-rdf-join" "^4.5.0"
+    "@comunica/core" "^4.5.0"
+    "@comunica/mediatortype-join-coefficients" "^4.5.0"
     asyncjoin "^1.2.4"
 
-"@comunica/actor-rdf-join-inner-none@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-rdf-join-inner-none/-/actor-rdf-join-inner-none-4.2.0.tgz"
-  integrity sha512-NaKfXtsvQpoZVZjiom+zRN3CoT1TQ+LIyxusozdOwQAe4WsThGdnzC2AQ8cRFZB1SU+BWsoDw75lkSvJU908xg==
+"@comunica/actor-rdf-join-inner-none@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-join-inner-none/-/actor-rdf-join-inner-none-4.5.0.tgz#95df1d5d68f48e37cbf6df0a87ee539918f4ac9d"
+  integrity sha512-PSOkwq2NMvDL6ikcDuPEa1Rp2aqFlmgvAzUk8OhiCDI0kEqlUzWxskrqQIjVneK8PmJiV3CaA+QkfDp/V48h0w==
   dependencies:
-    "@comunica/bus-merge-bindings-context" "^4.2.0"
-    "@comunica/bus-rdf-join" "^4.2.0"
-    "@comunica/context-entries" "^4.2.0"
-    "@comunica/core" "^4.2.0"
-    "@comunica/mediatortype-join-coefficients" "^4.2.0"
-    "@comunica/types" "^4.2.0"
-    "@comunica/utils-bindings-factory" "^4.2.0"
-    "@comunica/utils-metadata" "^4.2.0"
+    "@comunica/bus-merge-bindings-context" "^4.5.0"
+    "@comunica/bus-rdf-join" "^4.5.0"
+    "@comunica/context-entries" "^4.5.0"
+    "@comunica/core" "^4.5.0"
+    "@comunica/mediatortype-join-coefficients" "^4.5.0"
+    "@comunica/types" "^4.5.0"
+    "@comunica/utils-bindings-factory" "^4.5.0"
+    "@comunica/utils-metadata" "^4.5.0"
     "@rdfjs/types" "*"
     asynciterator "^3.9.0"
 
-"@comunica/actor-rdf-join-inner-single@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-rdf-join-inner-single/-/actor-rdf-join-inner-single-4.2.0.tgz"
-  integrity sha512-2v7ZT6w/wbN/Lf/RzujX0LBd9HRm2wmDI4jKSUP9K/3Be/svbgPOR2k6e7q0pfLJ7urVogbaYIGzBA02WooS4A==
+"@comunica/actor-rdf-join-inner-single@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-join-inner-single/-/actor-rdf-join-inner-single-4.5.0.tgz#e6900999ee4d5647cc402ed52aeff33c38b7faae"
+  integrity sha512-XCSO3ULvMMfpmPduzj06oInkvUyTk/n0/p7ovhC/A/0zUJc6Ml9dPrwJZdCiHWF7zjqd74mDrRmu23ouDmuwow==
   dependencies:
-    "@comunica/bus-rdf-join" "^4.2.0"
-    "@comunica/core" "^4.2.0"
-    "@comunica/mediatortype-join-coefficients" "^4.2.0"
+    "@comunica/bus-rdf-join" "^4.5.0"
+    "@comunica/core" "^4.5.0"
+    "@comunica/mediatortype-join-coefficients" "^4.5.0"
 
-"@comunica/actor-rdf-join-inner-symmetrichash@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-rdf-join-inner-symmetrichash/-/actor-rdf-join-inner-symmetrichash-4.2.0.tgz"
-  integrity sha512-oiiaMztBKEMYAtfO4hHnBRRpwZvGLhK7WY4Ewx0pBs8WRyjtElAGtxNAV450X9N/DG+vKBJBTHG39G4oP6gvXw==
+"@comunica/actor-rdf-join-inner-symmetrichash@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-join-inner-symmetrichash/-/actor-rdf-join-inner-symmetrichash-4.5.0.tgz#42d5d53e21a1513ad150b561d8c2f96e3bc76c3e"
+  integrity sha512-TgOoAG/Z7+tgR/vLvym7v3udcIqcD90+w5ttQ+hTa7dfHw/NNhAUALmK6ZMa6uJ6RWeNUu2JZSDDaLFkPDeqDg==
   dependencies:
-    "@comunica/bus-hash-bindings" "^4.2.0"
-    "@comunica/bus-rdf-join" "^4.2.0"
-    "@comunica/core" "^4.2.0"
-    "@comunica/mediatortype-join-coefficients" "^4.2.0"
+    "@comunica/bus-hash-bindings" "^4.5.0"
+    "@comunica/bus-rdf-join" "^4.5.0"
+    "@comunica/core" "^4.5.0"
+    "@comunica/mediatortype-join-coefficients" "^4.5.0"
     asyncjoin "^1.2.4"
 
-"@comunica/actor-rdf-join-minus-hash@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-rdf-join-minus-hash/-/actor-rdf-join-minus-hash-4.2.0.tgz"
-  integrity sha512-wJYpuhW1XToLiuZbMpoThBwjx1G+IgrXVRr2n9c6a78XswNhRsTkdsuMS/F8CiBO28Nh+McKM9IC4xZuvA2ErA==
+"@comunica/actor-rdf-join-minus-hash@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-join-minus-hash/-/actor-rdf-join-minus-hash-4.5.0.tgz#3fce3cf390cc3f7e3d8541cb202ad5982196f179"
+  integrity sha512-3smcJln7Tr+wNEiRuL4KPO+FodMhqQeIaEdnEcs+gzU6JAE9zlPtJDqlTn2pwmUfUYg4xXcScIQJHJoBuf516A==
   dependencies:
-    "@comunica/bus-rdf-join" "^4.2.0"
-    "@comunica/core" "^4.2.0"
-    "@comunica/mediatortype-join-coefficients" "^4.2.0"
-    "@comunica/types" "^4.2.0"
-    "@comunica/utils-bindings-factory" "^4.2.0"
-    "@comunica/utils-bindings-index" "^4.2.0"
-    "@comunica/utils-iterator" "^4.0.1"
+    "@comunica/bus-rdf-join" "^4.5.0"
+    "@comunica/core" "^4.5.0"
+    "@comunica/mediatortype-join-coefficients" "^4.5.0"
+    "@comunica/types" "^4.5.0"
+    "@comunica/utils-bindings-factory" "^4.5.0"
+    "@comunica/utils-bindings-index" "^4.5.0"
+    "@comunica/utils-iterator" "^4.5.0"
     "@rdfjs/types" "*"
     rdf-string "^1.6.3"
 
-"@comunica/actor-rdf-join-optional-bind@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-rdf-join-optional-bind/-/actor-rdf-join-optional-bind-4.2.0.tgz"
-  integrity sha512-yT/MGqez3mDPbDiQK0V28zn/9IKx7At57AeEjufy7pAOCw6VuMewCkT6SyFwxMA03lQtgQIIxHqF2gAOaIjuZw==
+"@comunica/actor-rdf-join-optional-bind@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-join-optional-bind/-/actor-rdf-join-optional-bind-4.5.0.tgz#0cd9ce09ea1be421e5bbc0ab67b3cfe60ebfb5bf"
+  integrity sha512-R0XBCZXv3bL0712FIwqZ+2U+P+k9YGgQFLHI2/PtW9sJWi/s79JSYnwnACfEEfMwIdkPHwK0NIuNmnw3BTT+1w==
   dependencies:
-    "@comunica/actor-rdf-join-inner-multi-bind" "^4.2.0"
-    "@comunica/bus-merge-bindings-context" "^4.2.0"
-    "@comunica/bus-query-operation" "^4.2.0"
-    "@comunica/bus-rdf-join" "^4.2.0"
-    "@comunica/context-entries" "^4.2.0"
-    "@comunica/core" "^4.2.0"
-    "@comunica/mediatortype-join-coefficients" "^4.2.0"
-    "@comunica/types" "^4.2.0"
-    "@comunica/utils-bindings-factory" "^4.2.0"
-    "@comunica/utils-query-operation" "^4.2.0"
-    sparqlalgebrajs "^4.3.8"
+    "@comunica/actor-rdf-join-inner-multi-bind" "^4.5.0"
+    "@comunica/bus-merge-bindings-context" "^4.5.0"
+    "@comunica/bus-query-operation" "^4.5.0"
+    "@comunica/bus-rdf-join" "^4.5.0"
+    "@comunica/context-entries" "^4.5.0"
+    "@comunica/core" "^4.5.0"
+    "@comunica/mediatortype-join-coefficients" "^4.5.0"
+    "@comunica/types" "^4.5.0"
+    "@comunica/utils-bindings-factory" "^4.5.0"
+    "@comunica/utils-query-operation" "^4.5.0"
+    sparqlalgebrajs "^5.0.2"
 
-"@comunica/actor-rdf-join-optional-hash@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-rdf-join-optional-hash/-/actor-rdf-join-optional-hash-4.2.0.tgz"
-  integrity sha512-HNIhXgSNt2A+yOl3Asdx5l6xSrHdCztzsStgWBQh+rlUcDIcEixwReTXh1kB1egI6UDYnGLL08w5TmKKGVJUqA==
+"@comunica/actor-rdf-join-optional-hash@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-join-optional-hash/-/actor-rdf-join-optional-hash-4.5.0.tgz#f87446d6730348214ce7380bc04610404a645d80"
+  integrity sha512-ogSoBp2OJGZFlUyu5XnggNKBhhQoYBivf4Avvphnm4xZ+4IQmLfwBuzEXhPTZN5Yyfu7L0hQK6Kykk1YuAZo0w==
   dependencies:
-    "@comunica/bus-rdf-join" "^4.2.0"
-    "@comunica/core" "^4.2.0"
-    "@comunica/mediatortype-join-coefficients" "^4.2.0"
-    "@comunica/types" "^4.2.0"
-    "@comunica/utils-bindings-factory" "^4.2.0"
-    "@comunica/utils-bindings-index" "^4.2.0"
-    "@comunica/utils-iterator" "^4.0.1"
+    "@comunica/bus-rdf-join" "^4.5.0"
+    "@comunica/core" "^4.5.0"
+    "@comunica/mediatortype-join-coefficients" "^4.5.0"
+    "@comunica/types" "^4.5.0"
+    "@comunica/utils-bindings-factory" "^4.5.0"
+    "@comunica/utils-bindings-index" "^4.5.0"
+    "@comunica/utils-iterator" "^4.5.0"
     asynciterator "^3.9.0"
     rdf-string "^1.6.3"
 
-"@comunica/actor-rdf-join-optional-nestedloop@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-rdf-join-optional-nestedloop/-/actor-rdf-join-optional-nestedloop-4.2.0.tgz"
-  integrity sha512-RRzxkms7Nzkpxh/HTPORHwcXdBiZkHYskTAwOz4r3vyvzHu0LroZ6ZyByP77XyNirZ5moxX9n4kq3GSjlKvxTw==
+"@comunica/actor-rdf-join-optional-nestedloop@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-join-optional-nestedloop/-/actor-rdf-join-optional-nestedloop-4.5.0.tgz#ac92098e62ca8d9d1c1a728457537fcccc77df91"
+  integrity sha512-szhKIYdV7r6Sv1+q7WW7831O33dO7yYlgbsTDwPir5hgLYHRprrjDFKhPbyA361waWiR7JLrUfdJaXt6FbSIYg==
   dependencies:
-    "@comunica/bus-rdf-join" "^4.2.0"
-    "@comunica/core" "^4.2.0"
-    "@comunica/mediatortype-join-coefficients" "^4.2.0"
+    "@comunica/bus-rdf-join" "^4.5.0"
+    "@comunica/core" "^4.5.0"
+    "@comunica/mediatortype-join-coefficients" "^4.5.0"
     asyncjoin "^1.2.4"
 
-"@comunica/actor-rdf-join-selectivity-variable-counting@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-rdf-join-selectivity-variable-counting/-/actor-rdf-join-selectivity-variable-counting-4.2.0.tgz"
-  integrity sha512-8TIM0PR/Ixfhgjfl9b5UFAd+EEhilPnZtLsHfgMSiZO6StG08KIbCOzR2izMizFcUe1IXLT2WmoxZEfUAfjBNA==
+"@comunica/actor-rdf-join-selectivity-variable-counting@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-join-selectivity-variable-counting/-/actor-rdf-join-selectivity-variable-counting-4.5.0.tgz#6d295f253aab281f39c784106ad4bcde49e24508"
+  integrity sha512-98plhmPvrnYPXQa5PES6sAeNFB+qrGiZg1bUvAM5Jtg5jQ9BfwH+Bf02yIVAfyACjaLaTNGoOP/qHzb6HrUQdg==
   dependencies:
-    "@comunica/bus-rdf-join-selectivity" "^4.2.0"
-    "@comunica/core" "^4.2.0"
-    "@comunica/mediatortype-accuracy" "^4.2.0"
-    sparqlalgebrajs "^4.3.8"
+    "@comunica/bus-rdf-join-selectivity" "^4.5.0"
+    "@comunica/core" "^4.5.0"
+    "@comunica/mediatortype-accuracy" "^4.5.0"
+    sparqlalgebrajs "^5.0.2"
 
-"@comunica/actor-rdf-metadata-accumulate-cardinality@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-rdf-metadata-accumulate-cardinality/-/actor-rdf-metadata-accumulate-cardinality-4.2.0.tgz"
-  integrity sha512-wtMrxThX6m9tYgElYbd8i6hWh3nCr+1CLtk/ep1G5ZaNPD6eL494yabK75dLJHkz/eLv2jpdWDWGdfakGnVuMA==
+"@comunica/actor-rdf-metadata-accumulate-cardinality@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-metadata-accumulate-cardinality/-/actor-rdf-metadata-accumulate-cardinality-4.5.0.tgz#0f28bedaf829b714ed49ee9268b2e034fa03e2b7"
+  integrity sha512-fHQAs1dqOGwWrSAyCLMGMU3M1GKbjjvcyKS9cYwN47OiT2rEsbBZ1sGWOcpNgxJa4T59lvO4RlfDuuMpmcYLSQ==
   dependencies:
-    "@comunica/bus-rdf-metadata-accumulate" "^4.2.0"
-    "@comunica/core" "^4.2.0"
-    "@comunica/types" "^4.2.0"
+    "@comunica/bus-rdf-metadata-accumulate" "^4.5.0"
+    "@comunica/core" "^4.5.0"
+    "@comunica/types" "^4.5.0"
 
-"@comunica/actor-rdf-metadata-accumulate-pagesize@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-rdf-metadata-accumulate-pagesize/-/actor-rdf-metadata-accumulate-pagesize-4.2.0.tgz"
-  integrity sha512-lAttY0x9nTmcWgsiMHv0PAGG3ok1YDeNq3hdkjY+j6mqYM6eKCU5bZFyg96wAaTJtppASzOw4WTON0r8RJ8YeQ==
+"@comunica/actor-rdf-metadata-accumulate-pagesize@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-metadata-accumulate-pagesize/-/actor-rdf-metadata-accumulate-pagesize-4.5.0.tgz#dde6b0ec93ec52f9ce2fe3b8335f659e1077c7f3"
+  integrity sha512-V3Gci3XEN4gO6w+dSHt9QnzaO1+lhytmYxoHIkkwVcjh4X5WYxM82D2fjFf4dW9xF0Yej009ps8RpuX54YRseQ==
   dependencies:
-    "@comunica/bus-rdf-metadata-accumulate" "^4.2.0"
-    "@comunica/core" "^4.2.0"
+    "@comunica/bus-rdf-metadata-accumulate" "^4.5.0"
+    "@comunica/core" "^4.5.0"
 
-"@comunica/actor-rdf-metadata-accumulate-requesttime@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-rdf-metadata-accumulate-requesttime/-/actor-rdf-metadata-accumulate-requesttime-4.2.0.tgz"
-  integrity sha512-Ur5v/+UOx9qNAmLu6XV1fTy3DvgqPVM5BDGY9eZqre+uDTJzCLw8BtJI+5j8oCUMuLuHUmepzIE3owfJjWK01Q==
+"@comunica/actor-rdf-metadata-accumulate-requesttime@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-metadata-accumulate-requesttime/-/actor-rdf-metadata-accumulate-requesttime-4.5.0.tgz#944fe918e6ae55d91f82ad8665f3ec93dcec52c4"
+  integrity sha512-Br5hlNujsRFCHJ0g48oW8xBBQvDDT5lNaCuY0ky/sIv/ULk5aT5J/jBIvc5aeIXpA37D3KrvfenXz3ScqvTHSA==
   dependencies:
-    "@comunica/bus-rdf-metadata-accumulate" "^4.2.0"
-    "@comunica/core" "^4.2.0"
+    "@comunica/bus-rdf-metadata-accumulate" "^4.5.0"
+    "@comunica/core" "^4.5.0"
 
 "@comunica/actor-rdf-parse-html-microdata@^2.0.1":
   version "2.10.0"
@@ -3604,151 +3624,151 @@
     "@comunica/types" "^2.10.0"
     rdfa-streaming-parser "^2.0.1"
 
-"@comunica/actor-rdf-serialize-jsonld@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-rdf-serialize-jsonld/-/actor-rdf-serialize-jsonld-4.2.0.tgz"
-  integrity sha512-NtugnrS53bC23iWQ1Y981fy2tdjB8OMTnmvKLisQiy4TbfVEp//mNGNsKg9bGjmK7GQoMCbOw6RbO/F/AKdW1Q==
+"@comunica/actor-rdf-serialize-jsonld@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-serialize-jsonld/-/actor-rdf-serialize-jsonld-4.5.0.tgz#4fe6991a4b02a3e11674af444f392db1a178b0de"
+  integrity sha512-mHGiQ6roZaDNvhzlaSSXMPoLZpQypHY/+QLc8veR9lMWfsyo/BYBbhtVlVRU9r8rRe4EfSidAwxtfYhyiSzxuQ==
   dependencies:
-    "@comunica/bus-rdf-serialize" "^4.2.0"
-    "@comunica/types" "^4.2.0"
+    "@comunica/bus-rdf-serialize" "^4.5.0"
+    "@comunica/types" "^4.5.0"
     jsonld-streaming-serializer "^3.0.1"
 
-"@comunica/actor-rdf-serialize-n3@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-rdf-serialize-n3/-/actor-rdf-serialize-n3-4.2.0.tgz"
-  integrity sha512-c4aQ21BtMSWS2ssK51BKEsUbg6Fb+oIPG+uOssRKQ9Gyoy0RySjJ5KkqURdGEZ7qx4mxEb3V5Nt5r4VXYm7gbA==
+"@comunica/actor-rdf-serialize-n3@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-serialize-n3/-/actor-rdf-serialize-n3-4.5.0.tgz#0457325a1c54001c27a5aa3812e7ac810c60363e"
+  integrity sha512-VdhSUe9Ph5CdxuEILyKRtjeNGO5RcwpID/5zIItXJfiZeaeyBepIOAyFNzbk+M0tfMCtFOZKmSGFqGATZY2Dew==
   dependencies:
-    "@comunica/bus-rdf-serialize" "^4.2.0"
+    "@comunica/bus-rdf-serialize" "^4.5.0"
     n3 "^1.17.0"
 
-"@comunica/actor-rdf-serialize-shaclc@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-rdf-serialize-shaclc/-/actor-rdf-serialize-shaclc-4.2.0.tgz"
-  integrity sha512-zQPq5DzClgxeWhR0Z34bHSZWAxCh9jD+d9fxNYC4YfvFqYELCUsR86sHlTuVs/Ri4p7Mx+3xaZqM4LXfhZQRZw==
+"@comunica/actor-rdf-serialize-shaclc@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-serialize-shaclc/-/actor-rdf-serialize-shaclc-4.5.0.tgz#9081596dca90ae69d54b8c78a43dc12bcda01487"
+  integrity sha512-XC1YhgwXq9tEF9wPNZZOMtPo6oaQUlZnj3tPSRVHpi84bUveRcIJsaNmLUeudqMKTW6cwarAnDrwqtonaBJVsA==
   dependencies:
-    "@comunica/bus-rdf-serialize" "^4.2.0"
+    "@comunica/bus-rdf-serialize" "^4.5.0"
     arrayify-stream "^2.0.1"
     readable-stream "^4.5.2"
     shaclc-write "^1.4.2"
 
-"@comunica/actor-rdf-update-quads-rdfjs-store@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-rdf-update-quads-rdfjs-store/-/actor-rdf-update-quads-rdfjs-store-4.2.0.tgz"
-  integrity sha512-gLBHHa2DMELJM/h0tEUM7LEQGyVG8pxzGWXHGAFT4892Xyj/Omr8Jask/w7ZYTdYehNjYiyUyB7vvp3wXO6Hiw==
+"@comunica/actor-rdf-update-quads-rdfjs-store@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-update-quads-rdfjs-store/-/actor-rdf-update-quads-rdfjs-store-4.5.0.tgz#c74a6b97e31dcfaf642a88a201aa52b0955799e0"
+  integrity sha512-PsV7Fdm/y0jLfSsByUpU0GkbRIV4d73q7d6Ytl5iWQLwvfYiJ8KE6qQyN0tOvcYO9cCwhMCYusEoy6kep6Ml4A==
   dependencies:
-    "@comunica/bus-rdf-update-quads" "^4.2.0"
-    "@comunica/context-entries" "^4.2.0"
-    "@comunica/core" "^4.2.0"
-    "@comunica/types" "^4.2.0"
+    "@comunica/bus-rdf-update-quads" "^4.5.0"
+    "@comunica/context-entries" "^4.5.0"
+    "@comunica/core" "^4.5.0"
+    "@comunica/types" "^4.5.0"
     "@rdfjs/types" "*"
     asynciterator "^3.9.0"
     event-emitter-promisify "^1.1.0"
     rdf-string "^1.6.1"
 
-"@comunica/actor-term-comparator-factory-expression-evaluator@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/actor-term-comparator-factory-expression-evaluator/-/actor-term-comparator-factory-expression-evaluator-4.2.0.tgz"
-  integrity sha512-wgt6nZGC0/WhBgtBqpLkiZgN10VUaqL14AMZg3HsMkdb02/+uksWlWjmRDW9zaKYvgcWAaYbODpciSyqlRoZEA==
+"@comunica/actor-term-comparator-factory-expression-evaluator@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-term-comparator-factory-expression-evaluator/-/actor-term-comparator-factory-expression-evaluator-4.5.0.tgz#4af245abfc5a17f7c4e2c16eec822cf0fda3149c"
+  integrity sha512-sI46VJ80mfgwTDBhSuzPfIzNABOc10du4rE3NPVl9ysXU+mlfy71B1tkOq25wkGc/bKqo3etNURJz790qCD+4w==
   dependencies:
-    "@comunica/actor-expression-evaluator-factory-default" "^4.2.0"
-    "@comunica/bus-function-factory" "^4.2.0"
-    "@comunica/bus-term-comparator-factory" "^4.2.0"
-    "@comunica/context-entries" "^4.2.0"
-    "@comunica/core" "^4.2.0"
-    "@comunica/utils-bindings-factory" "^4.2.0"
-    "@comunica/utils-expression-evaluator" "^4.2.0"
+    "@comunica/actor-expression-evaluator-factory-default" "^4.5.0"
+    "@comunica/bus-function-factory" "^4.5.0"
+    "@comunica/bus-term-comparator-factory" "^4.5.0"
+    "@comunica/context-entries" "^4.5.0"
+    "@comunica/core" "^4.5.0"
+    "@comunica/utils-bindings-factory" "^4.5.0"
+    "@comunica/utils-expression-evaluator" "^4.5.0"
     "@rdfjs/types" "*"
 
-"@comunica/bus-bindings-aggregator-factory@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/bus-bindings-aggregator-factory/-/bus-bindings-aggregator-factory-4.2.0.tgz"
-  integrity sha512-Rwu4AP2OwXbjOHHDHi8nSit1xDcuL/PsrWjhKvGanQGFgRe/xB8TVfOfzLLpnFy1WELFsbVbV55ybKEF5N2Gug==
+"@comunica/bus-bindings-aggregator-factory@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/bus-bindings-aggregator-factory/-/bus-bindings-aggregator-factory-4.5.0.tgz#d52e1c039dfb392770a4bd5f81041025252ff327"
+  integrity sha512-gI8UIgEJwYriQmalmMcA1q5g9cu7EzXLuJELiJZMm03msAoVB+RcZmbRBlYnVfRw/uTShl7IV8k27Hl05AjpCQ==
   dependencies:
-    "@comunica/bus-expression-evaluator-factory" "^4.2.0"
-    "@comunica/context-entries" "^4.2.0"
-    "@comunica/core" "^4.2.0"
-    "@comunica/types" "^4.2.0"
-    "@comunica/utils-expression-evaluator" "^4.2.0"
+    "@comunica/bus-expression-evaluator-factory" "^4.5.0"
+    "@comunica/context-entries" "^4.5.0"
+    "@comunica/core" "^4.5.0"
+    "@comunica/types" "^4.5.0"
+    "@comunica/utils-expression-evaluator" "^4.5.0"
     "@rdfjs/types" "*"
     rdf-string "^1.6.3"
-    sparqlalgebrajs "^4.2.0"
+    sparqlalgebrajs "^5.0.2"
 
-"@comunica/bus-context-preprocess@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/bus-context-preprocess/-/bus-context-preprocess-4.2.0.tgz"
-  integrity sha512-Au+RmbJddaHpWulfQXSS+FkijFai96oOuk1Jrq4Dw5iOPvY4gKFI1/iK8OnkU0wn1vINyCKTPHCLx6lUSHu4fw==
+"@comunica/bus-context-preprocess@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/bus-context-preprocess/-/bus-context-preprocess-4.5.0.tgz#f74a99c9b375155673c0c0d55178a153b40076bc"
+  integrity sha512-PE2aSmzcQsDuIUJGt0Ko6yD8YithHy6XwXKeS8OHaQeI93S+V6DZKaaCE+gCNcDBi8jZ4P4cislay/+8V1ZIPg==
   dependencies:
-    "@comunica/core" "^4.2.0"
-    "@comunica/types" "^4.2.0"
+    "@comunica/core" "^4.5.0"
+    "@comunica/types" "^4.5.0"
 
-"@comunica/bus-dereference-rdf@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/bus-dereference-rdf/-/bus-dereference-rdf-4.2.0.tgz"
-  integrity sha512-RQvj/BMP9QD9v3ZR4vIYLLlRWawAhXDzCOZZ6oJnhmxSOW0NfdL3h5rFI03HVPpDfyWtV4ACKK8FNe6gOIeXZw==
+"@comunica/bus-dereference-rdf@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/bus-dereference-rdf/-/bus-dereference-rdf-4.5.0.tgz#597daf78c5793142dc151716045ce4893fb6d6ba"
+  integrity sha512-z9NQ7zOoNQH7XoiZEHkMl4Y6fYLkinP+KQgGGSTm2ylhAHnId7qf+UVZhbe1+jmX50YhNOPc3ZT1LOm1YdSnzw==
   dependencies:
-    "@comunica/bus-dereference" "^4.2.0"
-    "@comunica/bus-rdf-parse" "^4.2.0"
-    "@comunica/core" "^4.2.0"
+    "@comunica/bus-dereference" "^4.5.0"
+    "@comunica/bus-rdf-parse" "^4.5.0"
+    "@comunica/core" "^4.5.0"
     "@rdfjs/types" "*"
 
-"@comunica/bus-dereference@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/bus-dereference/-/bus-dereference-4.2.0.tgz"
-  integrity sha512-KWaGcrW9B0tWbgtG8gDK6nosdl94unyaaX5eCDSjTXqN6ZZA+NEDHbzRWypxcxbzMugAvyNwcAmC28KW+h9KCQ==
+"@comunica/bus-dereference@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/bus-dereference/-/bus-dereference-4.5.0.tgz#0019f744a6d1dd2554c75b7ea1f379bec5396693"
+  integrity sha512-aaiPxZMS/KlkLbQErOtGRMtirVGWYVEmQiFtlKkak2w+584rHTS33m0YD21r6iuQ9RIleRIAb8kAsPa6zDgAnA==
   dependencies:
-    "@comunica/actor-abstract-mediatyped" "^4.2.0"
-    "@comunica/actor-abstract-parse" "^4.2.0"
-    "@comunica/context-entries" "^4.2.0"
-    "@comunica/core" "^4.2.0"
-    "@comunica/types" "^4.2.0"
+    "@comunica/actor-abstract-mediatyped" "^4.5.0"
+    "@comunica/actor-abstract-parse" "^4.5.0"
+    "@comunica/context-entries" "^4.5.0"
+    "@comunica/core" "^4.5.0"
+    "@comunica/types" "^4.5.0"
     readable-stream "^4.5.2"
 
-"@comunica/bus-expression-evaluator-factory@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/bus-expression-evaluator-factory/-/bus-expression-evaluator-factory-4.2.0.tgz"
-  integrity sha512-wrtC4deJU6sd6eDBYiP0fQ76vAZSIRzaB55qtBWjYxYlMkEnXHhOAiXyhFSOeELa0t9ynkiP6+uqbwso5Vf3KA==
+"@comunica/bus-expression-evaluator-factory@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/bus-expression-evaluator-factory/-/bus-expression-evaluator-factory-4.5.0.tgz#210ba3c935e6205a7e1cd6f4594436c503ccbc0c"
+  integrity sha512-QaeEiiXq75fV6+P3DnTKJkrV5p9yv1PqmsSPJ3h66DUManXrQEh9ATnJAwEBoUJlHE4Sy2aqho6Whate1W/orA==
   dependencies:
-    "@comunica/bus-function-factory" "^4.2.0"
-    "@comunica/bus-merge-bindings-context" "^4.2.0"
-    "@comunica/bus-query-operation" "^4.2.0"
-    "@comunica/core" "^4.2.0"
-    "@comunica/types" "^4.2.0"
-    sparqlalgebrajs "^4.2.0"
+    "@comunica/bus-function-factory" "^4.5.0"
+    "@comunica/bus-merge-bindings-context" "^4.5.0"
+    "@comunica/bus-query-operation" "^4.5.0"
+    "@comunica/core" "^4.5.0"
+    "@comunica/types" "^4.5.0"
+    sparqlalgebrajs "^5.0.2"
 
-"@comunica/bus-function-factory@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/bus-function-factory/-/bus-function-factory-4.2.0.tgz"
-  integrity sha512-sxMImvteTSt/5IXYmJ7Gz2OjxIr0XJB7yhBcbMFw1JW2C7yTFl2MHaH8ED+95Ap4xtDUQNx4P70P4Odq9K6Gaw==
+"@comunica/bus-function-factory@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/bus-function-factory/-/bus-function-factory-4.5.0.tgz#1558e4df2961831a0ac1332f37adeafc8daec556"
+  integrity sha512-C/D9hzDWAv0GNDYV547rZrVAvkR7pc5CBeE3f3VOHW1aEBc3cvRFSf6FkrweqtxvywK3gI2V+3OPr4kwmRAGXg==
   dependencies:
-    "@comunica/context-entries" "^4.2.0"
-    "@comunica/core" "^4.2.0"
-    "@comunica/types" "^4.2.0"
-    "@comunica/utils-expression-evaluator" "^4.2.0"
-    sparqlalgebrajs "^4.2.0"
+    "@comunica/context-entries" "^4.5.0"
+    "@comunica/core" "^4.5.0"
+    "@comunica/types" "^4.5.0"
+    "@comunica/utils-expression-evaluator" "^4.5.0"
+    sparqlalgebrajs "^5.0.2"
 
-"@comunica/bus-hash-bindings@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/bus-hash-bindings/-/bus-hash-bindings-4.2.0.tgz"
-  integrity sha512-mQ3EmvT/IKBSpa+37PyB1iMwIObpTQss2hqgLmTkM1P8HfrVoGYvr3/LHbbB8lFhhEvaY2O4OfaCXMWsJbmP7g==
+"@comunica/bus-hash-bindings@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/bus-hash-bindings/-/bus-hash-bindings-4.5.0.tgz#3ee7324557219cb559f19523580f09c092c3dfd6"
+  integrity sha512-SV1B83AD1ULprq9Xj/DAConubdOkH7ZYWF5MePolYTE1Wx7BMZv1giGVvR56/tA3/37NZzvffZPfqUc6C8Ip0A==
   dependencies:
-    "@comunica/core" "^4.2.0"
-    "@comunica/types" "^4.2.0"
+    "@comunica/core" "^4.5.0"
+    "@comunica/types" "^4.5.0"
     "@rdfjs/types" "*"
 
-"@comunica/bus-hash-quads@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/bus-hash-quads/-/bus-hash-quads-4.2.0.tgz"
-  integrity sha512-vSydgS2a6UykuleSAdpx4SrZT7Gim6ocR55NUYmZdqNYwkBZ9/7PfRYsKpo6i3NTaXv8WArIg7p+KuDUZIDmIQ==
+"@comunica/bus-hash-quads@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/bus-hash-quads/-/bus-hash-quads-4.5.0.tgz#c78608cd629721af265642c3d707e58b54382ff4"
+  integrity sha512-733+aHqi+hnlOY6bKAvy27Py54/IvOeGtehr6De8g6ZswP5UatiL4GURQk+acBK4aYSw9RzeyQhCu/LxO0q//g==
   dependencies:
-    "@comunica/core" "^4.2.0"
+    "@comunica/core" "^4.5.0"
     rdf-data-factory "^1.1.2"
 
-"@comunica/bus-http-invalidate@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/bus-http-invalidate/-/bus-http-invalidate-4.2.0.tgz"
-  integrity sha512-HsWj+AMPHcshRv+srt3r1I4WJCVgITrHFqr/GPCOrXibLpbA9ECoQ20npb5hO/MJIOsG6wvWaqIbv6loOwVOqA==
+"@comunica/bus-http-invalidate@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/bus-http-invalidate/-/bus-http-invalidate-4.5.0.tgz#561747b2029da03e6480327d7b982e24a329baaa"
+  integrity sha512-s6BJuWjN4enAqWMk07jVVxCaib9KlMTo/XW+ySM+RAa6KUmiy01ucNcvxaqjrFMdLTAoxl6R+4/XZdTOyH4bJQ==
   dependencies:
-    "@comunica/core" "^4.2.0"
+    "@comunica/core" "^4.5.0"
 
 "@comunica/bus-http@^2.0.1", "@comunica/bus-http@^2.10.2":
   version "2.10.2"
@@ -3761,12 +3781,12 @@
     readable-stream-node-to-web "^1.0.1"
     web-streams-ponyfill "^1.4.2"
 
-"@comunica/bus-http@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/bus-http/-/bus-http-4.2.0.tgz"
-  integrity sha512-ZCtufwu+xMFUlE8FvI1CrNncW6Npa44wWN+RMGu+X0qhP0DIu9DyUZlKJgwy1KcMfhqwbEQpsWf9kWlyW2IpCQ==
+"@comunica/bus-http@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/bus-http/-/bus-http-4.5.0.tgz#8f3facfc352da10a64bfffbdc6458c89829e2922"
+  integrity sha512-wWyPNNOl6shDbtibdBl/pa9OIcoEMemNIo/J4tUViXxYXZ8i1h4FZ6PqaLtAls6O+pV71mR4SKJzKEUuiZiXPg==
   dependencies:
-    "@comunica/core" "^4.2.0"
+    "@comunica/core" "^4.5.0"
     "@jeswr/stream-to-string" "^2.0.0"
     is-stream "^2.0.1"
     readable-from-web "^1.0.0"
@@ -3780,149 +3800,149 @@
     "@comunica/core" "^2.10.0"
     readable-stream "^4.4.2"
 
-"@comunica/bus-init@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/bus-init/-/bus-init-4.2.0.tgz"
-  integrity sha512-AxX9fOI0xKjed4nbxz5ADLb5ILbBJPkvDuehvKOtK5i2fto+cUDg3V4QUVJEdSrCoreSwdSzmygG93NBOkqHrg==
+"@comunica/bus-init@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/bus-init/-/bus-init-4.5.0.tgz#d58e931906d80f01efae81c0a70878a83da47571"
+  integrity sha512-9TYFLjirHDt7HPXj3eQW9KX3x5T3mZ1G/EKadL1gQxo0FAqs3y8TdicepCLhk3HY/egidlyv9WQYAPvJ+WAmAg==
   dependencies:
-    "@comunica/core" "^4.2.0"
+    "@comunica/core" "^4.5.0"
     readable-stream "^4.5.2"
 
-"@comunica/bus-merge-bindings-context@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/bus-merge-bindings-context/-/bus-merge-bindings-context-4.2.0.tgz"
-  integrity sha512-iORfEkZ4Z1tFlh7jvZtB7pfr51z1mVn03LJSMwKo4Y8nke+MDXtrSpUd0/KLJ9Y5YF9F+2JodbzWoiLEE4NbQA==
+"@comunica/bus-merge-bindings-context@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/bus-merge-bindings-context/-/bus-merge-bindings-context-4.5.0.tgz#b674fdc4b6f7c03cd063b1a29af5f58622f97505"
+  integrity sha512-btvNISwnA+e7ZEvgD80yWnUc90obUgCVDPTA0mx2s2gpi3rx8JV3RusC1fjw4R6d5s9xc4kGq0BmEP60w1v82Q==
   dependencies:
-    "@comunica/core" "^4.2.0"
-    "@comunica/types" "^4.2.0"
+    "@comunica/core" "^4.5.0"
+    "@comunica/types" "^4.5.0"
 
-"@comunica/bus-optimize-query-operation@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/bus-optimize-query-operation/-/bus-optimize-query-operation-4.2.0.tgz"
-  integrity sha512-Dotr1353dJZQ+J7PqHjSH/EheClMEWZ+ZyHYYrYx21sCJvaGqY4X+qHY2yBTnkl/2RakbQu/PLVnVbkwtYSGxQ==
+"@comunica/bus-optimize-query-operation@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/bus-optimize-query-operation/-/bus-optimize-query-operation-4.5.0.tgz#0da73bc039d9bd87fb191ee10e3304f30786618c"
+  integrity sha512-JMSpmIehaIQKDktrI5JKqxjU7M/4PYIGbuNHMYgcauZ2XxhFCbUhthshT+tY7pknmJg38whr9bK0Ziyw233Nvw==
   dependencies:
-    "@comunica/core" "^4.2.0"
-    "@comunica/types" "^4.2.0"
-    sparqlalgebrajs "^4.3.8"
+    "@comunica/core" "^4.5.0"
+    "@comunica/types" "^4.5.0"
+    sparqlalgebrajs "^5.0.2"
 
-"@comunica/bus-query-operation@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/bus-query-operation/-/bus-query-operation-4.2.0.tgz"
-  integrity sha512-trefCh+bAEQBOx5RKrtvyGcTeR41tsemyqVg8m/gYCpz4tO26u9EXWjxtTdjU81Lopv2S4l4VpmlDFOXLSBTZA==
+"@comunica/bus-query-operation@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/bus-query-operation/-/bus-query-operation-4.5.0.tgz#1e3caffa77389f6e0ca1246d5a0973d06349ec83"
+  integrity sha512-5sLmlmF+oBmNep0lEQuz9V291ddYSRzFJXT3nF+kswB6SjHj2FzwQZpjDEBkIhNXy3h5JY6J/3BqO20hR/IK2g==
   dependencies:
-    "@comunica/context-entries" "^4.2.0"
-    "@comunica/core" "^4.2.0"
-    "@comunica/types" "^4.2.0"
-    "@comunica/utils-metadata" "^4.2.0"
+    "@comunica/context-entries" "^4.5.0"
+    "@comunica/core" "^4.5.0"
+    "@comunica/types" "^4.5.0"
+    "@comunica/utils-metadata" "^4.5.0"
     "@rdfjs/types" "*"
-    sparqlalgebrajs "^4.3.8"
+    sparqlalgebrajs "^5.0.2"
 
-"@comunica/bus-query-parse@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/bus-query-parse/-/bus-query-parse-4.2.0.tgz"
-  integrity sha512-4CbzXpi+B6JrSprUxiZTzfBsY50sDc48/t3HFeX4dkux52tyuv4Flo4RPq2Ffs4Sb1XBo7WcI7GIuR6jlfGEwg==
+"@comunica/bus-query-parse@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/bus-query-parse/-/bus-query-parse-4.5.0.tgz#c487f7c20fac6c6800b6170603b1278482a045a4"
+  integrity sha512-Zd5uKEAVmVuAC9RQWg4QfVD8qidg7SqUdLA4lDMp6UfRUv+GyGQzTuGIr9DD3xjnxPfeiaO4t7M1CSaMA0kqhQ==
   dependencies:
-    "@comunica/core" "^4.2.0"
+    "@comunica/core" "^4.5.0"
     "@rdfjs/types" "*"
-    sparqlalgebrajs "^4.3.8"
+    sparqlalgebrajs "^5.0.2"
 
-"@comunica/bus-query-process@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/bus-query-process/-/bus-query-process-4.2.0.tgz"
-  integrity sha512-g20Ra9VoGBdTLVS10zU0v0V8uS/UDxBaqF3m1tvvxyLWaaDVluURJkGI9H809nSr7ID2z9zmpYgl+9GT9SNNKQ==
+"@comunica/bus-query-process@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/bus-query-process/-/bus-query-process-4.5.0.tgz#1323991655b3f96ba684822c10d1b313cf1aa803"
+  integrity sha512-GYNGP9bjB8UtHCqQ77RPYaR0Kd58brGjSuA1xFxVCm255r6AmM5o0SwG6hydl4I3scdz+E12h938a1YV+LFL1A==
   dependencies:
-    "@comunica/core" "^4.2.0"
-    "@comunica/types" "^4.2.0"
-    sparqlalgebrajs "^4.3.8"
+    "@comunica/core" "^4.5.0"
+    "@comunica/types" "^4.5.0"
+    sparqlalgebrajs "^5.0.2"
 
-"@comunica/bus-query-result-serialize@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/bus-query-result-serialize/-/bus-query-result-serialize-4.2.0.tgz"
-  integrity sha512-vF7NGsoVX69KfcVdX3seLPhGEO8xFVRFDglD6i5PR9TtFaI6X0IKfwm0yvNIi99M36RczzdWxrCBwY92cW7Rvg==
+"@comunica/bus-query-result-serialize@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/bus-query-result-serialize/-/bus-query-result-serialize-4.5.0.tgz#754348840521492fa5b56bbd1be9afdea073700b"
+  integrity sha512-KONwhEtNcoiKsVATz9RikdpWSLlKcxII+Bwh8jT9XogWwFXx0oj0WoqTPl97IwtNN2DNvfnzHqZ06v/nsMXBSw==
   dependencies:
-    "@comunica/actor-abstract-mediatyped" "^4.2.0"
-    "@comunica/core" "^4.2.0"
-    "@comunica/types" "^4.2.0"
+    "@comunica/actor-abstract-mediatyped" "^4.5.0"
+    "@comunica/core" "^4.5.0"
+    "@comunica/types" "^4.5.0"
 
-"@comunica/bus-query-source-identify-hypermedia@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/bus-query-source-identify-hypermedia/-/bus-query-source-identify-hypermedia-4.2.0.tgz"
-  integrity sha512-xuahx4w8o7gSUxKhkrmMOaPyoR5UeK2B6Tr21fLdd3kjfYnY13XZU+mjxrPIJNPfPRxYyiFcJ5xJjSE/6jWIIw==
+"@comunica/bus-query-source-identify-hypermedia@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/bus-query-source-identify-hypermedia/-/bus-query-source-identify-hypermedia-4.5.0.tgz#e554e93967a27f085fc78bccd7038348aea61d2a"
+  integrity sha512-0vl5oxj4ohmPok2M55BpsUKXp60RR0xpCsnkHhoNhHegrRSGJHGlIQV7D8E/mUijxm6UFXXfxAUj4qUGYujdKQ==
   dependencies:
-    "@comunica/core" "^4.2.0"
-    "@comunica/types" "^4.2.0"
+    "@comunica/core" "^4.5.0"
+    "@comunica/types" "^4.5.0"
     "@rdfjs/types" "*"
 
-"@comunica/bus-query-source-identify@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/bus-query-source-identify/-/bus-query-source-identify-4.2.0.tgz"
-  integrity sha512-lULfROk9jV+jL5M1axwaQUrlG4kMAuqSUH3bcheTUAKsJo7jo+/omI0SfOMr/shczKrYn9lgHih2Oh9CmVnGEA==
+"@comunica/bus-query-source-identify@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/bus-query-source-identify/-/bus-query-source-identify-4.5.0.tgz#a99d7f648ce1658edc988f655f3f4de3628cd9ad"
+  integrity sha512-snauZ+CF/S8NWm/isIk940qy/5RVhPWAvt2D0cmKpCFZOSnOrHe1zh0mX7mQrH/IA2IQmJloXE2rGugbNm22YQ==
   dependencies:
-    "@comunica/core" "^4.2.0"
-    "@comunica/types" "^4.2.0"
-    "@comunica/utils-bindings-factory" "^4.2.0"
-    "@comunica/utils-iterator" "^4.0.1"
-    "@comunica/utils-metadata" "^4.2.0"
+    "@comunica/core" "^4.5.0"
+    "@comunica/types" "^4.5.0"
+    "@comunica/utils-bindings-factory" "^4.5.0"
+    "@comunica/utils-iterator" "^4.5.0"
+    "@comunica/utils-metadata" "^4.5.0"
     "@rdfjs/types" "*"
     asynciterator "^3.9.0"
     rdf-string "^1.6.3"
     rdf-terms "^1.11.0"
-    sparqlalgebrajs "^4.3.8"
+    sparqlalgebrajs "^5.0.2"
 
-"@comunica/bus-rdf-join-entries-sort@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/bus-rdf-join-entries-sort/-/bus-rdf-join-entries-sort-4.2.0.tgz"
-  integrity sha512-ngUYf7iq9be3DbzfAcplCrjb3Nah5Y3FN71+pZt2c8icBl7/GT209iDmmDwexm7qz/xLTuwfQTdGuVci9g1djg==
+"@comunica/bus-rdf-join-entries-sort@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/bus-rdf-join-entries-sort/-/bus-rdf-join-entries-sort-4.5.0.tgz#5cfad41d4fd60430ebed166d7f82f9679582f1c9"
+  integrity sha512-WdAHVpFvDyF3Ale56bxSaAwLhxyE8344B5uOxCGsqrlbh+luVZL4ccyUFPyCyvP24M1YUEyxVzV6hHQu860x8Q==
   dependencies:
-    "@comunica/core" "^4.2.0"
-    "@comunica/types" "^4.2.0"
+    "@comunica/core" "^4.5.0"
+    "@comunica/types" "^4.5.0"
 
-"@comunica/bus-rdf-join-selectivity@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/bus-rdf-join-selectivity/-/bus-rdf-join-selectivity-4.2.0.tgz"
-  integrity sha512-GQwrbWqx+ga843TfrKwSLJ+Y0HiEhwkYMRQWRlsJnA3AgKdkJb2u6CpU1eHjQwEgcnDC4xYatPnhu/GJ/LEIJw==
+"@comunica/bus-rdf-join-selectivity@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/bus-rdf-join-selectivity/-/bus-rdf-join-selectivity-4.5.0.tgz#91376524af3a2fbe26a70a47af508375fd390e19"
+  integrity sha512-QocxGFR0XPoq7CnvGs3cyh3xYnTVwTHTZHkMksO/GJ6WBeAFo9PYaSdusrfShyNHL3SxrfhGO4vqBfNzvtzHLw==
   dependencies:
-    "@comunica/core" "^4.2.0"
-    "@comunica/mediatortype-accuracy" "^4.2.0"
-    "@comunica/types" "^4.2.0"
+    "@comunica/core" "^4.5.0"
+    "@comunica/mediatortype-accuracy" "^4.5.0"
+    "@comunica/types" "^4.5.0"
 
-"@comunica/bus-rdf-join@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/bus-rdf-join/-/bus-rdf-join-4.2.0.tgz"
-  integrity sha512-gWpKLcC/8ffWr+snVcqx8UuLthuaigRc9YIN4TVDOZ5Hqv7do/Wy7bgctGjGGsOsTl7rhvPGHFnP2dwAgg8Ayg==
+"@comunica/bus-rdf-join@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/bus-rdf-join/-/bus-rdf-join-4.5.0.tgz#657a208e3118ed4d9ee183e85f9d4ec2bf1f5242"
+  integrity sha512-qvasYM2hfF+nEvAi5N/0KZfqFRrPDxu7xU9Tq9XK+14cQRaxGQ/8Xh+cGRTQvNgdXM6zo5MBmtauDsJ0L85msg==
   dependencies:
-    "@comunica/bus-rdf-join-entries-sort" "^4.2.0"
-    "@comunica/bus-rdf-join-selectivity" "^4.2.0"
-    "@comunica/context-entries" "^4.2.0"
-    "@comunica/core" "^4.2.0"
-    "@comunica/mediatortype-join-coefficients" "^4.2.0"
-    "@comunica/types" "^4.2.0"
-    "@comunica/utils-iterator" "^4.0.1"
-    "@comunica/utils-metadata" "^4.2.0"
+    "@comunica/bus-rdf-join-entries-sort" "^4.5.0"
+    "@comunica/bus-rdf-join-selectivity" "^4.5.0"
+    "@comunica/context-entries" "^4.5.0"
+    "@comunica/core" "^4.5.0"
+    "@comunica/mediatortype-join-coefficients" "^4.5.0"
+    "@comunica/types" "^4.5.0"
+    "@comunica/utils-iterator" "^4.5.0"
+    "@comunica/utils-metadata" "^4.5.0"
     "@rdfjs/types" "*"
 
-"@comunica/bus-rdf-metadata-accumulate@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/bus-rdf-metadata-accumulate/-/bus-rdf-metadata-accumulate-4.2.0.tgz"
-  integrity sha512-urv343Sbmez5xk6djkXpIMq6o1M/4drdBTVH8AzmTx4RSilAPYBnSneC3TS068NQDeFG2XjdJJbhKs3zU4ko4Q==
+"@comunica/bus-rdf-metadata-accumulate@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/bus-rdf-metadata-accumulate/-/bus-rdf-metadata-accumulate-4.5.0.tgz#1cccc7349ccf0cd2f29ea61c3f9843781b33fd7c"
+  integrity sha512-rnyo4XNGwRiK4tue0i928LgPt0rTuOCILYL4Qvon5Zj4tHQtV9yKinvnR58NnUqjLmjQLEmPrcpgYTZN4KLzjw==
   dependencies:
-    "@comunica/core" "^4.2.0"
-    "@comunica/types" "^4.2.0"
+    "@comunica/core" "^4.5.0"
+    "@comunica/types" "^4.5.0"
 
-"@comunica/bus-rdf-metadata-extract@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/bus-rdf-metadata-extract/-/bus-rdf-metadata-extract-4.2.0.tgz"
-  integrity sha512-/cVqE2AqMZwyv4hRs/XuqcHQ0fOFzOT33+h/S1mVpSsycKI1VtYX4Mv7my9sdE2EHicYRAnxwUDlrS4w7X2HHg==
+"@comunica/bus-rdf-metadata-extract@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/bus-rdf-metadata-extract/-/bus-rdf-metadata-extract-4.5.0.tgz#33e7edf4d019224526e4299ccd4bf4d1f070cb13"
+  integrity sha512-GNblaXBlVbMhHKEgzOACz8NLfHvz4jfqHWAOIMQZMIytS9umbO7Fz8ZLePQrIQogXAELlmOpynrUyuGf0QOOjQ==
   dependencies:
-    "@comunica/core" "^4.2.0"
+    "@comunica/core" "^4.5.0"
     "@rdfjs/types" "*"
 
-"@comunica/bus-rdf-metadata@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/bus-rdf-metadata/-/bus-rdf-metadata-4.2.0.tgz"
-  integrity sha512-LUcRGA4jlBPrr4X2DcDsBIasJYEq6awKplnFU4nBJHKC0QZgQC1DwsTvoxCHKvdQMkAJ6lAbbzkgTRtYRfPiHA==
+"@comunica/bus-rdf-metadata@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/bus-rdf-metadata/-/bus-rdf-metadata-4.5.0.tgz#90b1f44915c491f7438928d7ae8e2c4f5ff788b6"
+  integrity sha512-Ni7854D2O95aJWQJsC9vSk5FM/NoS4vy5xE/N3jRM2gIDicA445cWWqUU9VBX2VBJ9msxWHk8HZBy67KZl4gFg==
   dependencies:
-    "@comunica/core" "^4.2.0"
+    "@comunica/core" "^4.5.0"
     "@rdfjs/types" "*"
 
 "@comunica/bus-rdf-parse-html@^2.0.1", "@comunica/bus-rdf-parse-html@^2.10.0":
@@ -3943,62 +3963,62 @@
     "@comunica/core" "^2.10.0"
     "@rdfjs/types" "*"
 
-"@comunica/bus-rdf-parse@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/bus-rdf-parse/-/bus-rdf-parse-4.2.0.tgz"
-  integrity sha512-P92ACuOk2zicOfNDiRc8xAA/u3yw6pHKQDZWRs/XXJJQIyEU+9CAKA6URHcb0+ffnVtxHtiiqI2nsra7MRadIg==
+"@comunica/bus-rdf-parse@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/bus-rdf-parse/-/bus-rdf-parse-4.5.0.tgz#cb50f932aad38b34ad5d0a725de5b6e3fedb9ec7"
+  integrity sha512-TnTS9F2GSbibuCd0Rep20C9WXU0KH0iWl2S2xycefMFrZK7noA8LeT/AHNshQlMPKejKxWME+jNsvcXgC++8zw==
   dependencies:
-    "@comunica/actor-abstract-mediatyped" "^4.2.0"
-    "@comunica/actor-abstract-parse" "^4.2.0"
-    "@comunica/core" "^4.2.0"
+    "@comunica/actor-abstract-mediatyped" "^4.5.0"
+    "@comunica/actor-abstract-parse" "^4.5.0"
+    "@comunica/core" "^4.5.0"
     "@rdfjs/types" "*"
 
-"@comunica/bus-rdf-resolve-hypermedia-links-queue@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/bus-rdf-resolve-hypermedia-links-queue/-/bus-rdf-resolve-hypermedia-links-queue-4.2.0.tgz"
-  integrity sha512-57MEes59Yte57j9Wf5L9N8STXxJFjwcuNoC97PkKTH0jSARL82DDgRseJBs2RxjL0L2Yg0+naCgCzo2xnnnAKg==
+"@comunica/bus-rdf-resolve-hypermedia-links-queue@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/bus-rdf-resolve-hypermedia-links-queue/-/bus-rdf-resolve-hypermedia-links-queue-4.5.0.tgz#5bdb6fd0fd8cde2d7c7e41a726bcace3f6d26d4d"
+  integrity sha512-FRHVUaE+vEHz9keSArAbYCYTMi30YRLMR4UDyVVaOpOOu3P8vorDkUx1mjk//+miNn+0/o7kkLa53UlSwXAgbA==
   dependencies:
-    "@comunica/core" "^4.2.0"
-    "@comunica/types" "^4.2.0"
+    "@comunica/core" "^4.5.0"
+    "@comunica/types" "^4.5.0"
 
-"@comunica/bus-rdf-resolve-hypermedia-links@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/bus-rdf-resolve-hypermedia-links/-/bus-rdf-resolve-hypermedia-links-4.2.0.tgz"
-  integrity sha512-Lpx5bVG8CLyIIw4jesvt6ZjgFmV5+veagePa8guBgurWErkuGryPQhrCUqqdr4hqHfbgzd5FlfunBrY9Plgl4g==
+"@comunica/bus-rdf-resolve-hypermedia-links@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/bus-rdf-resolve-hypermedia-links/-/bus-rdf-resolve-hypermedia-links-4.5.0.tgz#5c30175bfe9f0e33e63cab3918fc48bc99a95015"
+  integrity sha512-sGNJPsbM4ZIzO6xLE8btPfZ/lsPSmiBvGgCWvpNTaPVCCMvlTkIl/mBEcCwdNEQRkmkIDoK6HH8Tb1ADcJ3mpA==
   dependencies:
-    "@comunica/core" "^4.2.0"
-    "@comunica/types" "^4.2.0"
+    "@comunica/core" "^4.5.0"
+    "@comunica/types" "^4.5.0"
 
-"@comunica/bus-rdf-serialize@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/bus-rdf-serialize/-/bus-rdf-serialize-4.2.0.tgz"
-  integrity sha512-F/U1I6qNQlwCzoIOwW1ZbCW6gUzPRHI53+n2qk/Kvnla0e/V/4eYQfd1FhVsNxO2X1jhWhG+sRDKb+cmpRjPBQ==
+"@comunica/bus-rdf-serialize@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/bus-rdf-serialize/-/bus-rdf-serialize-4.5.0.tgz#9ff9dc0bbc1ffb3c0eaa191b7bbf032d718fc696"
+  integrity sha512-4hBw+34Q1SoW1iBgw2UaAli+UcHTdxTNvNFKlJizsN1G20YNJYi/xS9cE36mSZO+pntYxQRRN2cp8Ou622pkig==
   dependencies:
-    "@comunica/actor-abstract-mediatyped" "^4.2.0"
-    "@comunica/core" "^4.2.0"
+    "@comunica/actor-abstract-mediatyped" "^4.5.0"
+    "@comunica/core" "^4.5.0"
     "@rdfjs/types" "*"
 
-"@comunica/bus-rdf-update-quads@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/bus-rdf-update-quads/-/bus-rdf-update-quads-4.2.0.tgz"
-  integrity sha512-c24G5zbl8+m3t8WOCcMwsJMoEyF6zIXSiI1Y3EacRHdw0KjdbyempS/8dauaHuyNfjWbrYOM0nEMep3Sn944+Q==
+"@comunica/bus-rdf-update-quads@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/bus-rdf-update-quads/-/bus-rdf-update-quads-4.5.0.tgz#7cb02ed428845d05840eeef6db31b4c1aac224b9"
+  integrity sha512-ZxUzqT+/DSyAMYWP/hSh3VIMErgjrWD73EciNqLg/QL6gjuG3twSbnO9ywSlYe2eKDEu8f4aX8ghGW400gZLPA==
   dependencies:
-    "@comunica/actor-context-preprocess-query-source-skolemize" "^4.2.0"
-    "@comunica/context-entries" "^4.2.0"
-    "@comunica/core" "^4.2.0"
-    "@comunica/types" "^4.2.0"
+    "@comunica/actor-context-preprocess-query-source-skolemize" "^4.5.0"
+    "@comunica/context-entries" "^4.5.0"
+    "@comunica/core" "^4.5.0"
+    "@comunica/types" "^4.5.0"
     "@rdfjs/types" "*"
     asynciterator "^3.9.0"
 
-"@comunica/bus-term-comparator-factory@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/bus-term-comparator-factory/-/bus-term-comparator-factory-4.2.0.tgz"
-  integrity sha512-YBz5lqJSljR99xOP3uEkkQjqE/4YbVbRBtaEygpaogebczvpb/rhL3bQUh1gYEWNT7co/iNw+hz2dHipYQaVUg==
+"@comunica/bus-term-comparator-factory@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/bus-term-comparator-factory/-/bus-term-comparator-factory-4.5.0.tgz#d03485accc0afafefabc0a24c9fb7fd4141c2619"
+  integrity sha512-UXqoBtF9uPT6V/uUo8byWOssOtHtc5Azrg2sb9cT8AWH2Salt0c/Hd4vWCM602Z1Hs/LxTSDaGEMdpZJin/7Ng==
   dependencies:
-    "@comunica/bus-function-factory" "^4.2.0"
-    "@comunica/bus-merge-bindings-context" "^4.2.0"
-    "@comunica/bus-query-operation" "^4.2.0"
-    "@comunica/core" "^4.2.0"
+    "@comunica/bus-function-factory" "^4.5.0"
+    "@comunica/bus-merge-bindings-context" "^4.5.0"
+    "@comunica/bus-query-operation" "^4.5.0"
+    "@comunica/core" "^4.5.0"
     "@rdfjs/types" "*"
 
 "@comunica/config-query-sparql@^2.0.1":
@@ -4006,10 +4026,10 @@
   resolved "https://registry.npmjs.org/@comunica/config-query-sparql/-/config-query-sparql-2.7.0.tgz"
   integrity sha512-rMnFgT7cz9+0z7wV4OzIMY5qM9/Z0mTGrR8y2JokoHyyTcBGOSajFmy61XCSLMCsLLG8qDXsJ4ClCCky3TGfqA==
 
-"@comunica/config-query-sparql@^4.3.0":
-  version "4.3.0"
-  resolved "https://registry.npmjs.org/@comunica/config-query-sparql/-/config-query-sparql-4.3.0.tgz"
-  integrity sha512-uFCwe5eSewx1bznciTZSTjMbN+9i4wD8l1KQEFe9b+UOGWJ0JLs4rz4PMYx0k/DQQqz6OyG87G2ikn16DoNzWg==
+"@comunica/config-query-sparql@^4.4.0":
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/@comunica/config-query-sparql/-/config-query-sparql-4.4.0.tgz#f00917eb3601c34afef4e4dc4bb17f145ffd03f5"
+  integrity sha512-ZVK6eqpYLNa3MRLOWjRaudgfSdraJH/oZIkc5S2doJI2ZmnHROqQUtjPs13kwkI3hGZ6MVBtLm55oz+tKj2lKA==
 
 "@comunica/context-entries@^2.10.0":
   version "2.10.0"
@@ -4022,16 +4042,16 @@
     jsonld-context-parser "^2.2.2"
     sparqlalgebrajs "^4.2.0"
 
-"@comunica/context-entries@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/context-entries/-/context-entries-4.2.0.tgz"
-  integrity sha512-F9FDSHXUP9TT9urSC+oXo6oNJYV6Q7lDRVQPi4DL81M9S34iNgOBnTdOlHxExiEwVnRfKdTKkRii/qe4Zk7Gbg==
+"@comunica/context-entries@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/context-entries/-/context-entries-4.5.0.tgz#c0ed66c2ea55cb8a20100de62e877ccfa1865297"
+  integrity sha512-mgeSYFBcpMKLq34COpy129LVHigGUgA1uEI66WXmk3mdmlAKRQNe9D/W2Q924w0FZZmIOpeLMo+s358tFsodow==
   dependencies:
-    "@comunica/core" "^4.2.0"
-    "@comunica/types" "^4.2.0"
+    "@comunica/core" "^4.5.0"
+    "@comunica/types" "^4.5.0"
     "@rdfjs/types" "*"
     jsonld-context-parser "^2.2.2"
-    sparqlalgebrajs "^4.3.8"
+    sparqlalgebrajs "^5.0.2"
 
 "@comunica/core@^2.0.1", "@comunica/core@^2.10.0":
   version "2.10.0"
@@ -4041,36 +4061,36 @@
     "@comunica/types" "^2.10.0"
     immutable "^4.1.0"
 
-"@comunica/core@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/core/-/core-4.2.0.tgz"
-  integrity sha512-E4TfsxmBYgan9xPSCAom6B231EonTFxM/hEdFbRmVhuCv+Ids7d4UhGt3MENJDXH+UhURjqKpfzYySvAqYqVOA==
+"@comunica/core@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/core/-/core-4.5.0.tgz#1fd0c243c6e8c2bd9d890df1f5e0181feaa94313"
+  integrity sha512-UFHBboFaY0eESH0H8qJRIRuRfda2QduS886l2sRum/V4qhzJkMpf3zdOoZoBbRDU24PBmliWysi9TEsaPsyRwg==
   dependencies:
-    "@comunica/types" "^4.2.0"
-    immutable "^4.3.7"
+    "@comunica/types" "^4.5.0"
+    immutable "^5.1.3"
 
-"@comunica/logger-pretty@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/logger-pretty/-/logger-pretty-4.2.0.tgz"
-  integrity sha512-PkiAv13icKnq5JydB7W1mBR4tc+mxpZUsnWG9tc/6V26ayd/W42FZPWDFUk7+jqdxa0oHPsaq6YrOeGFYmnsUA==
+"@comunica/logger-pretty@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/logger-pretty/-/logger-pretty-4.5.0.tgz#fcc724e059c11d2f8e6ab49e5f63aaf4e30f4f2e"
+  integrity sha512-4Fs0FCnHWFO1EHmFTNhd92o9WTVIigesu6kuk2DP+Zwvm6HKTqgMqllovyllE0nIVyL+YcWSAPvkUTWmQybFIg==
   dependencies:
-    "@comunica/types" "^4.2.0"
+    "@comunica/types" "^4.5.0"
     object-inspect "^1.12.2"
     process "^0.11.10"
 
-"@comunica/logger-void@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/logger-void/-/logger-void-4.2.0.tgz"
-  integrity sha512-HHutmKwSh32eX+HQkPRyWc2etyWz1ZpkdVUIn60kANpfzGz9J+tWMqUZvhU4IBWrt8ezcpEsNFSXYa1XejsjJA==
+"@comunica/logger-void@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/logger-void/-/logger-void-4.5.0.tgz#56c36c970f54aac378595a82085973567fc5904c"
+  integrity sha512-qvRxSlD65KLLqIkU7zwnJ/uPMmYTlsI9J4gsYgEi8OOss5YuNSChAbbzZwRCNrAZOnRGjyrPfgN/Cd3NuglGew==
   dependencies:
-    "@comunica/types" "^4.2.0"
+    "@comunica/types" "^4.5.0"
 
-"@comunica/mediator-all@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/mediator-all/-/mediator-all-4.2.0.tgz"
-  integrity sha512-R8p5zbj+NJwpIUexNkDudUFVogheNJJRE4vHpQ3roPBWJ6hOIDSg80lGAmHeAKswKd7RkhoyeurGvwVtfGA6ug==
+"@comunica/mediator-all@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/mediator-all/-/mediator-all-4.5.0.tgz#90ac2c38664100f612d87025db8757fe671b9e6c"
+  integrity sha512-9qX58JgDaC56at0m3FdyYZhXw7kBUPuXihpwYowBwuopdlh0XioJyT/b3g+DC0/kiuSCcx6NhSAWzfNLAqTL7A==
   dependencies:
-    "@comunica/core" "^4.2.0"
+    "@comunica/core" "^4.5.0"
 
 "@comunica/mediator-combine-pipeline@^2.0.1":
   version "2.10.0"
@@ -4080,13 +4100,13 @@
     "@comunica/core" "^2.10.0"
     "@comunica/types" "^2.10.0"
 
-"@comunica/mediator-combine-pipeline@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/mediator-combine-pipeline/-/mediator-combine-pipeline-4.2.0.tgz"
-  integrity sha512-UYFBKR3bmFqJC+A9sx+kEsvGuILNimt/5yTC0yId56sjdwAaEEQz9iFLI1HqJS2T6weu81S/VXiYUpwp9DGJbg==
+"@comunica/mediator-combine-pipeline@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/mediator-combine-pipeline/-/mediator-combine-pipeline-4.5.0.tgz#4e9c8a945946a78d697fad5b003c507d34819b22"
+  integrity sha512-Z4uLxugl+Ls8oAwD0dAIQg+i1rkiXbpiFLhgv5h6nksnz9q6Nv14xItm6baivxAJ9p8XVHCOwPxW46YJBtWIoQ==
   dependencies:
-    "@comunica/core" "^4.2.0"
-    "@comunica/types" "^4.2.0"
+    "@comunica/core" "^4.5.0"
+    "@comunica/types" "^4.5.0"
 
 "@comunica/mediator-combine-union@^2.0.1":
   version "2.10.0"
@@ -4095,23 +4115,23 @@
   dependencies:
     "@comunica/core" "^2.10.0"
 
-"@comunica/mediator-combine-union@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/mediator-combine-union/-/mediator-combine-union-4.2.0.tgz"
-  integrity sha512-hdqtqmGb0aEW8sIcp3WvzziXAxPfGWYDBgH/QQIk2JVWc7auGWvddut2pQCGHyFrv6MXI0vbjj8g1UIaAMviBQ==
+"@comunica/mediator-combine-union@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/mediator-combine-union/-/mediator-combine-union-4.5.0.tgz#fa0578843f8cf1939af68665b83c2b8bd77a0ea8"
+  integrity sha512-aCoO3CiANssR8PEjad2aNuCcfhKdUFZWplTWq77cVUMVc4nsUWNleeEvN6kfOx51qdT8lFpH3b8X+S7bT8CABg==
   dependencies:
-    "@comunica/core" "^4.2.0"
+    "@comunica/core" "^4.5.0"
 
-"@comunica/mediator-join-coefficients-fixed@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/mediator-join-coefficients-fixed/-/mediator-join-coefficients-fixed-4.2.0.tgz"
-  integrity sha512-7XyjxHfONutzwiPfdIjRMooZnkqd1N14gaOynl4Lp8wxVcEU0GNDkk4A/axcIR3APRmSWY6fgw/FKkcbEzFtKw==
+"@comunica/mediator-join-coefficients-fixed@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/mediator-join-coefficients-fixed/-/mediator-join-coefficients-fixed-4.5.0.tgz#ef9151f6da6972d0f80773b82410c8ba9fe711c8"
+  integrity sha512-kSK0i5FPOmeUmg6nJcoqOvRE6aCXFYMzCFPiId/k5cCjvpT4Uaod33xHEQ0TnX52uLdjNENIRjH8z3OsnhSd/w==
   dependencies:
-    "@comunica/bus-rdf-join" "^4.2.0"
-    "@comunica/context-entries" "^4.2.0"
-    "@comunica/core" "^4.2.0"
-    "@comunica/mediatortype-join-coefficients" "^4.2.0"
-    "@comunica/types" "^4.2.0"
+    "@comunica/bus-rdf-join" "^4.5.0"
+    "@comunica/context-entries" "^4.5.0"
+    "@comunica/core" "^4.5.0"
+    "@comunica/mediatortype-join-coefficients" "^4.5.0"
+    "@comunica/types" "^4.5.0"
 
 "@comunica/mediator-number@^2.0.1":
   version "2.10.0"
@@ -4120,12 +4140,12 @@
   dependencies:
     "@comunica/core" "^2.10.0"
 
-"@comunica/mediator-number@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/mediator-number/-/mediator-number-4.2.0.tgz"
-  integrity sha512-TYwcukPQLblV3sfkNMsl3oj3AXSzcGmB+tUYy/++kKohQ67xy2r0wfBo1Ij/6G4ZnzlMIuOWzQcXojFrnV9iWQ==
+"@comunica/mediator-number@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/mediator-number/-/mediator-number-4.5.0.tgz#226c8de8879cf4ff54d44d492f02efb47a82a870"
+  integrity sha512-fChc4gh+gtwPOS0F5eNeDuU4Kyb2fAuppN28d1/5s+OUr5v+1Wya7yZ1zbPHYxDMWZEpJBR06eX6djcI0gKlkQ==
   dependencies:
-    "@comunica/core" "^4.2.0"
+    "@comunica/core" "^4.5.0"
 
 "@comunica/mediator-race@^2.0.1":
   version "2.10.0"
@@ -4134,26 +4154,26 @@
   dependencies:
     "@comunica/core" "^2.10.0"
 
-"@comunica/mediator-race@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/mediator-race/-/mediator-race-4.2.0.tgz"
-  integrity sha512-KHfRVB+Qfaou8tJeXrCrcw1NlTUD+xbi5/7qSwvRqEbbajW2B4cRYbw0VrTJDFUb1tva5IHQQGpMFJ/aHHpH5w==
+"@comunica/mediator-race@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/mediator-race/-/mediator-race-4.5.0.tgz#54cbd91a4341e62243ea0e15bfef98d5b1c3f906"
+  integrity sha512-eAWjQolFMOxKoKuUMmcQzxwf/ZL9ooT0/OUWv1vbVfHIQb/eqDs/h8wDqwXMgEiK5dIF9ZQYaRL2vEaLq+U3Ew==
   dependencies:
-    "@comunica/core" "^4.2.0"
+    "@comunica/core" "^4.5.0"
 
-"@comunica/mediatortype-accuracy@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/mediatortype-accuracy/-/mediatortype-accuracy-4.2.0.tgz"
-  integrity sha512-IAjY98uTTloCaAQuc/CYR1eK4NxX2oLXRexf2JtpiUMO79JM9MXZjFVWpibNZpH5fSqXPb9BQ/T93BnALVwbLg==
+"@comunica/mediatortype-accuracy@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/mediatortype-accuracy/-/mediatortype-accuracy-4.5.0.tgz#b86d3580efc2ab499fe651c1152fd2b0fe611729"
+  integrity sha512-f6OVVGwzf3udDT6x0oP/k76XqBV8ZJFdo5SYGVBR/ebsG81V6LciAHvo8BrihZXgmpo1KTCbIFbRmN++M8b6Rg==
   dependencies:
-    "@comunica/core" "^4.2.0"
+    "@comunica/core" "^4.5.0"
 
-"@comunica/mediatortype-join-coefficients@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/mediatortype-join-coefficients/-/mediatortype-join-coefficients-4.2.0.tgz"
-  integrity sha512-vTMn37N7Stj9LXkbWG9WQTOcCX8Qixa3wKv8a86nLELnjPR2uL59mxdelr1GXURuboSTJuKOMJZGNXyyEAewtQ==
+"@comunica/mediatortype-join-coefficients@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/mediatortype-join-coefficients/-/mediatortype-join-coefficients-4.5.0.tgz#671705d92898408eb1dc309de490b9d26e541e75"
+  integrity sha512-wLhEdEd7TBF1r5xoShOk42Hh4kH4r7YyoPs4W7k41Q5m5tPdv8iyZojqv/MItDKv7XCiTpZLcIQpfV3RcAewhg==
   dependencies:
-    "@comunica/core" "^4.2.0"
+    "@comunica/core" "^4.5.0"
     "@rdfjs/types" "*"
 
 "@comunica/mediatortype-time@^2.10.0":
@@ -4163,231 +4183,232 @@
   dependencies:
     "@comunica/core" "^2.10.0"
 
-"@comunica/mediatortype-time@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/mediatortype-time/-/mediatortype-time-4.2.0.tgz"
-  integrity sha512-t/IVwZPeb4hijIjdQKl/BS14HR7PXDgiv2Djq1f42596mluPjDemUG3suxx8VxBCGhG6Jckupg/WvvLYdW585w==
+"@comunica/mediatortype-time@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/mediatortype-time/-/mediatortype-time-4.5.0.tgz#75cf3458d3453d6c20199988be321ce4cf846aed"
+  integrity sha512-HND+om4L0VW3VcQrLHHE4+7Nsg7soC98i7g7UqqzDkJ4fix2FnJs0i9WH4RP+oLcx+bPhBSl5mG1m44A6sV19g==
   dependencies:
-    "@comunica/core" "^4.2.0"
+    "@comunica/core" "^4.5.0"
 
 "@comunica/query-sparql-rdfjs@^4.0.2":
-  version "4.3.0"
-  resolved "https://registry.npmjs.org/@comunica/query-sparql-rdfjs/-/query-sparql-rdfjs-4.3.0.tgz"
-  integrity sha512-UWMEZ+xj/kVWyXPLqHvKdEk+p0X60ma9o18sNbDMRO283dgJBZX4AlaXJOrF8WjDnHCXCm7OQvQZVr9umXbglw==
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/query-sparql-rdfjs/-/query-sparql-rdfjs-4.5.0.tgz#139dc5a22ba627e5931a77a297a91c5b4cf0ce9d"
+  integrity sha512-v39ceBPEYrhZQVFfbPnc7ShQoOgvvBZOB+pnHLB2aY2EOOq9i45KAuC++s0o1ZkFVIXHldoKoKZbih4ZTrjHgw==
   dependencies:
-    "@comunica/actor-bindings-aggregator-factory-average" "^4.2.0"
-    "@comunica/actor-bindings-aggregator-factory-count" "^4.2.0"
-    "@comunica/actor-bindings-aggregator-factory-group-concat" "^4.2.0"
-    "@comunica/actor-bindings-aggregator-factory-max" "^4.2.0"
-    "@comunica/actor-bindings-aggregator-factory-min" "^4.2.0"
-    "@comunica/actor-bindings-aggregator-factory-sample" "^4.2.0"
-    "@comunica/actor-bindings-aggregator-factory-sum" "^4.2.0"
-    "@comunica/actor-bindings-aggregator-factory-wildcard-count" "^4.2.0"
-    "@comunica/actor-context-preprocess-convert-shortcuts" "^4.2.0"
-    "@comunica/actor-context-preprocess-query-source-identify" "^4.2.0"
-    "@comunica/actor-context-preprocess-query-source-skolemize" "^4.2.0"
-    "@comunica/actor-context-preprocess-set-defaults" "^4.2.0"
-    "@comunica/actor-context-preprocess-source-to-destination" "^4.2.0"
-    "@comunica/actor-expression-evaluator-factory-default" "^4.2.0"
-    "@comunica/actor-function-factory-expression-bnode" "^4.2.0"
-    "@comunica/actor-function-factory-expression-bound" "^4.2.0"
-    "@comunica/actor-function-factory-expression-coalesce" "^4.2.0"
-    "@comunica/actor-function-factory-expression-concat" "^4.2.0"
-    "@comunica/actor-function-factory-expression-extensions" "^4.2.0"
-    "@comunica/actor-function-factory-expression-if" "^4.2.0"
-    "@comunica/actor-function-factory-expression-in" "^4.2.0"
-    "@comunica/actor-function-factory-expression-logical-and" "^4.2.0"
-    "@comunica/actor-function-factory-expression-logical-or" "^4.2.0"
-    "@comunica/actor-function-factory-expression-not-in" "^4.2.0"
-    "@comunica/actor-function-factory-expression-same-term" "^4.2.0"
-    "@comunica/actor-function-factory-term-abs" "^4.2.0"
-    "@comunica/actor-function-factory-term-addition" "^4.2.0"
-    "@comunica/actor-function-factory-term-ceil" "^4.2.0"
-    "@comunica/actor-function-factory-term-contains" "^4.2.0"
-    "@comunica/actor-function-factory-term-datatype" "^4.2.0"
-    "@comunica/actor-function-factory-term-day" "^4.2.0"
-    "@comunica/actor-function-factory-term-division" "^4.2.0"
-    "@comunica/actor-function-factory-term-encode-for-uri" "^4.2.0"
-    "@comunica/actor-function-factory-term-equality" "^4.2.0"
-    "@comunica/actor-function-factory-term-floor" "^4.2.0"
-    "@comunica/actor-function-factory-term-greater-than" "^4.2.0"
-    "@comunica/actor-function-factory-term-greater-than-equal" "^4.2.0"
-    "@comunica/actor-function-factory-term-hours" "^4.2.0"
-    "@comunica/actor-function-factory-term-inequality" "^4.2.0"
-    "@comunica/actor-function-factory-term-iri" "^4.2.0"
-    "@comunica/actor-function-factory-term-is-blank" "^4.2.0"
-    "@comunica/actor-function-factory-term-is-iri" "^4.2.0"
-    "@comunica/actor-function-factory-term-is-literal" "^4.2.0"
-    "@comunica/actor-function-factory-term-is-numeric" "^4.2.0"
-    "@comunica/actor-function-factory-term-is-triple" "^4.2.0"
-    "@comunica/actor-function-factory-term-lang" "^4.2.0"
-    "@comunica/actor-function-factory-term-langmatches" "^4.2.0"
-    "@comunica/actor-function-factory-term-lcase" "^4.2.0"
-    "@comunica/actor-function-factory-term-lesser-than" "^4.2.0"
-    "@comunica/actor-function-factory-term-lesser-than-equal" "^4.2.0"
-    "@comunica/actor-function-factory-term-md5" "^4.2.0"
-    "@comunica/actor-function-factory-term-minutes" "^4.2.0"
-    "@comunica/actor-function-factory-term-month" "^4.2.0"
-    "@comunica/actor-function-factory-term-multiplication" "^4.2.0"
-    "@comunica/actor-function-factory-term-not" "^4.2.0"
-    "@comunica/actor-function-factory-term-now" "^4.2.0"
-    "@comunica/actor-function-factory-term-object" "^4.2.0"
-    "@comunica/actor-function-factory-term-predicate" "^4.2.0"
-    "@comunica/actor-function-factory-term-rand" "^4.2.0"
-    "@comunica/actor-function-factory-term-regex" "^4.2.0"
-    "@comunica/actor-function-factory-term-replace" "^4.2.0"
-    "@comunica/actor-function-factory-term-round" "^4.2.0"
-    "@comunica/actor-function-factory-term-seconds" "^4.2.0"
-    "@comunica/actor-function-factory-term-sha1" "^4.2.0"
-    "@comunica/actor-function-factory-term-sha256" "^4.2.0"
-    "@comunica/actor-function-factory-term-sha384" "^4.2.0"
-    "@comunica/actor-function-factory-term-sha512" "^4.2.0"
-    "@comunica/actor-function-factory-term-str" "^4.2.0"
-    "@comunica/actor-function-factory-term-str-after" "^4.2.0"
-    "@comunica/actor-function-factory-term-str-before" "^4.2.0"
-    "@comunica/actor-function-factory-term-str-dt" "^4.2.0"
-    "@comunica/actor-function-factory-term-str-ends" "^4.2.0"
-    "@comunica/actor-function-factory-term-str-lang" "^4.2.0"
-    "@comunica/actor-function-factory-term-str-len" "^4.2.0"
-    "@comunica/actor-function-factory-term-str-starts" "^4.2.0"
-    "@comunica/actor-function-factory-term-str-uuid" "^4.2.0"
-    "@comunica/actor-function-factory-term-sub-str" "^4.2.0"
-    "@comunica/actor-function-factory-term-subject" "^4.2.0"
-    "@comunica/actor-function-factory-term-subtraction" "^4.2.0"
-    "@comunica/actor-function-factory-term-timezone" "^4.2.0"
-    "@comunica/actor-function-factory-term-triple" "^4.2.0"
-    "@comunica/actor-function-factory-term-tz" "^4.2.0"
-    "@comunica/actor-function-factory-term-ucase" "^4.2.0"
-    "@comunica/actor-function-factory-term-unary-minus" "^4.2.0"
-    "@comunica/actor-function-factory-term-unary-plus" "^4.2.0"
-    "@comunica/actor-function-factory-term-uuid" "^4.2.0"
-    "@comunica/actor-function-factory-term-xsd-to-boolean" "^4.2.0"
-    "@comunica/actor-function-factory-term-xsd-to-date" "^4.2.0"
-    "@comunica/actor-function-factory-term-xsd-to-datetime" "^4.2.0"
-    "@comunica/actor-function-factory-term-xsd-to-day-time-duration" "^4.2.0"
-    "@comunica/actor-function-factory-term-xsd-to-decimal" "^4.2.0"
-    "@comunica/actor-function-factory-term-xsd-to-double" "^4.2.0"
-    "@comunica/actor-function-factory-term-xsd-to-duration" "^4.2.0"
-    "@comunica/actor-function-factory-term-xsd-to-float" "^4.2.0"
-    "@comunica/actor-function-factory-term-xsd-to-integer" "^4.2.0"
-    "@comunica/actor-function-factory-term-xsd-to-string" "^4.2.0"
-    "@comunica/actor-function-factory-term-xsd-to-time" "^4.2.0"
-    "@comunica/actor-function-factory-term-xsd-to-year-month-duration" "^4.2.0"
-    "@comunica/actor-function-factory-term-year" "^4.2.0"
-    "@comunica/actor-hash-bindings-murmur" "^4.2.0"
-    "@comunica/actor-hash-quads-murmur" "^4.2.0"
-    "@comunica/actor-init-query" "^4.3.0"
-    "@comunica/actor-optimize-query-operation-assign-sources-exhaustive" "^4.2.0"
-    "@comunica/actor-optimize-query-operation-bgp-to-join" "^4.2.0"
-    "@comunica/actor-optimize-query-operation-construct-distinct" "^4.2.0"
-    "@comunica/actor-optimize-query-operation-describe-to-constructs-subject" "^4.2.0"
-    "@comunica/actor-optimize-query-operation-filter-pushdown" "^4.2.0"
-    "@comunica/actor-optimize-query-operation-group-sources" "^4.2.0"
-    "@comunica/actor-optimize-query-operation-join-bgp" "^4.2.0"
-    "@comunica/actor-optimize-query-operation-join-connected" "^4.2.0"
-    "@comunica/actor-optimize-query-operation-prune-empty-source-operations" "^4.2.0"
-    "@comunica/actor-optimize-query-operation-rewrite-add" "^4.2.0"
-    "@comunica/actor-optimize-query-operation-rewrite-copy" "^4.2.0"
-    "@comunica/actor-optimize-query-operation-rewrite-move" "^4.2.0"
-    "@comunica/actor-query-operation-ask" "^4.2.0"
-    "@comunica/actor-query-operation-bgp-join" "^4.2.0"
-    "@comunica/actor-query-operation-construct" "^4.2.0"
-    "@comunica/actor-query-operation-distinct-identity" "^4.3.0"
-    "@comunica/actor-query-operation-extend" "^4.2.0"
-    "@comunica/actor-query-operation-filter" "^4.2.0"
-    "@comunica/actor-query-operation-from-quad" "^4.2.0"
-    "@comunica/actor-query-operation-group" "^4.2.0"
-    "@comunica/actor-query-operation-join" "^4.2.0"
-    "@comunica/actor-query-operation-leftjoin" "^4.2.0"
-    "@comunica/actor-query-operation-minus" "^4.2.0"
-    "@comunica/actor-query-operation-nop" "^4.2.0"
-    "@comunica/actor-query-operation-orderby" "^4.2.0"
-    "@comunica/actor-query-operation-path-alt" "^4.3.0"
-    "@comunica/actor-query-operation-path-inv" "^4.3.0"
-    "@comunica/actor-query-operation-path-link" "^4.3.0"
-    "@comunica/actor-query-operation-path-nps" "^4.3.0"
-    "@comunica/actor-query-operation-path-one-or-more" "^4.3.0"
-    "@comunica/actor-query-operation-path-seq" "^4.3.0"
-    "@comunica/actor-query-operation-path-zero-or-more" "^4.3.0"
-    "@comunica/actor-query-operation-path-zero-or-one" "^4.3.0"
-    "@comunica/actor-query-operation-project" "^4.2.0"
-    "@comunica/actor-query-operation-reduced-hash" "^4.2.0"
-    "@comunica/actor-query-operation-service" "^4.2.0"
-    "@comunica/actor-query-operation-slice" "^4.2.0"
-    "@comunica/actor-query-operation-source" "^4.2.0"
-    "@comunica/actor-query-operation-union" "^4.2.0"
-    "@comunica/actor-query-operation-update-clear" "^4.2.0"
-    "@comunica/actor-query-operation-update-compositeupdate" "^4.2.0"
-    "@comunica/actor-query-operation-update-create" "^4.2.0"
-    "@comunica/actor-query-operation-update-deleteinsert" "^4.2.0"
-    "@comunica/actor-query-operation-update-drop" "^4.2.0"
-    "@comunica/actor-query-operation-update-load" "^4.2.0"
-    "@comunica/actor-query-operation-values" "^4.2.0"
-    "@comunica/actor-query-parse-graphql" "^4.2.0"
-    "@comunica/actor-query-parse-sparql" "^4.2.0"
-    "@comunica/actor-query-process-explain-logical" "^4.2.0"
-    "@comunica/actor-query-process-explain-parsed" "^4.2.0"
-    "@comunica/actor-query-process-explain-physical" "^4.2.0"
-    "@comunica/actor-query-process-sequential" "^4.2.0"
-    "@comunica/actor-query-result-serialize-json" "^4.2.0"
-    "@comunica/actor-query-result-serialize-rdf" "^4.2.0"
-    "@comunica/actor-query-result-serialize-simple" "^4.2.0"
-    "@comunica/actor-query-result-serialize-sparql-csv" "^4.2.0"
-    "@comunica/actor-query-result-serialize-sparql-json" "^4.2.0"
-    "@comunica/actor-query-result-serialize-sparql-tsv" "^4.2.0"
-    "@comunica/actor-query-result-serialize-sparql-xml" "^4.2.0"
-    "@comunica/actor-query-result-serialize-stats" "^4.2.0"
-    "@comunica/actor-query-result-serialize-table" "^4.2.0"
-    "@comunica/actor-query-result-serialize-tree" "^4.2.0"
-    "@comunica/actor-query-source-identify-hypermedia" "^4.3.0"
-    "@comunica/actor-query-source-identify-hypermedia-sparql" "^4.2.0"
-    "@comunica/actor-query-source-identify-rdfjs" "^4.3.0"
-    "@comunica/actor-rdf-join-entries-sort-cardinality" "^4.2.0"
-    "@comunica/actor-rdf-join-inner-hash" "^4.2.0"
-    "@comunica/actor-rdf-join-inner-multi-bind" "^4.2.0"
-    "@comunica/actor-rdf-join-inner-multi-bind-source" "^4.2.0"
-    "@comunica/actor-rdf-join-inner-multi-empty" "^4.2.0"
-    "@comunica/actor-rdf-join-inner-multi-smallest" "^4.2.0"
-    "@comunica/actor-rdf-join-inner-multi-smallest-filter-bindings" "^4.2.0"
-    "@comunica/actor-rdf-join-inner-nestedloop" "^4.2.0"
-    "@comunica/actor-rdf-join-inner-none" "^4.2.0"
-    "@comunica/actor-rdf-join-inner-single" "^4.2.0"
-    "@comunica/actor-rdf-join-inner-symmetrichash" "^4.2.0"
-    "@comunica/actor-rdf-join-minus-hash" "^4.2.0"
-    "@comunica/actor-rdf-join-optional-bind" "^4.2.0"
-    "@comunica/actor-rdf-join-optional-hash" "^4.2.0"
-    "@comunica/actor-rdf-join-optional-nestedloop" "^4.2.0"
-    "@comunica/actor-rdf-join-selectivity-variable-counting" "^4.2.0"
-    "@comunica/actor-rdf-metadata-accumulate-cardinality" "^4.2.0"
-    "@comunica/actor-rdf-metadata-accumulate-pagesize" "^4.2.0"
-    "@comunica/actor-rdf-metadata-accumulate-requesttime" "^4.2.0"
-    "@comunica/actor-rdf-serialize-jsonld" "^4.2.0"
-    "@comunica/actor-rdf-serialize-n3" "^4.2.0"
-    "@comunica/actor-rdf-serialize-shaclc" "^4.2.0"
-    "@comunica/actor-rdf-update-quads-rdfjs-store" "^4.2.0"
-    "@comunica/actor-term-comparator-factory-expression-evaluator" "^4.2.0"
-    "@comunica/bus-function-factory" "^4.2.0"
-    "@comunica/bus-http-invalidate" "^4.2.0"
-    "@comunica/bus-query-operation" "^4.2.0"
-    "@comunica/config-query-sparql" "^4.3.0"
-    "@comunica/core" "^4.2.0"
-    "@comunica/logger-void" "^4.2.0"
-    "@comunica/mediator-all" "^4.2.0"
-    "@comunica/mediator-combine-pipeline" "^4.2.0"
-    "@comunica/mediator-combine-union" "^4.2.0"
-    "@comunica/mediator-join-coefficients-fixed" "^4.2.0"
-    "@comunica/mediator-number" "^4.2.0"
-    "@comunica/mediator-race" "^4.2.0"
-    "@comunica/runner" "^4.2.0"
-    "@comunica/types" "^4.2.0"
+    "@comunica/actor-bindings-aggregator-factory-average" "^4.5.0"
+    "@comunica/actor-bindings-aggregator-factory-count" "^4.5.0"
+    "@comunica/actor-bindings-aggregator-factory-group-concat" "^4.5.0"
+    "@comunica/actor-bindings-aggregator-factory-max" "^4.5.0"
+    "@comunica/actor-bindings-aggregator-factory-min" "^4.5.0"
+    "@comunica/actor-bindings-aggregator-factory-sample" "^4.5.0"
+    "@comunica/actor-bindings-aggregator-factory-sum" "^4.5.0"
+    "@comunica/actor-bindings-aggregator-factory-wildcard-count" "^4.5.0"
+    "@comunica/actor-context-preprocess-convert-shortcuts" "^4.5.0"
+    "@comunica/actor-context-preprocess-query-source-identify" "^4.5.0"
+    "@comunica/actor-context-preprocess-query-source-skolemize" "^4.5.0"
+    "@comunica/actor-context-preprocess-set-defaults" "^4.5.0"
+    "@comunica/actor-context-preprocess-source-to-destination" "^4.5.0"
+    "@comunica/actor-expression-evaluator-factory-default" "^4.5.0"
+    "@comunica/actor-function-factory-expression-bnode" "^4.5.0"
+    "@comunica/actor-function-factory-expression-bound" "^4.5.0"
+    "@comunica/actor-function-factory-expression-coalesce" "^4.5.0"
+    "@comunica/actor-function-factory-expression-concat" "^4.5.0"
+    "@comunica/actor-function-factory-expression-extensions" "^4.5.0"
+    "@comunica/actor-function-factory-expression-if" "^4.5.0"
+    "@comunica/actor-function-factory-expression-in" "^4.5.0"
+    "@comunica/actor-function-factory-expression-logical-and" "^4.5.0"
+    "@comunica/actor-function-factory-expression-logical-or" "^4.5.0"
+    "@comunica/actor-function-factory-expression-not-in" "^4.5.0"
+    "@comunica/actor-function-factory-expression-same-term" "^4.5.0"
+    "@comunica/actor-function-factory-term-abs" "^4.5.0"
+    "@comunica/actor-function-factory-term-addition" "^4.5.0"
+    "@comunica/actor-function-factory-term-ceil" "^4.5.0"
+    "@comunica/actor-function-factory-term-contains" "^4.5.0"
+    "@comunica/actor-function-factory-term-datatype" "^4.5.0"
+    "@comunica/actor-function-factory-term-day" "^4.5.0"
+    "@comunica/actor-function-factory-term-division" "^4.5.0"
+    "@comunica/actor-function-factory-term-encode-for-uri" "^4.5.0"
+    "@comunica/actor-function-factory-term-equality" "^4.5.0"
+    "@comunica/actor-function-factory-term-floor" "^4.5.0"
+    "@comunica/actor-function-factory-term-greater-than" "^4.5.0"
+    "@comunica/actor-function-factory-term-greater-than-equal" "^4.5.0"
+    "@comunica/actor-function-factory-term-hours" "^4.5.0"
+    "@comunica/actor-function-factory-term-inequality" "^4.5.0"
+    "@comunica/actor-function-factory-term-iri" "^4.5.0"
+    "@comunica/actor-function-factory-term-is-blank" "^4.5.0"
+    "@comunica/actor-function-factory-term-is-iri" "^4.5.0"
+    "@comunica/actor-function-factory-term-is-literal" "^4.5.0"
+    "@comunica/actor-function-factory-term-is-numeric" "^4.5.0"
+    "@comunica/actor-function-factory-term-is-triple" "^4.5.0"
+    "@comunica/actor-function-factory-term-lang" "^4.5.0"
+    "@comunica/actor-function-factory-term-langmatches" "^4.5.0"
+    "@comunica/actor-function-factory-term-lcase" "^4.5.0"
+    "@comunica/actor-function-factory-term-lesser-than" "^4.5.0"
+    "@comunica/actor-function-factory-term-lesser-than-equal" "^4.5.0"
+    "@comunica/actor-function-factory-term-md5" "^4.5.0"
+    "@comunica/actor-function-factory-term-minutes" "^4.5.0"
+    "@comunica/actor-function-factory-term-month" "^4.5.0"
+    "@comunica/actor-function-factory-term-multiplication" "^4.5.0"
+    "@comunica/actor-function-factory-term-not" "^4.5.0"
+    "@comunica/actor-function-factory-term-now" "^4.5.0"
+    "@comunica/actor-function-factory-term-object" "^4.5.0"
+    "@comunica/actor-function-factory-term-predicate" "^4.5.0"
+    "@comunica/actor-function-factory-term-rand" "^4.5.0"
+    "@comunica/actor-function-factory-term-regex" "^4.5.0"
+    "@comunica/actor-function-factory-term-replace" "^4.5.0"
+    "@comunica/actor-function-factory-term-round" "^4.5.0"
+    "@comunica/actor-function-factory-term-seconds" "^4.5.0"
+    "@comunica/actor-function-factory-term-sha1" "^4.5.0"
+    "@comunica/actor-function-factory-term-sha256" "^4.5.0"
+    "@comunica/actor-function-factory-term-sha384" "^4.5.0"
+    "@comunica/actor-function-factory-term-sha512" "^4.5.0"
+    "@comunica/actor-function-factory-term-str" "^4.5.0"
+    "@comunica/actor-function-factory-term-str-after" "^4.5.0"
+    "@comunica/actor-function-factory-term-str-before" "^4.5.0"
+    "@comunica/actor-function-factory-term-str-dt" "^4.5.0"
+    "@comunica/actor-function-factory-term-str-ends" "^4.5.0"
+    "@comunica/actor-function-factory-term-str-lang" "^4.5.0"
+    "@comunica/actor-function-factory-term-str-len" "^4.5.0"
+    "@comunica/actor-function-factory-term-str-starts" "^4.5.0"
+    "@comunica/actor-function-factory-term-str-uuid" "^4.5.0"
+    "@comunica/actor-function-factory-term-sub-str" "^4.5.0"
+    "@comunica/actor-function-factory-term-subject" "^4.5.0"
+    "@comunica/actor-function-factory-term-subtraction" "^4.5.0"
+    "@comunica/actor-function-factory-term-timezone" "^4.5.0"
+    "@comunica/actor-function-factory-term-triple" "^4.5.0"
+    "@comunica/actor-function-factory-term-tz" "^4.5.0"
+    "@comunica/actor-function-factory-term-ucase" "^4.5.0"
+    "@comunica/actor-function-factory-term-unary-minus" "^4.5.0"
+    "@comunica/actor-function-factory-term-unary-plus" "^4.5.0"
+    "@comunica/actor-function-factory-term-uuid" "^4.5.0"
+    "@comunica/actor-function-factory-term-xsd-to-boolean" "^4.5.0"
+    "@comunica/actor-function-factory-term-xsd-to-date" "^4.5.0"
+    "@comunica/actor-function-factory-term-xsd-to-datetime" "^4.5.0"
+    "@comunica/actor-function-factory-term-xsd-to-day-time-duration" "^4.5.0"
+    "@comunica/actor-function-factory-term-xsd-to-decimal" "^4.5.0"
+    "@comunica/actor-function-factory-term-xsd-to-double" "^4.5.0"
+    "@comunica/actor-function-factory-term-xsd-to-duration" "^4.5.0"
+    "@comunica/actor-function-factory-term-xsd-to-float" "^4.5.0"
+    "@comunica/actor-function-factory-term-xsd-to-integer" "^4.5.0"
+    "@comunica/actor-function-factory-term-xsd-to-string" "^4.5.0"
+    "@comunica/actor-function-factory-term-xsd-to-time" "^4.5.0"
+    "@comunica/actor-function-factory-term-xsd-to-year-month-duration" "^4.5.0"
+    "@comunica/actor-function-factory-term-year" "^4.5.0"
+    "@comunica/actor-hash-bindings-murmur" "^4.5.0"
+    "@comunica/actor-hash-quads-murmur" "^4.5.0"
+    "@comunica/actor-init-query" "^4.5.0"
+    "@comunica/actor-optimize-query-operation-assign-sources-exhaustive" "^4.5.0"
+    "@comunica/actor-optimize-query-operation-bgp-to-join" "^4.5.0"
+    "@comunica/actor-optimize-query-operation-construct-distinct" "^4.5.0"
+    "@comunica/actor-optimize-query-operation-describe-to-constructs-subject" "^4.5.0"
+    "@comunica/actor-optimize-query-operation-filter-pushdown" "^4.5.0"
+    "@comunica/actor-optimize-query-operation-group-sources" "^4.5.0"
+    "@comunica/actor-optimize-query-operation-join-bgp" "^4.5.0"
+    "@comunica/actor-optimize-query-operation-join-connected" "^4.5.0"
+    "@comunica/actor-optimize-query-operation-leftjoin-expression-pushdown" "^4.5.0"
+    "@comunica/actor-optimize-query-operation-prune-empty-source-operations" "^4.5.0"
+    "@comunica/actor-optimize-query-operation-rewrite-add" "^4.5.0"
+    "@comunica/actor-optimize-query-operation-rewrite-copy" "^4.5.0"
+    "@comunica/actor-optimize-query-operation-rewrite-move" "^4.5.0"
+    "@comunica/actor-query-operation-ask" "^4.5.0"
+    "@comunica/actor-query-operation-bgp-join" "^4.5.0"
+    "@comunica/actor-query-operation-construct" "^4.5.0"
+    "@comunica/actor-query-operation-distinct-identity" "^4.5.0"
+    "@comunica/actor-query-operation-extend" "^4.5.0"
+    "@comunica/actor-query-operation-filter" "^4.5.0"
+    "@comunica/actor-query-operation-from-quad" "^4.5.0"
+    "@comunica/actor-query-operation-group" "^4.5.0"
+    "@comunica/actor-query-operation-join" "^4.5.0"
+    "@comunica/actor-query-operation-leftjoin" "^4.5.0"
+    "@comunica/actor-query-operation-minus" "^4.5.0"
+    "@comunica/actor-query-operation-nop" "^4.5.0"
+    "@comunica/actor-query-operation-orderby" "^4.5.0"
+    "@comunica/actor-query-operation-path-alt" "^4.5.0"
+    "@comunica/actor-query-operation-path-inv" "^4.5.0"
+    "@comunica/actor-query-operation-path-link" "^4.5.0"
+    "@comunica/actor-query-operation-path-nps" "^4.5.0"
+    "@comunica/actor-query-operation-path-one-or-more" "^4.5.0"
+    "@comunica/actor-query-operation-path-seq" "^4.5.0"
+    "@comunica/actor-query-operation-path-zero-or-more" "^4.5.0"
+    "@comunica/actor-query-operation-path-zero-or-one" "^4.5.0"
+    "@comunica/actor-query-operation-project" "^4.5.0"
+    "@comunica/actor-query-operation-reduced-hash" "^4.5.0"
+    "@comunica/actor-query-operation-service" "^4.5.0"
+    "@comunica/actor-query-operation-slice" "^4.5.0"
+    "@comunica/actor-query-operation-source" "^4.5.0"
+    "@comunica/actor-query-operation-union" "^4.5.0"
+    "@comunica/actor-query-operation-update-clear" "^4.5.0"
+    "@comunica/actor-query-operation-update-compositeupdate" "^4.5.0"
+    "@comunica/actor-query-operation-update-create" "^4.5.0"
+    "@comunica/actor-query-operation-update-deleteinsert" "^4.5.0"
+    "@comunica/actor-query-operation-update-drop" "^4.5.0"
+    "@comunica/actor-query-operation-update-load" "^4.5.0"
+    "@comunica/actor-query-operation-values" "^4.5.0"
+    "@comunica/actor-query-parse-graphql" "^4.5.0"
+    "@comunica/actor-query-parse-sparql" "^4.5.0"
+    "@comunica/actor-query-process-explain-logical" "^4.5.0"
+    "@comunica/actor-query-process-explain-parsed" "^4.5.0"
+    "@comunica/actor-query-process-explain-physical" "^4.5.0"
+    "@comunica/actor-query-process-sequential" "^4.5.0"
+    "@comunica/actor-query-result-serialize-json" "^4.5.0"
+    "@comunica/actor-query-result-serialize-rdf" "^4.5.0"
+    "@comunica/actor-query-result-serialize-simple" "^4.5.0"
+    "@comunica/actor-query-result-serialize-sparql-csv" "^4.5.0"
+    "@comunica/actor-query-result-serialize-sparql-json" "^4.5.0"
+    "@comunica/actor-query-result-serialize-sparql-tsv" "^4.5.0"
+    "@comunica/actor-query-result-serialize-sparql-xml" "^4.5.0"
+    "@comunica/actor-query-result-serialize-stats" "^4.5.0"
+    "@comunica/actor-query-result-serialize-table" "^4.5.0"
+    "@comunica/actor-query-result-serialize-tree" "^4.5.0"
+    "@comunica/actor-query-source-identify-hypermedia" "^4.5.0"
+    "@comunica/actor-query-source-identify-hypermedia-sparql" "^4.5.0"
+    "@comunica/actor-query-source-identify-rdfjs" "^4.5.0"
+    "@comunica/actor-rdf-join-entries-sort-cardinality" "^4.5.0"
+    "@comunica/actor-rdf-join-inner-hash" "^4.5.0"
+    "@comunica/actor-rdf-join-inner-multi-bind" "^4.5.0"
+    "@comunica/actor-rdf-join-inner-multi-bind-source" "^4.5.0"
+    "@comunica/actor-rdf-join-inner-multi-empty" "^4.5.0"
+    "@comunica/actor-rdf-join-inner-multi-smallest" "^4.5.0"
+    "@comunica/actor-rdf-join-inner-multi-smallest-filter-bindings" "^4.5.0"
+    "@comunica/actor-rdf-join-inner-nestedloop" "^4.5.0"
+    "@comunica/actor-rdf-join-inner-none" "^4.5.0"
+    "@comunica/actor-rdf-join-inner-single" "^4.5.0"
+    "@comunica/actor-rdf-join-inner-symmetrichash" "^4.5.0"
+    "@comunica/actor-rdf-join-minus-hash" "^4.5.0"
+    "@comunica/actor-rdf-join-optional-bind" "^4.5.0"
+    "@comunica/actor-rdf-join-optional-hash" "^4.5.0"
+    "@comunica/actor-rdf-join-optional-nestedloop" "^4.5.0"
+    "@comunica/actor-rdf-join-selectivity-variable-counting" "^4.5.0"
+    "@comunica/actor-rdf-metadata-accumulate-cardinality" "^4.5.0"
+    "@comunica/actor-rdf-metadata-accumulate-pagesize" "^4.5.0"
+    "@comunica/actor-rdf-metadata-accumulate-requesttime" "^4.5.0"
+    "@comunica/actor-rdf-serialize-jsonld" "^4.5.0"
+    "@comunica/actor-rdf-serialize-n3" "^4.5.0"
+    "@comunica/actor-rdf-serialize-shaclc" "^4.5.0"
+    "@comunica/actor-rdf-update-quads-rdfjs-store" "^4.5.0"
+    "@comunica/actor-term-comparator-factory-expression-evaluator" "^4.5.0"
+    "@comunica/bus-function-factory" "^4.5.0"
+    "@comunica/bus-http-invalidate" "^4.5.0"
+    "@comunica/bus-query-operation" "^4.5.0"
+    "@comunica/config-query-sparql" "^4.4.0"
+    "@comunica/core" "^4.5.0"
+    "@comunica/logger-void" "^4.5.0"
+    "@comunica/mediator-all" "^4.5.0"
+    "@comunica/mediator-combine-pipeline" "^4.5.0"
+    "@comunica/mediator-combine-union" "^4.5.0"
+    "@comunica/mediator-join-coefficients-fixed" "^4.5.0"
+    "@comunica/mediator-number" "^4.5.0"
+    "@comunica/mediator-race" "^4.5.0"
+    "@comunica/runner" "^4.5.0"
+    "@comunica/types" "^4.5.0"
 
-"@comunica/runner@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/runner/-/runner-4.2.0.tgz"
-  integrity sha512-13YYeiU3VRES2owxZ5tPv+tIc3rAeg8SdZCNTAUBBI3LhJzMCdZazce+ufo716FDeMW+nfqPNzmnBv6OFDx/KQ==
+"@comunica/runner@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/runner/-/runner-4.5.0.tgz#c513fab2ff14508bd957f592f7f9197299362eef"
+  integrity sha512-Xq5HUsuNQ2cKHBqQjJ3Xx1jpcdD9Oi+ef7t6wPeUCR6VzZKCmRNxEcwQ0Cz629KMicrZCyWnIkXoB322GRWMVA==
   dependencies:
-    "@comunica/bus-init" "^4.2.0"
-    "@comunica/core" "^4.2.0"
+    "@comunica/bus-init" "^4.5.0"
+    "@comunica/core" "^4.5.0"
     componentsjs "^6.2.0"
     process "^0.11.10"
 
@@ -4411,35 +4432,35 @@
     asynciterator "^3.8.1"
     sparqlalgebrajs "^4.2.0"
 
-"@comunica/types@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/types/-/types-4.2.0.tgz"
-  integrity sha512-3Vf3FOUB/i7tdlghovHsgjoZbdqIgB0m01UGwpxCBHI/swbxcqhQzmKFjU9T3gNxurmsdqafF8Unoh9ZCwNuRw==
+"@comunica/types@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/types/-/types-4.5.0.tgz#719e3e5c87b0203f530ab74e5c3729e4bd467e0e"
+  integrity sha512-XhnkspVgYilchErpSAELHRA7B4wRszDdvCkhbd52vjLrThzGUDfDoGx+56y4AeziWkxQLNug8AZbo/Q6J2vCzQ==
   dependencies:
     "@rdfjs/types" "*"
     "@types/yargs" "^17.0.24"
     asynciterator "^3.9.0"
     lru-cache "^10.0.1"
-    sparqlalgebrajs "^4.3.8"
+    sparqlalgebrajs "^5.0.2"
 
-"@comunica/utils-bindings-factory@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/utils-bindings-factory/-/utils-bindings-factory-4.2.0.tgz"
-  integrity sha512-Rw6me8UCdYTvotKt0SJcyQy7tMoruE6gjL8ZSxRZhYORY0+peOgkHHOAmZ41K/TG8TlrthO5cuWB7kK81VeEig==
+"@comunica/utils-bindings-factory@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/utils-bindings-factory/-/utils-bindings-factory-4.5.0.tgz#0e4a01c853916cc395b9f199903899774f5a076a"
+  integrity sha512-LxwHMoBn8JqeVoGEZVaOne9iaShHmaDwJaCBJH3cQi224bv81ylmEBJgrxfNJt+FAzwBfsRdO4aR8dRX5l7Pdg==
   dependencies:
-    "@comunica/bus-merge-bindings-context" "^4.2.0"
-    "@comunica/core" "^4.2.0"
-    "@comunica/types" "^4.2.0"
+    "@comunica/bus-merge-bindings-context" "^4.5.0"
+    "@comunica/core" "^4.5.0"
+    "@comunica/types" "^4.5.0"
     "@rdfjs/types" "*"
-    immutable "^4.1.0"
+    immutable "^5.1.3"
     rdf-string "^1.6.1"
 
-"@comunica/utils-bindings-index@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/utils-bindings-index/-/utils-bindings-index-4.2.0.tgz"
-  integrity sha512-3ljU/1gvXUn8b1A2jFA0vz+Zr0IPYtssjOHhOsZK9ooMaJduAm8SFj5nznvT4rE70zZ5wCdINCKqwiSPxOqU1w==
+"@comunica/utils-bindings-index@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/utils-bindings-index/-/utils-bindings-index-4.5.0.tgz#65b23c5f57f85d061f307e919c436c0099c59b1b"
+  integrity sha512-vV+POCwgVxR3DqtlAt/+q1EzTTghCTYMkx2yV0PJYWdrjsu/JEfoS4S7B1zgb0DjUS7zq0aoeB7FShBUWz/fuw==
   dependencies:
-    "@comunica/types" "^4.2.0"
+    "@comunica/types" "^4.5.0"
     "@rdfjs/types" "*"
 
 "@comunica/utils-data-factory@^4.0.1":
@@ -4449,49 +4470,49 @@
   dependencies:
     "@rdfjs/types" "*"
 
-"@comunica/utils-expression-evaluator@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/utils-expression-evaluator/-/utils-expression-evaluator-4.2.0.tgz"
-  integrity sha512-HAX4Duv8Bva27f/ooIlALwPRFzqZcpb9Im9QoT4L42gCkBfbhOjDpd0skNXJ8nio30GG0aW90UM122u8vAGihQ==
+"@comunica/utils-expression-evaluator@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/utils-expression-evaluator/-/utils-expression-evaluator-4.5.0.tgz#68ed23398ceef2f660330468d4b7c4427f7915c0"
+  integrity sha512-i4kek6vg5yx/EqwoEEop7UyNy0aHp7MIMdId98opXa/hU64Z8icIaFD+3+1tv98M1LviuJAIPX6lCJwuB22jqA==
   dependencies:
-    "@comunica/context-entries" "^4.2.0"
-    "@comunica/types" "^4.2.0"
+    "@comunica/context-entries" "^4.5.0"
+    "@comunica/types" "^4.5.0"
     "@rdfjs/types" "*"
     lru-cache "^10.0.0"
     rdf-data-factory "^1.1.2"
     rdf-string "^1.6.3"
-    sparqlalgebrajs "^4.3.8"
+    sparqlalgebrajs "^5.0.2"
 
-"@comunica/utils-iterator@^4.0.1":
-  version "4.0.1"
-  resolved "https://registry.npmjs.org/@comunica/utils-iterator/-/utils-iterator-4.0.1.tgz"
-  integrity sha512-JfWFr212IFpRIe0kU//AdtrPgcKusnRnHeipqVKv6EVeWl3ZfPZsO/e+aSr/llQoAJBaGKfMH0ATuXzWCSjU/g==
+"@comunica/utils-iterator@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/utils-iterator/-/utils-iterator-4.5.0.tgz#751cd149002ab9c2be89fad283907cc3caab04c0"
+  integrity sha512-Gnn6asz0xILR1f5lQrTjg1BgW5IiSibOETul4iJ+sjYnVncZH1eK5qJNG81f6fX40D3FEHyu+jWQSPNMFqdaoQ==
   dependencies:
     asynciterator "^3.9.0"
 
-"@comunica/utils-metadata@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/utils-metadata/-/utils-metadata-4.2.0.tgz"
-  integrity sha512-xNqnI2XiUgs/xv/3jKo+ueui6akOlrwR/szyMKCu/DXuzSfYor0/czTWJLcLOxYDB4T4hMJCxQgaVyyX4D1ZeA==
+"@comunica/utils-metadata@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/utils-metadata/-/utils-metadata-4.5.0.tgz#db89c7a5c3999babeb957bf7efcee7ec1c3470dd"
+  integrity sha512-NmWWz9F558NQXR5UOyAIdhLmi4tBMtI0N3kHee/DsPCFaxn0wjQ/ckZGrTVTGeP+sdYzobaYvGcIPpf8MmPALQ==
   dependencies:
-    "@comunica/types" "^4.2.0"
+    "@comunica/types" "^4.5.0"
     "@rdfjs/types" "*"
     asynciterator "^3.9.0"
 
-"@comunica/utils-query-operation@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@comunica/utils-query-operation/-/utils-query-operation-4.2.0.tgz"
-  integrity sha512-HZyO6xYJcS9n6NcJAxrxltKph4NfCClUUjHiM3ayb8zrYmfO62dv0SGLp3VgalaMkPF5cRFuIGolt6uzgczHWQ==
+"@comunica/utils-query-operation@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@comunica/utils-query-operation/-/utils-query-operation-4.5.0.tgz#a21547e39b93d236e408514a3ff22504aa6179ba"
+  integrity sha512-R5j61Awzyz+p0FbvACSxh8GuZ4IiBt824UfNZpgDipwzX0JnSaKP5yFKL2dcmb9LlElN8wmDjzy4o512HLK67w==
   dependencies:
-    "@comunica/context-entries" "^4.2.0"
-    "@comunica/core" "^4.2.0"
-    "@comunica/types" "^4.2.0"
-    "@comunica/utils-bindings-factory" "^4.2.0"
+    "@comunica/context-entries" "^4.5.0"
+    "@comunica/core" "^4.5.0"
+    "@comunica/types" "^4.5.0"
+    "@comunica/utils-bindings-factory" "^4.5.0"
     "@rdfjs/types" "*"
     rdf-data-factory "^1.1.2"
     rdf-string "^1.6.1"
     rdf-terms "^1.11.0"
-    sparqlalgebrajs "^4.3.8"
+    sparqlalgebrajs "^5.0.2"
 
 "@confio/ics23@^0.6.8":
   version "0.6.8"
@@ -4960,12 +4981,12 @@
 
 "@esbuild/darwin-arm64@0.21.5":
   version "0.21.5"
-  resolved "https://registry.yarnpkg.com/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz#e495b539660e51690f3928af50a76fb0a6ccff2a"
+  resolved "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz"
   integrity sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==
 
 "@esbuild/darwin-arm64@0.25.12":
   version "0.25.12"
-  resolved "https://registry.yarnpkg.com/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz#79197898ec1ff745d21c071e1c7cc3c802f0c1fd"
+  resolved "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz"
   integrity sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==
 
 "@esbuild/darwin-x64@0.21.5":
@@ -5080,12 +5101,12 @@
 
 "@esbuild/linux-x64@0.21.5":
   version "0.21.5"
-  resolved "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz#6d8f0c768e070e64309af8004bb94e68ab2bb3b0"
   integrity sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==
 
 "@esbuild/linux-x64@0.25.12":
   version "0.25.12"
-  resolved "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz#0583775685ca82066d04c3507f09524d3cd7a306"
   integrity sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==
 
 "@esbuild/netbsd-arm64@0.25.12":
@@ -5164,9 +5185,9 @@
   integrity sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==
 
 "@eslint-community/eslint-utils@^4.2.0":
-  version "4.7.0"
-  resolved "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.7.0.tgz"
-  integrity sha512-dyybb3AcajC7uha6CvhdVRJqaKyn7w2YKqKyAN37NKYgZT36w+iRb0Dymmc5qEJ549c/S31cMMSFd75bteCpCw==
+  version "4.10.1"
+  resolved "https://registry.yarnpkg.com/@eslint-community/eslint-utils/-/eslint-utils-4.10.1.tgz#8911bd72b2c3640a543609e0400b8c4d2e7e7cb6"
+  integrity sha512-cuadcxVFE8sDK6iWJbs8Sn0av2Nrh2QSGQhVlBW9AaAHqHwjWsZHT8LJ4hFGPh7ASBV2deFdM7H/DPjulmh8rg==
   dependencies:
     eslint-visitor-keys "^3.4.3"
 
@@ -5702,48 +5723,36 @@
   resolved "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz"
   integrity sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==
 
-"@inquirer/external-editor@^1.0.0":
-  version "1.0.1"
-  resolved "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-1.0.1.tgz"
-  integrity sha512-Oau4yL24d2B5IL4ma4UpbQigkVhzPDXLoqy1ggK4gnHg/stmkffJE4oOXHXF3uz0UEpywG68KcyXsyYpA1Re/Q==
+"@inquirer/external-editor@^1.0.2":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@inquirer/external-editor/-/external-editor-1.0.3.tgz#c23988291ee676290fdab3fd306e64010a6d13b8"
+  integrity sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA==
   dependencies:
-    chardet "^2.1.0"
-    iconv-lite "^0.6.3"
+    chardet "^2.1.1"
+    iconv-lite "^0.7.0"
 
 "@ipld/dag-cbor@^9.2.0":
-  version "9.2.4"
-  resolved "https://registry.npmjs.org/@ipld/dag-cbor/-/dag-cbor-9.2.4.tgz"
-  integrity sha512-GbDWYl2fdJgkYtIJN0HY9oO0o50d1nB4EQb7uYWKUd2ztxCjxiEW3PjwGG0nqUpN1G4Cug6LX8NzbA7fKT+zfA==
+  version "9.2.7"
+  resolved "https://registry.yarnpkg.com/@ipld/dag-cbor/-/dag-cbor-9.2.7.tgz#239def198be0731e2dbdfa0c988206204198411f"
+  integrity sha512-ZmfXmElRWATr+hoUTSAOr6HUcjVhOcNHDqgczc76qte2DHHFEK0ZhNzUcdTDQhF/VSIvf2ioaRTRLWwLc83sNw==
   dependencies:
-    cborg "^4.0.0"
+    cborg "^5.0.1"
     multiformats "^13.1.0"
 
 "@ipld/dag-json@^10.2.0":
-  version "10.2.5"
-  resolved "https://registry.npmjs.org/@ipld/dag-json/-/dag-json-10.2.5.tgz"
-  integrity sha512-Q4Fr3IBDEN8gkpgNefynJ4U/ZO5Kwr7WSUMBDbZx0c37t0+IwQCTM9yJh8l5L4SRFjm31MuHwniZ/kM+P7GQ3Q==
+  version "10.2.9"
+  resolved "https://registry.yarnpkg.com/@ipld/dag-json/-/dag-json-10.2.9.tgz#d4d98ef204f2e4dc3881bbe667f6e6a909683def"
+  integrity sha512-opNPQQsTuCFZkaJCAqXrB/n9OqUD6W2Boz/Au5HjhLQyczmT8lxoOZObqQ5S5hhnV8p6sgKAimNhUB2W6y0Mzg==
   dependencies:
-    cborg "^4.0.0"
+    cborg "^5.0.0"
     multiformats "^13.1.0"
 
 "@ipld/dag-pb@^4.1.0":
-  version "4.1.5"
-  resolved "https://registry.npmjs.org/@ipld/dag-pb/-/dag-pb-4.1.5.tgz"
-  integrity sha512-w4PZ2yPqvNmlAir7/2hsCRMqny1EY5jj26iZcSgxREJexmbAc2FI21jp26MqiNdfgAxvkCnf2N/TJI18GaDNwA==
+  version "4.1.7"
+  resolved "https://registry.yarnpkg.com/@ipld/dag-pb/-/dag-pb-4.1.7.tgz#8133f099cf0172d41238b23a30355db565d19413"
+  integrity sha512-/i/13trFihjWfDyXlylRwhuYjtzYjvOFw0vlRjYGnZuv7d7MOgA2lV/vRuL5RfeUajM03aZfFLdq4S7cTbbTRg==
   dependencies:
-    multiformats "^13.1.0"
-
-"@isaacs/balanced-match@^4.0.1":
-  version "4.0.1"
-  resolved "https://registry.npmjs.org/@isaacs/balanced-match/-/balanced-match-4.0.1.tgz"
-  integrity sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==
-
-"@isaacs/brace-expansion@^5.0.0":
-  version "5.0.0"
-  resolved "https://registry.npmjs.org/@isaacs/brace-expansion/-/brace-expansion-5.0.0.tgz"
-  integrity sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==
-  dependencies:
-    "@isaacs/balanced-match" "^4.0.1"
+    multiformats "^14.0.0"
 
 "@isaacs/cliui@^8.0.2":
   version "8.0.2"
@@ -5983,10 +5992,18 @@
 
 "@jridgewell/gen-mapping@^0.3.12", "@jridgewell/gen-mapping@^0.3.5":
   version "0.3.13"
-  resolved "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz"
+  resolved "https://registry.yarnpkg.com/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz#6342a19f44347518c93e43b1ac69deb3c4656a1f"
   integrity sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==
   dependencies:
     "@jridgewell/sourcemap-codec" "^1.5.0"
+    "@jridgewell/trace-mapping" "^0.3.24"
+
+"@jridgewell/remapping@^2.3.5":
+  version "2.3.5"
+  resolved "https://registry.yarnpkg.com/@jridgewell/remapping/-/remapping-2.3.5.tgz#375c476d1972947851ba1e15ae8f123047445aa1"
+  integrity sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==
+  dependencies:
+    "@jridgewell/gen-mapping" "^0.3.5"
     "@jridgewell/trace-mapping" "^0.3.24"
 
 "@jridgewell/resolve-uri@^3.1.0":
@@ -5996,7 +6013,7 @@
 
 "@jridgewell/source-map@^0.3.3":
   version "0.3.11"
-  resolved "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz"
+  resolved "https://registry.yarnpkg.com/@jridgewell/source-map/-/source-map-0.3.11.tgz#b21835cbd36db656b857c2ad02ebd413cc13a9ba"
   integrity sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==
   dependencies:
     "@jridgewell/gen-mapping" "^0.3.5"
@@ -6007,17 +6024,9 @@
   resolved "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz"
   integrity sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==
 
-"@jridgewell/trace-mapping@^0.3.12", "@jridgewell/trace-mapping@^0.3.18", "@jridgewell/trace-mapping@^0.3.24", "@jridgewell/trace-mapping@^0.3.25", "@jridgewell/trace-mapping@^0.3.28":
-  version "0.3.30"
-  resolved "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.30.tgz"
-  integrity sha512-GQ7Nw5G2lTu/BtHTKfXhKHok2WGetd4XYcVKGx00SjAk8GMwgJM3zr6zORiPGuOE+/vkc90KtTosSSvaCjKb2Q==
-  dependencies:
-    "@jridgewell/resolve-uri" "^3.1.0"
-    "@jridgewell/sourcemap-codec" "^1.4.14"
-
-"@jridgewell/trace-mapping@^0.3.23":
+"@jridgewell/trace-mapping@^0.3.12", "@jridgewell/trace-mapping@^0.3.18", "@jridgewell/trace-mapping@^0.3.23", "@jridgewell/trace-mapping@^0.3.24", "@jridgewell/trace-mapping@^0.3.25", "@jridgewell/trace-mapping@^0.3.28":
   version "0.3.31"
-  resolved "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz"
+  resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz#db15d6781c931f3a251a3dac39501c98a6082fd0"
   integrity sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==
   dependencies:
     "@jridgewell/resolve-uri" "^3.1.0"
@@ -6176,10 +6185,10 @@
     progress-events "^1.0.0"
     uint8arraylist "^2.4.8"
 
-"@libp2p/interface@^2.10.5":
-  version "2.10.5"
-  resolved "https://registry.npmjs.org/@libp2p/interface/-/interface-2.10.5.tgz"
-  integrity sha512-Z52n04Mph/myGdwyExbFi5S/HqrmZ9JOmfLc2v4r2Cik3GRdw98vrGH19PFvvwjLwAjaqsweCtlGaBzAz09YDw==
+"@libp2p/interface@^2.11.0":
+  version "2.11.0"
+  resolved "https://registry.yarnpkg.com/@libp2p/interface/-/interface-2.11.0.tgz#a1032271d6532e53989781bd25b24f158e900e27"
+  integrity sha512-0MUFKoXWHTQW3oWIgSHApmYMUKWO/Y02+7Hpyp+n3z+geD4Xo2Rku2gYWmxcq+Pyjkz6Q9YjDWz3Yb2SoV2E8Q==
   dependencies:
     "@multiformats/dns" "^1.0.6"
     "@multiformats/multiaddr" "^12.4.4"
@@ -6252,11 +6261,11 @@
     weald "^1.0.2"
 
 "@libp2p/logger@^5.0.1":
-  version "5.1.21"
-  resolved "https://registry.npmjs.org/@libp2p/logger/-/logger-5.1.21.tgz"
-  integrity sha512-V1TWlZM5BuKkiGQ7En4qOnseVP82JwDIpIfNjceUZz1ArL32A5HXJjLQnJchkZ3VW8PVciJzUos/vP6slhPY6Q==
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/@libp2p/logger/-/logger-5.2.0.tgz#a3d85304c8341828bd675c5f016e9b0fc1f93e7e"
+  integrity sha512-OEFS529CnIKfbWEHmuCNESw9q0D0hL8cQ8klQfjIVPur15RcgAEgc1buQ7Y6l0B6tCYg120bp55+e9tGvn8c0g==
   dependencies:
-    "@libp2p/interface" "^2.10.5"
+    "@libp2p/interface" "^2.11.0"
     "@multiformats/multiaddr" "^12.4.4"
     interface-datastore "^8.3.1"
     multiformats "^13.3.6"
@@ -6382,13 +6391,13 @@
     uint8arrays "^5.1.0"
 
 "@libp2p/record@^4.0.4":
-  version "4.0.7"
-  resolved "https://registry.npmjs.org/@libp2p/record/-/record-4.0.7.tgz"
-  integrity sha512-9JFfOytFS730Z79azWi3Ozlb7IufpwbjC/frAv1yZUCLPp7flT9HNsNB+JQwi+V7z68MaNUYeAFE86VQaq2ccA==
+  version "4.0.15"
+  resolved "https://registry.yarnpkg.com/@libp2p/record/-/record-4.0.15.tgz#e7d857405e71017cb65a79d3c58c4644627087ba"
+  integrity sha512-EaHFtQAlZuM9vCpd+0KnZhTVgV26Uzje7DkyUseGNKTy+Wit9Q94C/+wDThpZuRHnK1FH/CvPxJ4kLj7AoQ1WA==
   dependencies:
-    protons-runtime "^5.5.0"
-    uint8arraylist "^2.4.8"
-    uint8arrays "^5.1.0"
+    protons-runtime "^7.0.0"
+    uint8arraylist "^3.0.2"
+    uint8arrays "^6.1.1"
 
 "@libp2p/tcp@^9.0.16":
   version "9.1.6"
@@ -6558,7 +6567,7 @@
 
 "@multiformats/multiaddr-matcher@^1.2.0", "@multiformats/multiaddr-matcher@^1.2.1":
   version "1.8.0"
-  resolved "https://registry.npmjs.org/@multiformats/multiaddr-matcher/-/multiaddr-matcher-1.8.0.tgz"
+  resolved "https://registry.yarnpkg.com/@multiformats/multiaddr-matcher/-/multiaddr-matcher-1.8.0.tgz#40a4813a591f64938335b12ebb100ee4a932e40b"
   integrity sha512-tR/HFhDucXjvwCef5lfXT7kikqR2ffUjliuYlg/RKYGPySVKVlvrDufz86cIuHNc+i/fNR16FWWgD/pMJ6RW4w==
   dependencies:
     "@chainsafe/is-ip" "^2.0.1"
@@ -6574,7 +6583,7 @@
 
 "@multiformats/multiaddr@^12.0.0", "@multiformats/multiaddr@^12.1.14", "@multiformats/multiaddr@^12.1.3", "@multiformats/multiaddr@^12.2.1", "@multiformats/multiaddr@^12.2.3", "@multiformats/multiaddr@^12.3.0", "@multiformats/multiaddr@^12.4.4":
   version "12.5.1"
-  resolved "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-12.5.1.tgz"
+  resolved "https://registry.yarnpkg.com/@multiformats/multiaddr/-/multiaddr-12.5.1.tgz#45d64456eddbf8cbe179366d7cb7b72efabe049f"
   integrity sha512-+DDlr9LIRUS8KncI1TX/FfUn8F2dl6BIxJgshS/yFQCNB5IAF0OGzcwB39g5NLE22s4qqDePv0Qof6HdpJ/4aQ==
   dependencies:
     "@chainsafe/is-ip" "^2.0.1"
@@ -6587,11 +6596,16 @@
 
 "@multiformats/uri-to-multiaddr@^8.0.0":
   version "8.1.0"
-  resolved "https://registry.npmjs.org/@multiformats/uri-to-multiaddr/-/uri-to-multiaddr-8.1.0.tgz"
+  resolved "https://registry.yarnpkg.com/@multiformats/uri-to-multiaddr/-/uri-to-multiaddr-8.1.0.tgz#386cec1df873ff050e1cf700c91e45e48c5a5863"
   integrity sha512-NHFqdKEwJ0A6JDXzC645Lgyw72zWhbM1QfaaD00ZYRrNvtx64p1bD9aIrWZIhLWZN87/lsV4QkJSNRF3Fd3ryw==
   dependencies:
     "@multiformats/multiaddr" "^12.1.14"
     is-ip "^5.0.0"
+
+"@napi-rs/lzma-linux-x64-gnu@1.5.1":
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/@napi-rs/lzma-linux-x64-gnu/-/lzma-linux-x64-gnu-1.5.1.tgz#e57d4306966078662038094fb38eb9146dc3aea9"
+  integrity sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ==
 
 "@nicolo-ribaudo/chokidar-2@2.1.8-no-fsevents.3":
   version "2.1.8-no-fsevents.3"
@@ -6600,7 +6614,7 @@
 
 "@nicolo-ribaudo/eslint-scope-5-internals@5.1.1-v1":
   version "5.1.1-v1"
-  resolved "https://registry.yarnpkg.com/@nicolo-ribaudo/eslint-scope-5-internals/-/eslint-scope-5-internals-5.1.1-v1.tgz#dbf733a965ca47b1973177dc0bb6c889edcfb129"
+  resolved "https://registry.npmjs.org/@nicolo-ribaudo/eslint-scope-5-internals/-/eslint-scope-5-internals-5.1.1-v1.tgz"
   integrity sha512-54/JRvkLIzzDWshCWfuhadfrfZVPiElY8Fcgmg1HroEly/EDSszzhBAsarCux+D/kOslTRquNzuyGSmUSTTHGg==
   dependencies:
     eslint-scope "5.1.1"
@@ -6648,13 +6662,13 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@peculiar/asn1-schema@^2.3.13", "@peculiar/asn1-schema@^2.3.8":
-  version "2.4.0"
-  resolved "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.4.0.tgz"
-  integrity sha512-umbembjIWOrPSOzEGG5vxFLkeM8kzIhLkgigtsOrfLKnuzxWxejAcUX+q/SoZCdemlODOcr5WiYa7+dIEzBXZQ==
+"@peculiar/asn1-schema@^2.3.8", "@peculiar/asn1-schema@^2.7.0":
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/@peculiar/asn1-schema/-/asn1-schema-2.8.0.tgz#69699f84259b2161607cabfc34e512a4023dbef9"
+  integrity sha512-7YT0U/ze0tF2QOBbE15gKZwy5tvgGyLRiRHLzhlbOpf7BT032oBSd0haZqXn5W6l26WLlu3dyxzjM+2638/z2Q==
   dependencies:
-    asn1js "^3.0.6"
-    pvtsutils "^1.3.6"
+    "@peculiar/utils" "^2.0.2"
+    asn1js "^3.0.10"
     tslib "^2.8.1"
 
 "@peculiar/json-schema@^1.1.12":
@@ -6663,6 +6677,13 @@
   integrity sha512-coUfuoMeIB7B8/NMekxaDzLhaYmp0HZNPEjYRm9goRou8UZIC3z21s0sL9AWoCw4EG876QyO3kYrc61WNF9B/w==
   dependencies:
     tslib "^2.0.0"
+
+"@peculiar/utils@^2.0.2":
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/@peculiar/utils/-/utils-2.0.3.tgz#a27ca4c4b73652e110f19a7d16d664f458a5528e"
+  integrity sha512-+oL3HPFRIZ1St2K50lWCXiioIgSoxzz7R1J3uF6neO2yl1sgmpgY6XXJH4BdpoDkMWznQTeYF6oWNDZLCdQ4eQ==
+  dependencies:
+    tslib "^2.8.1"
 
 "@peculiar/webcrypto@^1.1.6", "@peculiar/webcrypto@^1.5.0":
   version "1.5.0"
@@ -6735,14 +6756,14 @@
 
 "@rdfjs/types@*", "@rdfjs/types@>=1.0.0", "@rdfjs/types@^2.0.0":
   version "2.0.1"
-  resolved "https://registry.npmjs.org/@rdfjs/types/-/types-2.0.1.tgz"
+  resolved "https://registry.yarnpkg.com/@rdfjs/types/-/types-2.0.1.tgz#f10b50ceffff00b961c4265e60ac9f74550251da"
   integrity sha512-uyAzpugX7KekAXAHq26m3JlUIZJOC0uSBhpnefGV5i15bevDyyejoB7I+9MKeUrzXD8OOUI3+4FeV1wwQr5ihA==
   dependencies:
     "@types/node" "*"
 
 "@rdfjs/types@^1.0.0":
   version "1.1.2"
-  resolved "https://registry.npmjs.org/@rdfjs/types/-/types-1.1.2.tgz"
+  resolved "https://registry.yarnpkg.com/@rdfjs/types/-/types-1.1.2.tgz#9c2f9848c44c26d383bed2a808571de3b93b808d"
   integrity sha512-wqpOJK1QCbmsGNtyzYnojPU8gRDPid2JO0Q0kMtb4j65xhCK880cnKAfEOwC+dX85VJcCByQx5zOwyyfCjDJsg==
   dependencies:
     "@types/node" "*"
@@ -6776,7 +6797,7 @@
 
 "@rollup/plugin-commonjs@^28.0.1":
   version "28.0.9"
-  resolved "https://registry.yarnpkg.com/@rollup/plugin-commonjs/-/plugin-commonjs-28.0.9.tgz#b875cd1590617a40c4916d561d75761c6ca3c6d1"
+  resolved "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-28.0.9.tgz"
   integrity sha512-PIR4/OHZ79romx0BVVll/PkwWpJ7e5lsqFa3gFfcrFPWwLXLV39JVUzQV9RKjWerE7B845Hqjj9VYlQeieZ2dA==
   dependencies:
     "@rollup/pluginutils" "^5.0.1"
@@ -6796,7 +6817,7 @@
 
 "@rollup/plugin-json@^6.1.0":
   version "6.1.0"
-  resolved "https://registry.yarnpkg.com/@rollup/plugin-json/-/plugin-json-6.1.0.tgz#fbe784e29682e9bb6dee28ea75a1a83702e7b805"
+  resolved "https://registry.npmjs.org/@rollup/plugin-json/-/plugin-json-6.1.0.tgz"
   integrity sha512-EGI2te5ENk1coGeADSIwZ7G2Q8CJS2sF120T7jLw4xFw9n7wIOXHo+kIYRAoVpJAN+kmqZSoO3Fp4JtoNF4ReA==
   dependencies:
     "@rollup/pluginutils" "^5.1.0"
@@ -6826,258 +6847,249 @@
     estree-walker "^1.0.1"
     picomatch "^2.2.2"
 
-"@rollup/pluginutils@^5.0.1":
-  version "5.2.0"
-  resolved "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.2.0.tgz"
-  integrity sha512-qWJ2ZTbmumwiLFomfzTyt5Kng4hwPi9rwCYN4SHb6eaRU1KNO4ccxINHr/VhH4GgPlt1XfSTLX2LBTme8ne4Zw==
+"@rollup/pluginutils@^5.0.1", "@rollup/pluginutils@^5.1.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@rollup/pluginutils/-/pluginutils-5.4.0.tgz#ac23a29ced0247060a210815fca39c17de4d2f26"
+  integrity sha512-MfPp06CjRLfXQ3wY0R8vJDYBy/MvVcc9OulEfR0B8Iv9ko+GCNaRZ+EpJYFl27LhKsZK0o420sYCRHCjfCgeUg==
   dependencies:
     "@types/estree" "^1.0.0"
     estree-walker "^2.0.2"
     picomatch "^4.0.2"
 
-"@rollup/pluginutils@^5.1.0":
-  version "5.3.0"
-  resolved "https://registry.yarnpkg.com/@rollup/pluginutils/-/pluginutils-5.3.0.tgz#57ba1b0cbda8e7a3c597a4853c807b156e21a7b4"
-  integrity sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==
-  dependencies:
-    "@types/estree" "^1.0.0"
-    estree-walker "^2.0.2"
-    picomatch "^4.0.2"
+"@rollup/rollup-android-arm-eabi@4.53.5":
+  version "4.53.5"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.53.5.tgz#3d12635170ef3d32aa9222b4fb92b5d5400f08e9"
+  integrity sha512-iDGS/h7D8t7tvZ1t6+WPK04KD0MwzLZrG0se1hzBjSi5fyxlsiggoJHwh18PCFNn7tG43OWb6pdZ6Y+rMlmyNQ==
 
-"@rollup/rollup-android-arm-eabi@4.53.2":
-  version "4.53.2"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.53.2.tgz#7131f3d364805067fd5596302aad9ebef1434b32"
-  integrity sha512-yDPzwsgiFO26RJA4nZo8I+xqzh7sJTZIWQOxn+/XOdPE31lAvLIYCKqjV+lNH/vxE2L2iH3plKxDCRK6i+CwhA==
+"@rollup/rollup-android-arm-eabi@4.62.4":
+  version "4.62.4"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.4.tgz#2b86c8fff13a065845ddb65f64d814499ace020f"
+  integrity sha512-RrPokAb7dmbxFoeO3TloqHyOjgye8RkBhSqmp4aJMIex4c9r46ZstPnleDQOq1t46VOVjwIuwNogIqbodV1Vvg==
 
-"@rollup/rollup-android-arm-eabi@4.60.1":
-  version "4.60.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.1.tgz#043f145716234529052ef9e1ce1d847ffbe9e674"
-  integrity sha512-d6FinEBLdIiK+1uACUttJKfgZREXrF0Qc2SmLII7W2AD8FfiZ9Wjd+rD/iRuf5s5dWrr1GgwXCvPqOuDquOowA==
+"@rollup/rollup-android-arm64@4.53.5":
+  version "4.53.5"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.53.5.tgz#cd2a448be8fb337f6e5ca12a3053a407ac80766d"
+  integrity sha512-wrSAViWvZHBMMlWk6EJhvg8/rjxzyEhEdgfMMjREHEq11EtJ6IP6yfcCH57YAEca2Oe3FNCE9DSTgU70EIGmVw==
 
-"@rollup/rollup-android-arm64@4.53.2":
-  version "4.53.2"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.53.2.tgz#7ede14d7fcf7c57821a2731c04b29ccc03145d82"
-  integrity sha512-k8FontTxIE7b0/OGKeSN5B6j25EuppBcWM33Z19JoVT7UTXFSo3D9CdU39wGTeb29NO3XxpMNauh09B+Ibw+9g==
+"@rollup/rollup-android-arm64@4.62.4":
+  version "4.62.4"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.4.tgz#af217357ecc06ae5e4f54ef34ee72b1e37f8dbc3"
+  integrity sha512-JKuJc+pnpks2pjy7L/N3v/cAkZxYlnmuZoD840ldbMI5KDbC4iO9NKwPKYdjYFCMAIIlBzYSFHxIJVYzRo2/8A==
 
-"@rollup/rollup-android-arm64@4.60.1":
-  version "4.60.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.1.tgz#023e1bd146e7519087dfd9e8b29e4cf9f8ecd35c"
-  integrity sha512-YjG/EwIDvvYI1YvYbHvDz/BYHtkY4ygUIXHnTdLhG+hKIQFBiosfWiACWortsKPKU/+dUwQQCKQM3qrDe8c9BA==
+"@rollup/rollup-darwin-arm64@4.53.5":
+  version "4.53.5"
+  resolved "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.53.5.tgz"
+  integrity sha512-S87zZPBmRO6u1YXQLwpveZm4JfPpAa6oHBX7/ghSiGH3rz/KDgAu1rKdGutV+WUI6tKDMbaBJomhnT30Y2t4VQ==
 
-"@rollup/rollup-darwin-arm64@4.53.2":
-  version "4.53.2"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.53.2.tgz#d59bf9ed582b38838e86a17f91720c17db6575b9"
-  integrity sha512-A6s4gJpomNBtJ2yioj8bflM2oogDwzUiMl2yNJ2v9E7++sHrSrsQ29fOfn5DM/iCzpWcebNYEdXpaK4tr2RhfQ==
+"@rollup/rollup-darwin-arm64@4.62.4":
+  version "4.62.4"
+  resolved "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.4.tgz"
+  integrity sha512-krw5uS2STmvJ02x0uTXHbqQNuz+9eZ1iw+qXk9dmW2gvV4jV7O2hEoOnuhFrpOPiel1mBFtqbxYZZtC46hXLOw==
 
-"@rollup/rollup-darwin-arm64@4.60.1":
-  version "4.60.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.1.tgz#55ccb5487c02419954c57a7a80602885d616e1ee"
-  integrity sha512-mjCpF7GmkRtSJwon+Rq1N8+pI+8l7w5g9Z3vWj4T7abguC4Czwi3Yu/pFaLvA3TTeMVjnu3ctigusqWUfjZzvw==
+"@rollup/rollup-darwin-x64@4.53.5":
+  version "4.53.5"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.53.5.tgz#76956ce183eb461a58735770b7bf3030a549ceea"
+  integrity sha512-YTbnsAaHo6VrAczISxgpTva8EkfQus0VPEVJCEaboHtZRIb6h6j0BNxRBOwnDciFTZLDPW5r+ZBmhL/+YpTZgA==
 
-"@rollup/rollup-darwin-x64@4.53.2":
-  version "4.53.2"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.53.2.tgz#a76278d9b9da9f84ea7909a14d93b915d5bbe01e"
-  integrity sha512-e6XqVmXlHrBlG56obu9gDRPW3O3hLxpwHpLsBJvuI8qqnsrtSZ9ERoWUXtPOkY8c78WghyPHZdmPhHLWNdAGEw==
+"@rollup/rollup-darwin-x64@4.62.4":
+  version "4.62.4"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.4.tgz#eff983a29db7d8ea7f733f1ce430fc64e159a5e6"
+  integrity sha512-wsTxtgApb4PrOsNJIm0FZ1h3WvCC+k9uxLJ4ad75hgoS4NiRes2SoJFlDAyMwiUY8IssDqGcHbXuN0sx1tfF1A==
 
-"@rollup/rollup-darwin-x64@4.60.1":
-  version "4.60.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.1.tgz#254b65404b14488c83225e88b8819376ad71a784"
-  integrity sha512-haZ7hJ1JT4e9hqkoT9R/19XW2QKqjfJVv+i5AGg57S+nLk9lQnJ1F/eZloRO3o9Scy9CM3wQ9l+dkXtcBgN5Ew==
+"@rollup/rollup-freebsd-arm64@4.53.5":
+  version "4.53.5"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.53.5.tgz#287448b57d619007b14d34ed35bf1bc4f41c023b"
+  integrity sha512-1T8eY2J8rKJWzaznV7zedfdhD1BqVs1iqILhmHDq/bqCUZsrMt+j8VCTHhP0vdfbHK3e1IQ7VYx3jlKqwlf+vw==
 
-"@rollup/rollup-freebsd-arm64@4.53.2":
-  version "4.53.2"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.53.2.tgz#1a94821a1f565b9eaa74187632d482e4c59a1707"
-  integrity sha512-v0E9lJW8VsrwPux5Qe5CwmH/CF/2mQs6xU1MF3nmUxmZUCHazCjLgYvToOk+YuuUqLQBio1qkkREhxhc656ViA==
+"@rollup/rollup-freebsd-arm64@4.62.4":
+  version "4.62.4"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.4.tgz#abe1399a70e819034f492d05dbcc97964310bb57"
+  integrity sha512-GUOnQlyZe3yAXhWOtOMsn5Qkrv5E5mZXa0thbARWi5Ei2szlVXJFQhddZ4HbAzh8q92w5twp+CQvs/eFanz9YQ==
 
-"@rollup/rollup-freebsd-arm64@4.60.1":
-  version "4.60.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.1.tgz#6377ff38c052c76fcaffb7b2728d3172fe676fe6"
-  integrity sha512-czw90wpQq3ZsAVBlinZjAYTKduOjTywlG7fEeWKUA7oCmpA8xdTkxZZlwNJKWqILlq0wehoZcJYfBvOyhPTQ6w==
+"@rollup/rollup-freebsd-x64@4.53.5":
+  version "4.53.5"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.53.5.tgz#e6dca813e189aa189dab821ea8807f48873b80f2"
+  integrity sha512-sHTiuXyBJApxRn+VFMaw1U+Qsz4kcNlxQ742snICYPrY+DDL8/ZbaC4DVIB7vgZmp3jiDaKA0WpBdP0aqPJoBQ==
 
-"@rollup/rollup-freebsd-x64@4.53.2":
-  version "4.53.2"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.53.2.tgz#aad2274680106b2b6549b1e35e5d3a7a9f1f16af"
-  integrity sha512-ClAmAPx3ZCHtp6ysl4XEhWU69GUB1D+s7G9YjHGhIGCSrsg00nEGRRZHmINYxkdoJehde8VIsDC5t9C0gb6yqA==
+"@rollup/rollup-freebsd-x64@4.62.4":
+  version "4.62.4"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.4.tgz#b2e0f8c24a362ac7112be3d5549c6940597e0168"
+  integrity sha512-/Y7f3QuxjzPKsjA/rfEDa3+0vXqyjmJ50Ln8dPpCmWkKTrUoWHG1cWhTqaAMLob2m2nESWuC7yGrREz019Ztqg==
 
-"@rollup/rollup-freebsd-x64@4.60.1":
-  version "4.60.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.1.tgz#ba3902309d088eaf7139b916f09b7140b28b406d"
-  integrity sha512-KVB2rqsxTHuBtfOeySEyzEOB7ltlB/ux38iu2rBQzkjbwRVlkhAGIEDiiYnO2kFOkJp+Z7pUXKyrRRFuFUKt+g==
+"@rollup/rollup-linux-arm-gnueabihf@4.53.5":
+  version "4.53.5"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.53.5.tgz#74045a96fa6c5b1b1269440a68d1496d34b1730a"
+  integrity sha512-dV3T9MyAf0w8zPVLVBptVlzaXxka6xg1f16VAQmjg+4KMSTWDvhimI/Y6mp8oHwNrmnmVl9XxJ/w/mO4uIQONA==
 
-"@rollup/rollup-linux-arm-gnueabihf@4.53.2":
-  version "4.53.2"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.53.2.tgz#100fe4306399ffeec47318a3c9b8c0e5e8b07ddb"
-  integrity sha512-EPlb95nUsz6Dd9Qy13fI5kUPXNSljaG9FiJ4YUGU1O/Q77i5DYFW5KR8g1OzTcdZUqQQ1KdDqsTohdFVwCwjqg==
+"@rollup/rollup-linux-arm-gnueabihf@4.62.4":
+  version "4.62.4"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.4.tgz#a5f2a7e7eb719254a6800db18e9f369d3c623439"
+  integrity sha512-81wiiX3v7aqy+T+bT61TJ78yJjRquqFFTTbAPt08imfQQzkPIW8t6aJbkTagtCCrXMNc9D66+geqlK7ydLPNqA==
 
-"@rollup/rollup-linux-arm-gnueabihf@4.60.1":
-  version "4.60.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.1.tgz#e011b9a14638267e53b446286e838dbdaf53f167"
-  integrity sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g==
+"@rollup/rollup-linux-arm-musleabihf@4.53.5":
+  version "4.53.5"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.53.5.tgz#7d175bddc9acffc40431ee3fb9417136ccc499e1"
+  integrity sha512-wIGYC1x/hyjP+KAu9+ewDI+fi5XSNiUi9Bvg6KGAh2TsNMA3tSEs+Sh6jJ/r4BV/bx/CyWu2ue9kDnIdRyafcQ==
 
-"@rollup/rollup-linux-arm-musleabihf@4.53.2":
-  version "4.53.2"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.53.2.tgz#b84634952604b950e18fa11fddebde898c5928d8"
-  integrity sha512-BOmnVW+khAUX+YZvNfa0tGTEMVVEerOxN0pDk2E6N6DsEIa2Ctj48FOMfNDdrwinocKaC7YXUZ1pHlKpnkja/Q==
+"@rollup/rollup-linux-arm-musleabihf@4.62.4":
+  version "4.62.4"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.4.tgz#390c86c797695af87c38d6f005222d920b5bfa22"
+  integrity sha512-9kmDIvNZqdoHOBZgNtpTBeLWYO/LVipM3H/j62P8848/l/VPEQL6N3uxU9pvP1oZAsXyC2MEnFP3ovRjo7WYNQ==
 
-"@rollup/rollup-linux-arm-musleabihf@4.60.1":
-  version "4.60.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.1.tgz#0bce9ce9a009490abd28fd922dd97ed521311afe"
-  integrity sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==
+"@rollup/rollup-linux-arm64-gnu@4.53.5":
+  version "4.53.5"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.53.5.tgz#228b0aec95b24f4080175b51396cd14cb275e38f"
+  integrity sha512-Y+qVA0D9d0y2FRNiG9oM3Hut/DgODZbU9I8pLLPwAsU0tUKZ49cyV1tzmB/qRbSzGvY8lpgGkJuMyuhH7Ma+Vg==
 
-"@rollup/rollup-linux-arm64-gnu@4.53.2":
-  version "4.53.2"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.53.2.tgz#dad6f2fb41c2485f29a98e40e9bd78253255dbf3"
-  integrity sha512-Xt2byDZ+6OVNuREgBXr4+CZDJtrVso5woFtpKdGPhpTPHcNG7D8YXeQzpNbFRxzTVqJf7kvPMCub/pcGUWgBjA==
+"@rollup/rollup-linux-arm64-gnu@4.62.4":
+  version "4.62.4"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.4.tgz#1fea78609a15813cda98d93fe8d987c87017f572"
+  integrity sha512-CcnXHWnXg69g+DX5VWL3FHts3qMRN2uVEHX+BZvGLdd07/gXkn3ePjYtO1LDJvxkGKVHMclKBRa1QUTH+6toYQ==
 
-"@rollup/rollup-linux-arm64-gnu@4.60.1":
-  version "4.60.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.1.tgz#6f6cfbbf324fbb4ceff213abdf7f322fd45d25ff"
-  integrity sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ==
+"@rollup/rollup-linux-arm64-musl@4.53.5":
+  version "4.53.5"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.53.5.tgz#079050e023fad9bbb95d1d36fcfad23eeb0e1caa"
+  integrity sha512-juaC4bEgJsyFVfqhtGLz8mbopaWD+WeSOYr5E16y+1of6KQjc0BpwZLuxkClqY1i8sco+MdyoXPNiCkQou09+g==
 
-"@rollup/rollup-linux-arm64-musl@4.53.2":
-  version "4.53.2"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.53.2.tgz#0f3f77c8ce9fbf982f8a8378b70a73dc6704a706"
-  integrity sha512-+LdZSldy/I9N8+klim/Y1HsKbJ3BbInHav5qE9Iy77dtHC/pibw1SR/fXlWyAk0ThnpRKoODwnAuSjqxFRDHUQ==
+"@rollup/rollup-linux-arm64-musl@4.62.4":
+  version "4.62.4"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.4.tgz#3b50031c9916517576098f6e11b38a13147dc463"
+  integrity sha512-iFOibiHnTRuhrWLlRsOQFdZJJIa7S8OwkneJr4ocALP16u5yk6lWLINFwhHaEqBFMsKDUZofLkGos7+CPzGB3g==
 
-"@rollup/rollup-linux-arm64-musl@4.60.1":
-  version "4.60.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.1.tgz#f7cb3eecaea9c151ef77342af05f38ae924bf795"
-  integrity sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==
+"@rollup/rollup-linux-loong64-gnu@4.53.5":
+  version "4.53.5"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.53.5.tgz#3849451858c4d5c8838b5e16ec339b8e49aaf68a"
+  integrity sha512-rIEC0hZ17A42iXtHX+EPJVL/CakHo+tT7W0pbzdAGuWOt2jxDFh7A/lRhsNHBcqL4T36+UiAgwO8pbmn3dE8wA==
 
-"@rollup/rollup-linux-loong64-gnu@4.53.2":
-  version "4.53.2"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.53.2.tgz#870bb94e9dad28bb3124ba49bd733deaa6aa2635"
-  integrity sha512-8ms8sjmyc1jWJS6WdNSA23rEfdjWB30LH8Wqj0Cqvv7qSHnvw6kgMMXRdop6hkmGPlyYBdRPkjJnj3KCUHV/uQ==
+"@rollup/rollup-linux-loong64-gnu@4.62.4":
+  version "4.62.4"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.4.tgz#b403255546099a4300b17d976ee1776224c090e5"
+  integrity sha512-XnWYMI7euHlb5a871xPja+Gm7DRCFU+FGRrtS2sMq9N8FvqtpagUy6gD4YOemC5MRk9xbh8+jYMEJbigFQwsgA==
 
-"@rollup/rollup-linux-loong64-gnu@4.60.1":
-  version "4.60.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.1.tgz#499bfac6bb669fd88bb664357bf6be996a28b92f"
-  integrity sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ==
+"@rollup/rollup-linux-loong64-musl@4.62.4":
+  version "4.62.4"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.4.tgz#5900610e59c66ee594539c6590566dbfda7082b1"
+  integrity sha512-qGDAlO0U8xedCcsdRm9oaoQY8DAx/QT7uIxJWhCdx0ceIWX783UC9QSYkdpzAe29wNiVfp24+bZdQmn49o45SQ==
 
-"@rollup/rollup-linux-loong64-musl@4.60.1":
-  version "4.60.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.1.tgz#127dfac08764764396bbe04453c545d38a3ab518"
-  integrity sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==
+"@rollup/rollup-linux-ppc64-gnu@4.53.5":
+  version "4.53.5"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.53.5.tgz#10bdab69c660f6f7b48e23f17c42637aa1f9b29a"
+  integrity sha512-T7l409NhUE552RcAOcmJHj3xyZ2h7vMWzcwQI0hvn5tqHh3oSoclf9WgTl+0QqffWFG8MEVZZP1/OBglKZx52Q==
 
-"@rollup/rollup-linux-ppc64-gnu@4.53.2":
-  version "4.53.2"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.53.2.tgz#188427d11abefc6c9926e3870b3e032170f5577c"
-  integrity sha512-3HRQLUQbpBDMmzoxPJYd3W6vrVHOo2cVW8RUo87Xz0JPJcBLBr5kZ1pGcQAhdZgX9VV7NbGNipah1omKKe23/g==
+"@rollup/rollup-linux-ppc64-gnu@4.62.4":
+  version "4.62.4"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.4.tgz#a892cc8b8414bc8ae0b267816b5e384e5d321ff2"
+  integrity sha512-ru4H6ezD7ysA5EiEK6qkkaEb4modH8CTej6kUy/gQi20u3kB3G7Zn8snXXkeJSCOFKG/rbPPtM/+9Wgas1961w==
 
-"@rollup/rollup-linux-ppc64-gnu@4.60.1":
-  version "4.60.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.1.tgz#6a72f4d95852aac18326c5bf708393e8f3a41b70"
-  integrity sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw==
+"@rollup/rollup-linux-ppc64-musl@4.62.4":
+  version "4.62.4"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.4.tgz#d9e60d568b7db4df2196fb2411b0c6918b2360cc"
+  integrity sha512-2W4MO5WQVJnbJaZdvDb9rhBDuFU1nKIepPFpJUBsTh2k1YY2g+ODViaWuyOAjQ5cOP7NvrvLzt3wvHOoiAvc7w==
 
-"@rollup/rollup-linux-ppc64-musl@4.60.1":
-  version "4.60.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.1.tgz#ba8674666b00d6f9066cb9a5771a8430c34d2de6"
-  integrity sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==
+"@rollup/rollup-linux-riscv64-gnu@4.53.5":
+  version "4.53.5"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.53.5.tgz#c0e776c6193369ee16f8e9ebf6a6ec09828d603d"
+  integrity sha512-7OK5/GhxbnrMcxIFoYfhV/TkknarkYC1hqUw1wU2xUN3TVRLNT5FmBv4KkheSG2xZ6IEbRAhTooTV2+R5Tk0lQ==
 
-"@rollup/rollup-linux-riscv64-gnu@4.53.2":
-  version "4.53.2"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.53.2.tgz#9dec6eadbbb5abd3b76fe624dc4f006913ff4a7f"
-  integrity sha512-fMjKi+ojnmIvhk34gZP94vjogXNNUKMEYs+EDaB/5TG/wUkoeua7p7VCHnE6T2Tx+iaghAqQX8teQzcvrYpaQA==
+"@rollup/rollup-linux-riscv64-gnu@4.62.4":
+  version "4.62.4"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.4.tgz#5b3141ab43afbd9e50f639e562e94ed256d201cf"
+  integrity sha512-+fxjfuoAmVMCYV5QyjoIpu0cp5DOiOTeqYFk1AVaxGr+/ravWLX89XfQmptsoWcaVy/TGf2hexzbUOrCQIL1CQ==
 
-"@rollup/rollup-linux-riscv64-gnu@4.60.1":
-  version "4.60.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.1.tgz#17cc38b2a71e302547cad29bcf78d0db2618c922"
-  integrity sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg==
+"@rollup/rollup-linux-riscv64-musl@4.53.5":
+  version "4.53.5"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.53.5.tgz#6fcfb9084822036b9e4ff66e5c8b472d77226fae"
+  integrity sha512-GwuDBE/PsXaTa76lO5eLJTyr2k8QkPipAyOrs4V/KJufHCZBJ495VCGJol35grx9xryk4V+2zd3Ri+3v7NPh+w==
 
-"@rollup/rollup-linux-riscv64-musl@4.53.2":
-  version "4.53.2"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.53.2.tgz#b26ba1c80b6f104dc5bd83ed83181fc0411a0c38"
-  integrity sha512-XuGFGU+VwUUV5kLvoAdi0Wz5Xbh2SrjIxCtZj6Wq8MDp4bflb/+ThZsVxokM7n0pcbkEr2h5/pzqzDYI7cCgLQ==
+"@rollup/rollup-linux-riscv64-musl@4.62.4":
+  version "4.62.4"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.4.tgz#b0fe751015bc3822f9004884eaba5e5cdfde7aa6"
+  integrity sha512-jTn8JfHGL4djjFxPuM06LmNUJDsst2jeVlsd9OmIH6zc5sC9K6rIuO4YajXatLUpBmBKl6b35ro1QZocLi+tcA==
 
-"@rollup/rollup-linux-riscv64-musl@4.60.1":
-  version "4.60.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.1.tgz#e36a41e2d8bd247331bd5cfc13b8c951d33454a2"
-  integrity sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==
+"@rollup/rollup-linux-s390x-gnu@4.53.5":
+  version "4.53.5"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.53.5.tgz#204bf1f758b65263adad3183d1ea7c9fc333e453"
+  integrity sha512-IAE1Ziyr1qNfnmiQLHBURAD+eh/zH1pIeJjeShleII7Vj8kyEm2PF77o+lf3WTHDpNJcu4IXJxNO0Zluro8bOw==
 
-"@rollup/rollup-linux-s390x-gnu@4.53.2":
-  version "4.53.2"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.53.2.tgz#dc83647189b68ad8d56a956a6fcaa4ee9c728190"
-  integrity sha512-w6yjZF0P+NGzWR3AXWX9zc0DNEGdtvykB03uhonSHMRa+oWA6novflo2WaJr6JZakG2ucsyb+rvhrKac6NIy+w==
+"@rollup/rollup-linux-s390x-gnu@4.62.4":
+  version "4.62.4"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.4.tgz#0cb323e850509e1b9bf6d241328a98b0e12e2916"
+  integrity sha512-oCJCJL4pXsoDcP2QZ+JVlPTIRc6266zsIaeJJsWImmF7HO0W8nb6HuSgZlMWxJwaPf8ehbSw8yo0EUw925hKsA==
 
-"@rollup/rollup-linux-s390x-gnu@4.60.1":
-  version "4.60.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.1.tgz#1687265f1f4bdea0726c761a58c2db9933609d68"
-  integrity sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==
+"@rollup/rollup-linux-x64-gnu@4.53.5":
+  version "4.53.5"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.53.5.tgz#704a927285c370b4481a77e5a6468ebc841f72ca"
+  integrity sha512-Pg6E+oP7GvZ4XwgRJBuSXZjcqpIW3yCBhK4BcsANvb47qMvAbCjR6E+1a/U2WXz1JJxp9/4Dno3/iSJLcm5auw==
 
-"@rollup/rollup-linux-x64-gnu@4.53.2":
-  version "4.53.2"
-  resolved "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.53.2.tgz"
-  integrity sha512-yo8d6tdfdeBArzC7T/PnHd7OypfI9cbuZzPnzLJIyKYFhAQ8SvlkKtKBMbXDxe1h03Rcr7u++nFS7tqXz87Gtw==
+"@rollup/rollup-linux-x64-gnu@4.62.4":
+  version "4.62.4"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.4.tgz#1e7470123e7a8ba8c160a7a043447472d5549542"
+  integrity sha512-W69hukhZ3KKNRCaMIEzKvcFye42hh0FE1+YoYaf5+Ikacuftoco6yO/xouz0hc5d5W/s3yBro5jRiuEE/Q5vUw==
 
-"@rollup/rollup-linux-x64-gnu@4.60.1":
-  version "4.60.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.1.tgz#56a6a0d9076f2a05a976031493b24a20ddcc0e77"
-  integrity sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==
+"@rollup/rollup-linux-x64-musl@4.53.5":
+  version "4.53.5"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.53.5.tgz#3a7ccf6239f7efc6745b95075cf855b137cd0b52"
+  integrity sha512-txGtluxDKTxaMDzUduGP0wdfng24y1rygUMnmlUJ88fzCCULCLn7oE5kb2+tRB+MWq1QDZT6ObT5RrR8HFRKqg==
 
-"@rollup/rollup-linux-x64-musl@4.53.2":
-  version "4.53.2"
-  resolved "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.53.2.tgz"
-  integrity sha512-ah59c1YkCxKExPP8O9PwOvs+XRLKwh/mV+3YdKqQ5AMQ0r4M4ZDuOrpWkUaqO7fzAHdINzV9tEVu8vNw48z0lA==
+"@rollup/rollup-linux-x64-musl@4.62.4":
+  version "4.62.4"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.4.tgz#19df9a17d20ff3c17bd8e9cc2553563ae0aa0580"
+  integrity sha512-qiXbGG2jkjXhzXpsFZSR2Xpb8DN/UaxYsbb/STbuR/6fpaDgRmmaq1B/LmtF2wQFOFOSsK2jdE0RZ3a0zHn4QA==
 
-"@rollup/rollup-linux-x64-musl@4.60.1":
-  version "4.60.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.1.tgz#bc240ebb5b9fd8d41ca8a80cb458452e8c187e0f"
-  integrity sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==
+"@rollup/rollup-openbsd-x64@4.62.4":
+  version "4.62.4"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.4.tgz#31c3ca1bd00e80f309a1d0cb8da4bdf59cb2dfa3"
+  integrity sha512-nWeM//hxv8mIo6jD7Hu4o48DVmV9pbV6gsKaWU+4NFyqHoPKwrkRiZGLKUhOBk8qNmDmpwFtPKg80Bo/Tn4xiQ==
 
-"@rollup/rollup-openbsd-x64@4.60.1":
-  version "4.60.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.1.tgz#6f80d48a006c4b2ffa7724e95a3e33f6975872af"
-  integrity sha512-cl0w09WsCi17mcmWqqglez9Gk8isgeWvoUZ3WiJFYSR3zjBQc2J5/ihSjpl+VLjPqjQ/1hJRcqBfLjssREQILw==
+"@rollup/rollup-openharmony-arm64@4.53.5":
+  version "4.53.5"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.53.5.tgz#cb29644e4330b8d9aec0c594bf092222545db218"
+  integrity sha512-3DFiLPnTxiOQV993fMc+KO8zXHTcIjgaInrqlG8zDp1TlhYl6WgrOHuJkJQ6M8zHEcntSJsUp1XFZSY8C1DYbg==
 
-"@rollup/rollup-openharmony-arm64@4.53.2":
-  version "4.53.2"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.53.2.tgz#3acd0157cb8976f659442bfd8a99aca46f8a2931"
-  integrity sha512-4VEd19Wmhr+Zy7hbUsFZ6YXEiP48hE//KPLCSVNY5RMGX2/7HZ+QkN55a3atM1C/BZCGIgqN+xrVgtdak2S9+A==
+"@rollup/rollup-openharmony-arm64@4.62.4":
+  version "4.62.4"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.4.tgz#84561a14381caecb7652e158d10551a5edc0a6fc"
+  integrity sha512-s62SQ/vgsRSvMwDkOEfTqfgASF0f26ZNaQuTA6Aok5lrikf89yI2W0gFHvZb2Jpgc6N8JnOKZgCK2iciO3CsxQ==
 
-"@rollup/rollup-openharmony-arm64@4.60.1":
-  version "4.60.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.1.tgz#8f6db6f70d0a48abd833b263cd6dd3e7199c4c0e"
-  integrity sha512-4Cv23ZrONRbNtbZa37mLSueXUCtN7MXccChtKpUnQNgF010rjrjfHx3QxkS2PI7LqGT5xXyYs1a7LbzAwT0iCA==
+"@rollup/rollup-win32-arm64-msvc@4.53.5":
+  version "4.53.5"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.53.5.tgz#bae9daf924900b600f6a53c0659b12cb2f6c33e4"
+  integrity sha512-nggc/wPpNTgjGg75hu+Q/3i32R00Lq1B6N1DO7MCU340MRKL3WZJMjA9U4K4gzy3dkZPXm9E1Nc81FItBVGRlA==
 
-"@rollup/rollup-win32-arm64-msvc@4.53.2":
-  version "4.53.2"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.53.2.tgz#3eb9e7d4d0e1d2e0850c4ee9aa2d0ddf89a8effa"
-  integrity sha512-IlbHFYc/pQCgew/d5fslcy1KEaYVCJ44G8pajugd8VoOEI8ODhtb/j8XMhLpwHCMB3yk2J07ctup10gpw2nyMA==
+"@rollup/rollup-win32-arm64-msvc@4.62.4":
+  version "4.62.4"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.4.tgz#bc532edb20cd39c0b53eee2dfae43b52c2e3be1e"
+  integrity sha512-J6wGf8TVGbXJq+HH+ttTvrcfNKPbuZecV6KT1B8I18BC5IURUh5kl4Yl5OEP5eFIUoI5BWxCsyYMhFsDx8kekw==
 
-"@rollup/rollup-win32-arm64-msvc@4.60.1":
-  version "4.60.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.1.tgz#b68989bfa815d0b3d4e302ecd90bda744438b177"
-  integrity sha512-i1okWYkA4FJICtr7KpYzFpRTHgy5jdDbZiWfvny21iIKky5YExiDXP+zbXzm3dUcFpkEeYNHgQ5fuG236JPq0g==
+"@rollup/rollup-win32-ia32-msvc@4.53.5":
+  version "4.53.5"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.53.5.tgz#48002d2b9e4ab93049acd0d399c7aa7f7c5f363c"
+  integrity sha512-U/54pTbdQpPLBdEzCT6NBCFAfSZMvmjr0twhnD9f4EIvlm9wy3jjQ38yQj1AGznrNO65EWQMgm/QUjuIVrYF9w==
 
-"@rollup/rollup-win32-ia32-msvc@4.53.2":
-  version "4.53.2"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.53.2.tgz#d69280bc6680fe19e0956e965811946d542f6365"
-  integrity sha512-lNlPEGgdUfSzdCWU176ku/dQRnA7W+Gp8d+cWv73jYrb8uT7HTVVxq62DUYxjbaByuf1Yk0RIIAbDzp+CnOTFg==
+"@rollup/rollup-win32-ia32-msvc@4.62.4":
+  version "4.62.4"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.4.tgz#a6f51492976c9fc19801be298df2f76a3cbebf7a"
+  integrity sha512-zmfrQd/0wu6oJs8Vq8KwY/YtsKSsLtKe/HwAP4Wqy8LhWjeT55fHRAkOhYQ12wI3ayS4Tt12d5CDRD7N96SAYQ==
 
-"@rollup/rollup-win32-ia32-msvc@4.60.1":
-  version "4.60.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.1.tgz#c098e45338c50f22f1b288476354f025b746285b"
-  integrity sha512-u09m3CuwLzShA0EYKMNiFgcjjzwqtUMLmuCJLeZWjjOYA3IT2Di09KaxGBTP9xVztWyIWjVdsB2E9goMjZvTQg==
+"@rollup/rollup-win32-x64-gnu@4.53.5":
+  version "4.53.5"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.53.5.tgz#aa0344b25dc31f2d822caf886786e377b45e660b"
+  integrity sha512-2NqKgZSuLH9SXBBV2dWNRCZmocgSOx8OJSdpRaEcRlIfX8YrKxUT6z0F1NpvDVhOsl190UFTRh2F2WDWWCYp3A==
 
-"@rollup/rollup-win32-x64-gnu@4.53.2":
-  version "4.53.2"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.53.2.tgz#d182ce91e342bad9cbb8b284cf33ac542b126ead"
-  integrity sha512-S6YojNVrHybQis2lYov1sd+uj7K0Q05NxHcGktuMMdIQ2VixGwAfbJ23NnlvvVV1bdpR2m5MsNBViHJKcA4ADw==
+"@rollup/rollup-win32-x64-gnu@4.62.4":
+  version "4.62.4"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.4.tgz#ae60710b0868b2fe731d9f7c341fa49cbf8e8629"
+  integrity sha512-qPzHqdj9rfUD+w79dtE07zi/kFwKyCJqplp5K5ygeLTp7jLpAoc16OAH39HSmRC9UpozaecsleI8uAdEj6v2yw==
 
-"@rollup/rollup-win32-x64-gnu@4.60.1":
-  version "4.60.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.1.tgz#2c9e15be155b79d05999953b1737b2903842e903"
-  integrity sha512-k+600V9Zl1CM7eZxJgMyTUzmrmhB/0XZnF4pRypKAlAgxmedUA+1v9R+XOFv56W4SlHEzfeMtzujLJD22Uz5zg==
+"@rollup/rollup-win32-x64-msvc@4.53.5":
+  version "4.53.5"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.53.5.tgz#e0d19dffcf25f0fd86f50402a3413004003939e9"
+  integrity sha512-JRpZUhCfhZ4keB5v0fe02gQJy05GqboPOaxvjugW04RLSYYoB/9t2lx2u/tMs/Na/1NXfY8QYjgRljRpN+MjTQ==
 
-"@rollup/rollup-win32-x64-msvc@4.53.2":
-  version "4.53.2"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.53.2.tgz#d9ab606437fd072b2cb7df7e54bcdc7f1ccbe8b4"
-  integrity sha512-k+/Rkcyx//P6fetPoLMb8pBeqJBNGx81uuf7iljX9++yNBVRDQgD04L+SVXmXmh5ZP4/WOp4mWF0kmi06PW2tA==
-
-"@rollup/rollup-win32-x64-msvc@4.60.1":
-  version "4.60.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.1.tgz#23b860113e9f87eea015d1fa3a4240a52b42fcd4"
-  integrity sha512-lWMnixq/QzxyhTV6NjQJ4SFo1J6PvOX8vUx5Wb4bBPsEb+8xZ89Bz6kOXpfXj9ak9AHTQVQzlgzBEc1SyM27xQ==
+"@rollup/rollup-win32-x64-msvc@4.62.4":
+  version "4.62.4"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.4.tgz#c3a265fe0f9af4fb63bad86d3829386bc5da0026"
+  integrity sha512-zD6NdeWEByGE9QF9vCrlJ5YQB4oq9q91kPZS37Jwj5hOkvR1lTBSpsKhKDw4IJtbQ35LsTS1HD9DZYGKIshU1Q==
 
 "@rtsao/scc@^1.1.0":
   version "1.1.0"
@@ -7091,14 +7103,14 @@
   dependencies:
     xmlchars "^2.2.0"
 
-"@scure/base@^1.1.3":
-  version "1.2.6"
-  resolved "https://registry.npmjs.org/@scure/base/-/base-1.2.6.tgz"
-  integrity sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==
+"@scure/base@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/@scure/base/-/base-2.0.0.tgz"
+  integrity sha512-3E1kpuZginKkek01ovG8krQ0Z44E3DHPjc5S2rjJw9lZn3KSQOs8S7wqikF/AH7iRanHypj85uGyxk0XAyC37w==
 
 "@sd-jwt/core@0.9.2":
   version "0.9.2"
-  resolved "https://registry.yarnpkg.com/@sd-jwt/core/-/core-0.9.2.tgz#89092457660b45cdd0d9da2b30f2f8ecf19c7ba5"
+  resolved "https://registry.npmjs.org/@sd-jwt/core/-/core-0.9.2.tgz"
   integrity sha512-AbvID/VIogRtPtCWGmfUlCZczHaBSRFmTwOAiUeuPRjDJTGUQu3gMRKwsfSGRHlfPo0pSaRQ7lqN3N+a5i+SDA==
   dependencies:
     "@sd-jwt/decode" "0.9.2"
@@ -7108,12 +7120,12 @@
 
 "@sd-jwt/crypto-browser@^0.9.2":
   version "0.9.2"
-  resolved "https://registry.yarnpkg.com/@sd-jwt/crypto-browser/-/crypto-browser-0.9.2.tgz#124d83eba0883bdf3ca4de635197eaeabf224214"
+  resolved "https://registry.npmjs.org/@sd-jwt/crypto-browser/-/crypto-browser-0.9.2.tgz"
   integrity sha512-m/l+z3c6ily0uadGEdg6979h8HXgl975qeM2xn/qC0hXtzypM8XW9C7Ym7M6IaBTUkZoh9RRjD6wO0tEtpPsEg==
 
 "@sd-jwt/crypto-nodejs@^0.9.2":
   version "0.9.2"
-  resolved "https://registry.yarnpkg.com/@sd-jwt/crypto-nodejs/-/crypto-nodejs-0.9.2.tgz#23ad818b909a6b339d63cb38c1d230bf481ce0a1"
+  resolved "https://registry.npmjs.org/@sd-jwt/crypto-nodejs/-/crypto-nodejs-0.9.2.tgz"
   integrity sha512-OL5drLhrsDok60XfLoovAK+DT/6mA1myZe1tkA8JflV8tcx4OZTLi/UMVcW/hc+7nBugYICutVSoIejTYsgbEw==
 
 "@sd-jwt/decode@0.7.2", "@sd-jwt/decode@^0.7.2":
@@ -7126,7 +7138,7 @@
 
 "@sd-jwt/decode@0.9.2":
   version "0.9.2"
-  resolved "https://registry.yarnpkg.com/@sd-jwt/decode/-/decode-0.9.2.tgz#3f2df7b22bfce1ff4640f46b1e51d513c9c1446d"
+  resolved "https://registry.npmjs.org/@sd-jwt/decode/-/decode-0.9.2.tgz"
   integrity sha512-jHY7hqk7EMkp6E2cB13QmXvRZN7njvAveVh+zKKy0kxpAM7DmcR4TqcDA4mc5y4lP8zWFUgbk7oGLCx2wiBq+w==
   dependencies:
     "@sd-jwt/types" "0.9.2"
@@ -7134,7 +7146,7 @@
 
 "@sd-jwt/jwt-status-list@0.9.2":
   version "0.9.2"
-  resolved "https://registry.yarnpkg.com/@sd-jwt/jwt-status-list/-/jwt-status-list-0.9.2.tgz#9af484cad38c137831fd2d836be3789822b3d45b"
+  resolved "https://registry.npmjs.org/@sd-jwt/jwt-status-list/-/jwt-status-list-0.9.2.tgz"
   integrity sha512-59bPkgSnwvibJgUNVKmSE3SFMQwvDnh3Xr21aUi0bgII7yoHTQ+vqnryVOF8qcjpyICyi/clIlkTw3VWSyAV+g==
   dependencies:
     "@sd-jwt/types" "0.9.2"
@@ -7143,7 +7155,7 @@
 
 "@sd-jwt/present@0.9.2":
   version "0.9.2"
-  resolved "https://registry.yarnpkg.com/@sd-jwt/present/-/present-0.9.2.tgz#476af63defbe8459cb033a88b0263c78d4251572"
+  resolved "https://registry.npmjs.org/@sd-jwt/present/-/present-0.9.2.tgz"
   integrity sha512-ozBDYfQxUCwu0N+gbyk6zJDraMslFFuNLW+GxITybdDfVJek65tBtbROB8ZBvkAlEl0PDRKebq+xKOCRmplmWA==
   dependencies:
     "@sd-jwt/decode" "0.9.2"
@@ -7161,7 +7173,7 @@
 
 "@sd-jwt/sd-jwt-vc@^0.9.2":
   version "0.9.2"
-  resolved "https://registry.yarnpkg.com/@sd-jwt/sd-jwt-vc/-/sd-jwt-vc-0.9.2.tgz#bbb3ea645bd6426866bdcbc024604ee12cd49dd4"
+  resolved "https://registry.npmjs.org/@sd-jwt/sd-jwt-vc/-/sd-jwt-vc-0.9.2.tgz"
   integrity sha512-UOx5ULWyztJv2FbIjVJ0XCDixXwpgFxRCFykhLeRJI0T9+48hi2ucvOdqZqD2X7LkXkjCZNR0kQlJs+/n8gLEg==
   dependencies:
     "@sd-jwt/core" "0.9.2"
@@ -7177,7 +7189,7 @@
 
 "@sd-jwt/types@0.9.2":
   version "0.9.2"
-  resolved "https://registry.yarnpkg.com/@sd-jwt/types/-/types-0.9.2.tgz#17a9d62e36d9863b2c20a127be22a3e77005a6a8"
+  resolved "https://registry.npmjs.org/@sd-jwt/types/-/types-0.9.2.tgz"
   integrity sha512-eV/MY80ekeTrqaohzPpkrgwPki6Igx69D6RniduV1Ehv6o/zaJQ2F0hY/RqBAkJhQtBQoOzouwKYHme40k1Dlw==
 
 "@sd-jwt/utils@0.7.2":
@@ -7190,7 +7202,7 @@
 
 "@sd-jwt/utils@0.9.2":
   version "0.9.2"
-  resolved "https://registry.yarnpkg.com/@sd-jwt/utils/-/utils-0.9.2.tgz#7e15091a5b7c636379932014f1fedb1713dc4217"
+  resolved "https://registry.npmjs.org/@sd-jwt/utils/-/utils-0.9.2.tgz"
   integrity sha512-GpTD0isav2f+JyMyzeyf6wV3nYcD5e3oL+sVVr/61Y3oaIBGMWLtGGGhBRMCimSnd8kbb0P9jLxvp7ioASk6vw==
   dependencies:
     "@sd-jwt/types" "0.9.2"
@@ -7531,7 +7543,7 @@
 
 "@tokenizer/inflate@^0.4.1":
   version "0.4.1"
-  resolved "https://registry.yarnpkg.com/@tokenizer/inflate/-/inflate-0.4.1.tgz#fa6cdb8366151b3cc8426bf9755c1ea03a2fba08"
+  resolved "https://registry.npmjs.org/@tokenizer/inflate/-/inflate-0.4.1.tgz"
   integrity sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA==
   dependencies:
     debug "^4.4.3"
@@ -7542,18 +7554,18 @@
   resolved "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz"
   integrity sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==
 
-"@transmute/ed25519-key-pair@^0.7.0-unstable.82":
+"@transmute/ed25519-key-pair@0.7.0-unstable.82":
   version "0.7.0-unstable.82"
-  resolved "https://registry.npmjs.org/@transmute/ed25519-key-pair/-/ed25519-key-pair-0.7.0-unstable.82.tgz"
+  resolved "https://registry.yarnpkg.com/@transmute/ed25519-key-pair/-/ed25519-key-pair-0.7.0-unstable.82.tgz#6dab673381236a50d1f3997c7427afd0a52d4406"
   integrity sha512-ZPMlPXAzQ59ImUP5j0EPp05ZA7H3voM23+zWINZawd4tehTaUpyCXVBPyAyHscJ4isS/l+XZnnOnYcvl9+YrXg==
   dependencies:
     "@stablelib/ed25519" "^1.0.1"
     "@transmute/ld-key-pair" "^0.7.0-unstable.82"
     "@transmute/x25519-key-pair" "^0.7.0-unstable.82"
 
-"@transmute/jose-ld@^0.7.0-unstable.82":
+"@transmute/jose-ld@0.7.0-unstable.82":
   version "0.7.0-unstable.82"
-  resolved "https://registry.npmjs.org/@transmute/jose-ld/-/jose-ld-0.7.0-unstable.82.tgz"
+  resolved "https://registry.yarnpkg.com/@transmute/jose-ld/-/jose-ld-0.7.0-unstable.82.tgz#6f4e261dd1eb25c53bbd94e4d07fee467fc02f23"
   integrity sha512-FBDbb0bGs7Ssd1H6NXEXqzfF2cnIGRW2ggR13MaTeQR51CEX2lfWlf2fdioOZa0Bk1GZlmUtyEvhPTEjp302WQ==
   dependencies:
     "@peculiar/webcrypto" "^1.1.6"
@@ -7563,48 +7575,23 @@
     jose "^4.3.8"
     web-streams-polyfill "^3.0.3"
 
-"@transmute/json-web-signature@^0.7.0-unstable.82":
-  version "0.7.0-unstable.82"
-  resolved "https://registry.npmjs.org/@transmute/json-web-signature/-/json-web-signature-0.7.0-unstable.82.tgz"
-  integrity sha512-Snku9yg5sN10zkSy678n7VnHZgd7s0EQmjRylhW+mg4n9aL1SXPSbmRx6wUXfdXe1RGY1oNfDd7R5WegZVg9ew==
-  dependencies:
-    "@transmute/ed25519-key-pair" "^0.7.0-unstable.82"
-    "@transmute/jose-ld" "^0.7.0-unstable.82"
-    "@transmute/jsonld" "0.0.4"
-    "@transmute/secp256k1-key-pair" "^0.7.0-unstable.82"
-    "@transmute/security-context" "^0.7.0-unstable.82"
-    "@transmute/web-crypto-key-pair" "^0.7.0-unstable.82"
-
-"@transmute/jsonld@0.0.4":
-  version "0.0.4"
-  resolved "https://registry.npmjs.org/@transmute/jsonld/-/jsonld-0.0.4.tgz"
-  integrity sha512-6G++8imMYW9dtTvATPHNfrV3lLeX5E57DOmlgIDfO0A0yjkBCss1usB80NfONS26ynyveb8vTbp4nQDW9Ki4Rw==
-  dependencies:
-    json-pointer "^0.6.2"
-    jsonld "5.2.0"
-
 "@transmute/ld-key-pair@^0.7.0-unstable.82":
   version "0.7.0-unstable.82"
   resolved "https://registry.npmjs.org/@transmute/ld-key-pair/-/ld-key-pair-0.7.0-unstable.82.tgz"
   integrity sha512-XWnVNCL1LeohldBLu7O12tc53rzdCYjZiaMrWvEH/sNpqnZBiNWAsdLWengXhF67LqAXWMwstfbCLNTPCD+EGg==
 
-"@transmute/secp256k1-key-pair@^0.7.0-unstable.82":
+"@transmute/secp256k1-key-pair@0.7.0-unstable.82":
   version "0.7.0-unstable.82"
-  resolved "https://registry.npmjs.org/@transmute/secp256k1-key-pair/-/secp256k1-key-pair-0.7.0-unstable.82.tgz"
+  resolved "https://registry.yarnpkg.com/@transmute/secp256k1-key-pair/-/secp256k1-key-pair-0.7.0-unstable.82.tgz#8e8e839f672c66b3d836781e24e29ca887312174"
   integrity sha512-X+txATKPpwodcr0B5TPvcsi2UnSrS3UFkrALa2ui0B1zNLj56pUVMJ0FdX9eHUKdP7t5tB9iE73Y7/8NWL6exA==
   dependencies:
     "@bitauth/libauth" "^1.18.1"
     "@transmute/ld-key-pair" "^0.7.0-unstable.82"
     secp256k1 "^4.0.2"
 
-"@transmute/security-context@^0.7.0-unstable.82":
+"@transmute/web-crypto-key-pair@0.7.0-unstable.82":
   version "0.7.0-unstable.82"
-  resolved "https://registry.npmjs.org/@transmute/security-context/-/security-context-0.7.0-unstable.82.tgz"
-  integrity sha512-Hih4A3iatK8daSREtuF/y9hGnrLZGRTfBYBUlUeaGEoCrcnhNcZrn8EQmW2dqj/7VZ2W5ResxQLPljA9pVJt5w==
-
-"@transmute/web-crypto-key-pair@^0.7.0-unstable.82":
-  version "0.7.0-unstable.82"
-  resolved "https://registry.npmjs.org/@transmute/web-crypto-key-pair/-/web-crypto-key-pair-0.7.0-unstable.82.tgz"
+  resolved "https://registry.yarnpkg.com/@transmute/web-crypto-key-pair/-/web-crypto-key-pair-0.7.0-unstable.82.tgz#d0b13db1d63956469b20f6d2336bfb0a4159314e"
   integrity sha512-xhaFpW/jcYgmOZanBVkm034YX728ukVVPO0Bb53d5IcL5MiMSWjPDQfhOyX8+EZfa7rSNDOAi6zCsZMggtB9fg==
   dependencies:
     "@peculiar/webcrypto" "^1.1.6"
@@ -7632,7 +7619,7 @@
 
 "@types/babel__generator@*":
   version "7.27.0"
-  resolved "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz"
+  resolved "https://registry.yarnpkg.com/@types/babel__generator/-/babel__generator-7.27.0.tgz#b5819294c51179957afaec341442f9341e4108a9"
   integrity sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==
   dependencies:
     "@babel/types" "^7.0.0"
@@ -7647,7 +7634,7 @@
 
 "@types/babel__traverse@*", "@types/babel__traverse@^7.0.6":
   version "7.28.0"
-  resolved "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz"
+  resolved "https://registry.yarnpkg.com/@types/babel__traverse/-/babel__traverse-7.28.0.tgz#07d713d6cce0d265c9849db0cbe62d3f61f36f74"
   integrity sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==
   dependencies:
     "@babel/types" "^7.28.2"
@@ -7668,6 +7655,11 @@
   version "0.0.39"
   resolved "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz"
   integrity sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==
+
+"@types/estree@1.0.9":
+  version "1.0.9"
+  resolved "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz"
+  integrity sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==
 
 "@types/flat@^5.0.2":
   version "5.0.5"
@@ -7751,9 +7743,9 @@
   integrity sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==
 
 "@types/lodash@^4.14.195":
-  version "4.17.20"
-  resolved "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.20.tgz"
-  integrity sha512-H3MHACvFUEiujabxhaI/ImO6gUrd8oOurg7LQtS7mbwIXA/cUqWrvBsaeJ23aZEPk1TAYkurjfMbSELfoCXlGA==
+  version "4.17.25"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.17.25.tgz#69765ac7bcddb0eb072961cf292524a8f5b3c2c0"
+  integrity sha512-+K1NIO8I+F9/wNulfVvu23QYd0Pe9/OCqRrim4NoYIf1VoEDL90Ve4ClzpyqBLc7NpGGWRvYNCKZ1BE/Jpf8dQ==
 
 "@types/long@^4.0.1":
   version "4.0.2"
@@ -7799,19 +7791,19 @@
   integrity sha512-QvlqvYtGBYIDeO8dFdY4djkRubcrc+yTJtBc7n8VZPlJDUS/00A+PssbvERM8f9bYRmcaSEHPZgZojeQj7kzAA==
 
 "@types/n3@^1.0.0", "@types/n3@^1.10.4":
-  version "1.26.0"
-  resolved "https://registry.npmjs.org/@types/n3/-/n3-1.26.0.tgz"
-  integrity sha512-ugCaNuBvnSVBE0mEbHQ+2g5dC05EujW/XLhHDvI6a0q6cajJrQosy4CWF+B/O1kxH8lYDR60lBTC0duXXsE+VA==
+  version "1.26.1"
+  resolved "https://registry.yarnpkg.com/@types/n3/-/n3-1.26.1.tgz#c696b45a1bcbc37b0cf5db01e107ec9937f858fe"
+  integrity sha512-TilYHzpU6ecXVJAbV+6o17Z8ZkWLWx6ZJD3IluaU4RiGHxqjU2or9fopxFHS6iXS6qcl5Mg1K3wSx9L8xxJaJQ==
   dependencies:
     "@rdfjs/types" "*"
     "@types/node" "*"
 
-"@types/node@*", "@types/node@>=13.7.0":
-  version "24.3.0"
-  resolved "https://registry.npmjs.org/@types/node/-/node-24.3.0.tgz"
-  integrity sha512-aPTXCrfwnDLj4VvXrm+UUCQjNEvJgNA8s5F1cvwQU+3KNltTOkBm1j30uNLyqqPNe7gE3KFzImYoZEfLhp4Yow==
+"@types/node@*", "@types/node@>=13.7.0", "@types/node@^24.10.1":
+  version "24.10.4"
+  resolved "https://registry.npmjs.org/@types/node/-/node-24.10.4.tgz"
+  integrity sha512-vnDVpYPMzs4wunl27jHrfmwojOGKya0xyM3sH+UE5iv5uPS6vX7UIoh6m+vQc5LGBq52HBKPIn/zcSZVzeDEZg==
   dependencies:
-    undici-types "~7.10.0"
+    undici-types "~7.16.0"
 
 "@types/node@^12.7.1":
   version "12.20.55"
@@ -7819,18 +7811,11 @@
   integrity sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==
 
 "@types/node@^18.0.0":
-  version "18.19.123"
-  resolved "https://registry.npmjs.org/@types/node/-/node-18.19.123.tgz"
-  integrity sha512-K7DIaHnh0mzVxreCR9qwgNxp3MH9dltPNIEddW9MYUlcKAzm+3grKNSTe2vCJHI1FaLpvpL5JGJrz1UZDKYvDg==
+  version "18.19.130"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.19.130.tgz#da4c6324793a79defb7a62cba3947ec5add00d59"
+  integrity sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==
   dependencies:
     undici-types "~5.26.4"
-
-"@types/node@^24.10.1":
-  version "24.10.1"
-  resolved "https://registry.npmjs.org/@types/node/-/node-24.10.1.tgz"
-  integrity sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ==
-  dependencies:
-    undici-types "~7.16.0"
 
 "@types/readable-stream@^2.3.13":
   version "2.3.15"
@@ -7841,9 +7826,9 @@
     safe-buffer "~5.1.1"
 
 "@types/readable-stream@^4.0.0", "@types/readable-stream@^4.0.15":
-  version "4.0.21"
-  resolved "https://registry.npmjs.org/@types/readable-stream/-/readable-stream-4.0.21.tgz"
-  integrity sha512-19eKVv9tugr03IgfXlA9UVUVRbW6IuqRO5B92Dl4a6pT7K8uaGrNS0GkxiZD0BOk6PLuXl5FhWl//eX/pzYdTQ==
+  version "4.0.24"
+  resolved "https://registry.yarnpkg.com/@types/readable-stream/-/readable-stream-4.0.24.tgz#7b2431bfc1367d05c53598ad36094b044726d442"
+  integrity sha512-NRvUNC/JFGPJvqdAfEve8oginbM6V08u5NzLWpG8MwA2kTPOLnqk+wpwuPT+mp3aUsxyuT6m2gnrPuHYCruzEg==
   dependencies:
     "@types/node" "*"
 
@@ -7867,9 +7852,9 @@
     "@types/node" "*"
 
 "@types/semver@^7.3.12", "@types/semver@^7.3.4":
-  version "7.7.0"
-  resolved "https://registry.npmjs.org/@types/semver/-/semver-7.7.0.tgz"
-  integrity sha512-k107IF4+Xr7UHjwDc7Cfd6PRQfbdkiRabXGRjo07b4WyPahFBZCZ1sE+BNxYIJPPg73UkfOsVOLwqVc/6ETrIA==
+  version "7.8.0"
+  resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.8.0.tgz#0bfe3ec51f5e9615bc317174cd5b88ea08b7fc2f"
+  integrity sha512-1mAINjtQCXXeLkJ9ehXkwOcBpqtLxiVtKhpUf83DdRNdQKV0iXZpaHYqRr7nj+wvxuJzoAmAwXI+sCNMv1CzLQ==
 
 "@types/sinon@^17.0.3":
   version "17.0.4"
@@ -7912,12 +7897,12 @@
 
 "@types/uuid@^10.0.0":
   version "10.0.0"
-  resolved "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz"
+  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-10.0.0.tgz#e9c07fe50da0f53dc24970cca94d619ff03f6f6d"
   integrity sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==
 
 "@types/ws@^8.2.2", "@types/ws@^8.5.10":
   version "8.18.1"
-  resolved "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz"
+  resolved "https://registry.yarnpkg.com/@types/ws/-/ws-8.18.1.tgz#48464e4bf2ddfd17db13d845467f6070ffea4aa9"
   integrity sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==
   dependencies:
     "@types/node" "*"
@@ -8071,20 +8056,20 @@ abort-controller@^3.0.0:
   dependencies:
     event-target-shim "^5.0.0"
 
-abort-error@^1.0.0, abort-error@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.npmjs.org/abort-error/-/abort-error-1.0.1.tgz"
-  integrity sha512-fxqCblJiIPdSXIUrxI0PL+eJG49QdP9SQ70qtB65MVAoMr2rASlOyAbJFOylfB467F/f+5BCLJJq58RYi7mGfg==
+abort-error@^1.0.0, abort-error@^1.0.1, abort-error@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/abort-error/-/abort-error-1.0.2.tgz#9fd4b364b3659dadd9ad8af54ec9a1678b51c778"
+  integrity sha512-lVgvB2NyPLqbXXhVmXcYFTC1x5K7CiVdPgdY7LGgFQWC8506oN01sPN3i9cl9ynuwF4iJ0TS9exnR7cZ9FuX4w==
 
 acorn-jsx@^5.3.2:
   version "5.3.2"
   resolved "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz"
   integrity sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==
 
-acorn@^8.14.0, acorn@^8.9.0:
-  version "8.15.0"
-  resolved "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz"
-  integrity sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==
+acorn@^8.15.0, acorn@^8.9.0:
+  version "8.18.0"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.18.0.tgz#4faf01b2d6d326bfeed97aea1f52220b5f4c1940"
+  integrity sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==
 
 aes-js@3.0.0:
   version "3.0.0"
@@ -8106,19 +8091,19 @@ ajv-formats@^3.0.1:
     ajv "^8.0.0"
 
 ajv@^6.12.4:
-  version "6.14.0"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.14.0.tgz#fd067713e228210636ebb08c60bd3765d6dbe73a"
-  integrity sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==
+  version "6.12.6"
+  resolved "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz"
+  integrity sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==
   dependencies:
     fast-deep-equal "^3.1.1"
     fast-json-stable-stringify "^2.0.0"
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
-ajv@^8.0.0, ajv@^8.17.1:
-  version "8.18.0"
-  resolved "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz"
-  integrity sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==
+ajv@^8.0.0, ajv@^8.17.1, ajv@^8.20.0:
+  version "8.20.0"
+  resolved "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz"
+  integrity sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==
   dependencies:
     fast-deep-equal "^3.1.3"
     fast-uri "^3.0.1"
@@ -8126,19 +8111,9 @@ ajv@^8.0.0, ajv@^8.17.1:
     require-from-string "^2.0.2"
 
 ajv@^8.12.0:
-  version "8.17.1"
-  resolved "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz"
-  integrity sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==
-  dependencies:
-    fast-deep-equal "^3.1.3"
-    fast-uri "^3.0.1"
-    json-schema-traverse "^1.0.0"
-    require-from-string "^2.0.2"
-
-ajv@^8.20.0:
-  version "8.20.0"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.20.0.tgz#304b3636add88ba7d936760dd50ece006dea95f9"
-  integrity sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==
+  version "8.18.0"
+  resolved "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz"
+  integrity sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==
   dependencies:
     fast-deep-equal "^3.1.3"
     fast-uri "^3.0.1"
@@ -8219,7 +8194,7 @@ array-buffer-byte-length@^1.0.0, array-buffer-byte-length@^1.0.1, array-buffer-b
 
 array-includes@^3.1.9:
   version "3.1.9"
-  resolved "https://registry.npmjs.org/array-includes/-/array-includes-3.1.9.tgz"
+  resolved "https://registry.yarnpkg.com/array-includes/-/array-includes-3.1.9.tgz#1f0ccaa08e90cdbc3eb433210f903ad0f17c3f3a"
   integrity sha512-FmeCCAenzH0KH381SPT5FZmiA/TmpndpcaShhfgEN9eCVjnFBqq3l1xrI42y8+PPLI6hypzou4GXw00WHmPBLQ==
   dependencies:
     call-bind "^1.0.8"
@@ -8238,7 +8213,7 @@ array-union@^2.1.0:
 
 array.prototype.findlastindex@^1.2.6:
   version "1.2.6"
-  resolved "https://registry.npmjs.org/array.prototype.findlastindex/-/array.prototype.findlastindex-1.2.6.tgz"
+  resolved "https://registry.yarnpkg.com/array.prototype.findlastindex/-/array.prototype.findlastindex-1.2.6.tgz#cfa1065c81dcb64e34557c9b81d012f6a421c564"
   integrity sha512-F/TKATkzseUExPlfvmwQKGITM3DGTK+vkAsCZoDc5daVygbJBnjEUCbgkAvVFsgfXfX4YIqZ/27G3k3tdXrTxQ==
   dependencies:
     call-bind "^1.0.8"
@@ -8251,7 +8226,7 @@ array.prototype.findlastindex@^1.2.6:
 
 array.prototype.flat@^1.3.3:
   version "1.3.3"
-  resolved "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.3.tgz"
+  resolved "https://registry.yarnpkg.com/array.prototype.flat/-/array.prototype.flat-1.3.3.tgz#534aaf9e6e8dd79fb6b9a9917f839ef1ec63afe5"
   integrity sha512-rwG/ja1neyLqCuGZ5YYrznA62D4mZXg0i1cIskIUKSiqF3Cje9/wXAls9B9s1Wa2fomMsIv8czB8jZcPmxCXFg==
   dependencies:
     call-bind "^1.0.8"
@@ -8261,7 +8236,7 @@ array.prototype.flat@^1.3.3:
 
 array.prototype.flatmap@^1.3.3:
   version "1.3.3"
-  resolved "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.3.3.tgz"
+  resolved "https://registry.yarnpkg.com/array.prototype.flatmap/-/array.prototype.flatmap-1.3.3.tgz#712cc792ae70370ae40586264629e33aab5dd38b"
   integrity sha512-Y7Wt51eKJSyi80hFrJCePGGNo5ktJCslFuboqJsbf57CCPcm5zztluPlc4/aD8sWsKvlwatezpV4U1efk8kpjg==
   dependencies:
     call-bind "^1.0.8"
@@ -8271,7 +8246,7 @@ array.prototype.flatmap@^1.3.3:
 
 array.prototype.reduce@^1.0.6:
   version "1.0.8"
-  resolved "https://registry.npmjs.org/array.prototype.reduce/-/array.prototype.reduce-1.0.8.tgz"
+  resolved "https://registry.yarnpkg.com/array.prototype.reduce/-/array.prototype.reduce-1.0.8.tgz#42f97f5078daedca687d4463fd3c05cbfd83da57"
   integrity sha512-DwuEqgXFBwbmZSRqt3BpQigWNUoqw9Ml2dTWdF3B2zQlQX4OeUE0zyuzX0fX0IbTvjdkZbcBTU3idgpO78qkTw==
   dependencies:
     call-bind "^1.0.8"
@@ -8306,13 +8281,13 @@ asmcrypto.js@^2.3.2:
   resolved "https://registry.npmjs.org/asmcrypto.js/-/asmcrypto.js-2.3.2.tgz"
   integrity sha512-3FgFARf7RupsZETQ1nHnhLUUvpcttcCq1iZCaVAbJZbCZ5VNRrNyvpDyHTOb0KC3llFcsyOT/a99NZcCbeiEsA==
 
-asn1js@^3.0.5, asn1js@^3.0.6:
-  version "3.0.6"
-  resolved "https://registry.npmjs.org/asn1js/-/asn1js-3.0.6.tgz"
-  integrity sha512-UOCGPYbl0tv8+006qks/dTgV9ajs97X2p0FAbyS2iyCRrmLSRolDaHdp+v/CLgnzHc3fVB+CwYiUmei7ndFcgA==
+asn1js@^3.0.10, asn1js@^3.0.5:
+  version "3.0.10"
+  resolved "https://registry.yarnpkg.com/asn1js/-/asn1js-3.0.10.tgz#df26c874c8a8b41ca605efea47b2ad07551013dd"
+  integrity sha512-S2s3aOytiKdFRdulw2qPE51MzjzVOisppcVv7jVFR+Kw0kxwvFrDcYA0h7Ndqbmj0HkMIXYWaoj7fli8kgx1eg==
   dependencies:
     pvtsutils "^1.3.6"
-    pvutils "^1.1.3"
+    pvutils "^1.1.5"
     tslib "^2.8.1"
 
 assertion-error@^2.0.1:
@@ -8357,9 +8332,9 @@ axios@^0.21.2:
     follow-redirects "^1.14.0"
 
 b4a@^1.0.1:
-  version "1.6.7"
-  resolved "https://registry.npmjs.org/b4a/-/b4a-1.6.7.tgz"
-  integrity sha512-OnAYlL5b7LEkALw87fUVafQw5rVR9RjwGd4KUwNQ6DrrNmaVaUCgLipfVlzrPQ4tWOR9P0IXGNOx50jYCCdSJg==
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/b4a/-/b4a-1.8.1.tgz#7f16334ca80127aeb26064a28841acbf174840a4"
+  integrity sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==
 
 b64-lite@^1.4.0:
   version "1.4.0"
@@ -8421,33 +8396,33 @@ babel-plugin-jest-hoist@^29.6.3:
     "@types/babel__core" "^7.1.14"
     "@types/babel__traverse" "^7.0.6"
 
-babel-plugin-polyfill-corejs2@^0.4.14:
-  version "0.4.14"
-  resolved "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.14.tgz"
-  integrity sha512-Co2Y9wX854ts6U8gAAPXfn0GmAyctHuK8n0Yhfjd6t30g7yvKjspvvOo9yG+z52PZRgFErt7Ka2pYnXCjLKEpg==
+babel-plugin-polyfill-corejs2@^0.4.15:
+  version "0.4.17"
+  resolved "https://registry.yarnpkg.com/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.17.tgz#198f970f1c99a856b466d1187e88ce30bd199d91"
+  integrity sha512-aTyf30K/rqAsNwN76zYrdtx8obu0E4KoUME29B1xj+B3WxgvWkp943vYQ+z8Mv3lw9xHXMHpvSPOBxzAkIa94w==
   dependencies:
-    "@babel/compat-data" "^7.27.7"
-    "@babel/helper-define-polyfill-provider" "^0.6.5"
+    "@babel/compat-data" "^7.28.6"
+    "@babel/helper-define-polyfill-provider" "^0.6.8"
     semver "^6.3.1"
 
-babel-plugin-polyfill-corejs3@^0.13.0:
-  version "0.13.0"
-  resolved "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.13.0.tgz"
-  integrity sha512-U+GNwMdSFgzVmfhNm8GJUX88AadB3uo9KpJqS3FaqNIPKgySuvMb+bHPsOmmuWyIcuqZj/pzt1RUIUZns4y2+A==
+babel-plugin-polyfill-corejs3@^0.14.0:
+  version "0.14.2"
+  resolved "https://registry.yarnpkg.com/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.14.2.tgz#6ac08d2f312affb70c4c69c0fbba4cb417ee5587"
+  integrity sha512-coWpDLJ410R781Npmn/SIBZEsAetR4xVi0SxLMXPaMO4lSf1MwnkGYMtkFxew0Dn8B3/CpbpYxN0JCgg8mn67g==
   dependencies:
-    "@babel/helper-define-polyfill-provider" "^0.6.5"
-    core-js-compat "^3.43.0"
+    "@babel/helper-define-polyfill-provider" "^0.6.8"
+    core-js-compat "^3.48.0"
 
-babel-plugin-polyfill-regenerator@^0.6.5:
-  version "0.6.5"
-  resolved "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.6.5.tgz"
-  integrity sha512-ISqQ2frbiNU9vIJkzg7dlPpznPZ4jOiUQ1uSmB0fEHeowtN3COYRsXr/xexn64NpU13P06jc/L5TgiJXOgrbEg==
+babel-plugin-polyfill-regenerator@^0.6.6:
+  version "0.6.8"
+  resolved "https://registry.yarnpkg.com/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.6.8.tgz#8a6bfd5dd54239362b3d06ce47ac52b2d95d7721"
+  integrity sha512-M762rNHfSF1EV3SLtnCJXFoQbbIIz0OyRwnCmV0KPC7qosSfCO0QLTSuJX3ayAebubhE6oYBAYPrBA5ljowaZg==
   dependencies:
-    "@babel/helper-define-polyfill-provider" "^0.6.5"
+    "@babel/helper-define-polyfill-provider" "^0.6.8"
 
 babel-preset-current-node-syntax@^1.0.0:
   version "1.2.0"
-  resolved "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.2.0.tgz"
+  resolved "https://registry.yarnpkg.com/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.2.0.tgz#20730d6cdc7dda5d89401cab10ac6a32067acde6"
   integrity sha512-E/VlAEzRrsLEb2+dv8yp3bo4scof3l9nR4lrld+Iy5NyVqgVYUJnDAmunkhPMisRI32Qc4iRiz425d8vM++2fg==
   dependencies:
     "@babel/plugin-syntax-async-generators" "^7.8.4"
@@ -8494,7 +8469,7 @@ base-64@^0.1.0:
 
 base-x@^4.0.0:
   version "4.0.1"
-  resolved "https://registry.npmjs.org/base-x/-/base-x-4.0.1.tgz"
+  resolved "https://registry.yarnpkg.com/base-x/-/base-x-4.0.1.tgz#817fb7b57143c501f649805cb247617ad016a885"
   integrity sha512-uAZ8x6r6S3aUM9rbHGVOIsR15U/ZSc82b3ymnCPsT45Gk1DDvhDPdIgB5MrhirZWt+5K0EEPQH985kNqZgNPFw==
 
 base64-js@1.5.1, base64-js@^1.3.0, base64-js@^1.3.1:
@@ -8506,6 +8481,11 @@ base64url@^3.0.1:
   version "3.0.1"
   resolved "https://registry.npmjs.org/base64url/-/base64url-3.0.1.tgz"
   integrity sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A==
+
+baseline-browser-mapping@^2.10.44:
+  version "2.11.12"
+  resolved "https://registry.yarnpkg.com/baseline-browser-mapping/-/baseline-browser-mapping-2.11.12.tgz#42ac48770bf73d292f60ce8ba4dc5e7ebb242ec3"
+  integrity sha512-r7WnVImvVCeFpf2DOXfy41aPWzeNg3H/A2X4dKmy1QL0MSyyk/e7z8ihJ3N6Nn2PsdhkVlqnEfnUE4a05P2aTA==
 
 bech32@1.1.4, bech32@^1.1.4:
   version "1.1.4"
@@ -8526,7 +8506,7 @@ big-integer@^1.6.48:
 
 bignumber.js@^9.1.2:
   version "9.3.1"
-  resolved "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz"
+  resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-9.3.1.tgz#759c5aaddf2ffdc4f154f7b493e1c8770f88c4d7"
   integrity sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==
 
 binary-extensions@^2.0.0:
@@ -8590,27 +8570,27 @@ bn.js@4.11.6:
   integrity sha512-XWwnNNFCuuSQ0m3r3C4LE3EiORltHd9M05pq6FOlVeiophzRbMo50Sbz1ehl8K3Z+jw9+vmgnXefY1hz8X+2wA==
 
 bn.js@^4.11.9:
-  version "4.12.2"
-  resolved "https://registry.npmjs.org/bn.js/-/bn.js-4.12.2.tgz"
-  integrity sha512-n4DSx829VRTRByMRGdjQ9iqsN0Bh4OolPsFnaZBLcbi8iXcB+kJ9s7EnRt4wILZNV3kPLHkRVfOc/HvhC3ovDw==
+  version "4.12.5"
+  resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.12.5.tgz#74f119ffecd823168d188eae06d97ea40835c489"
+  integrity sha512-3aRg6/JxfffFD+OlOjOFR3Vo79l39ooBTFucxx+MT3dhCtzn3EmiUPQo+6/OZuI2jbXi3YKgmiTFBgChQMwIRQ==
 
 bn.js@^5.2.0, bn.js@^5.2.1:
-  version "5.2.2"
-  resolved "https://registry.npmjs.org/bn.js/-/bn.js-5.2.2.tgz"
-  integrity sha512-v2YAxEmKaBLahNwE1mjp4WON6huMNeuDvagFZW+ASCuA/ku0bXR9hSMw0XpiqMoA3+rmnyck/tPRSFQkoC9Cuw==
+  version "5.2.5"
+  resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-5.2.5.tgz#e81ce41cf25e6f0cd1e05f20a9db8c18405e375f"
+  integrity sha512-Vq886eXykuP5E6HcKSSStP3bJgrE6In5WKxVUvJ8XGpWWYs2xZHWqUwzCtGgEtBcxyd57KBFDPFoUfNzdaHCNg==
 
 brace-expansion@^1.1.7:
-  version "1.1.13"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.13.tgz#d37875c01dc9eff988dd49d112a57cb67b54efe6"
-  integrity sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==
+  version "1.1.18"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.18.tgz#3ce74d89885136be1535341f8c3d4425c29a5cab"
+  integrity sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==
   dependencies:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
 
 brace-expansion@^2.0.1:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.0.3.tgz#0493338bdd58e319b1039c67cf7ee439892c01d9"
-  integrity sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==
+  version "2.0.2"
+  resolved "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz"
+  integrity sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==
   dependencies:
     balanced-match "^1.0.0"
 
@@ -8627,19 +8607,20 @@ brorand@^1.1.0:
   integrity sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w==
 
 browser-readablestream-to-it@^2.0.3:
-  version "2.0.10"
-  resolved "https://registry.npmjs.org/browser-readablestream-to-it/-/browser-readablestream-to-it-2.0.10.tgz"
-  integrity sha512-I/9hEcRtjct8CzD9sVo9Mm4ntn0D+7tOVrjbPl69XAoOfgJ8NBdOQU+WX+5SHhcELJDb14mWt7zuvyqha+MEAQ==
+  version "2.0.12"
+  resolved "https://registry.yarnpkg.com/browser-readablestream-to-it/-/browser-readablestream-to-it-2.0.12.tgz#9693af1b2c92fa49d3ed8000c19712d38f4337af"
+  integrity sha512-VDAcuM39JVtxZ7auqE2p0zHYk1fq+pac0cWLOQJ48MIChTZ1RjCR2PYCdL3kIisst7oGZCxYrJhfHlbNYIa0Tg==
 
-browserslist@^4.24.0, browserslist@^4.25.1:
-  version "4.25.3"
-  resolved "https://registry.npmjs.org/browserslist/-/browserslist-4.25.3.tgz"
-  integrity sha512-cDGv1kkDI4/0e5yON9yM5G/0A5u8sf5TnmdX5C9qHzI9PPu++sQ9zjm1k9NiOrf3riY4OkK0zSGqfvJyJsgCBQ==
+browserslist@^4.24.0, browserslist@^4.28.7:
+  version "4.28.7"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.28.7.tgz#409046517fccd2e51cdc20f077454b7141184028"
+  integrity sha512-JxV13hNrFxqjOc8alRbq9dK1MM79NEXYpma2B2J4wAtpWS5zIEIKqWPGCl7N4o7Uc7B7itylh7SuDujATRyyTw==
   dependencies:
-    caniuse-lite "^1.0.30001735"
-    electron-to-chromium "^1.5.204"
-    node-releases "^2.0.19"
-    update-browserslist-db "^1.1.3"
+    baseline-browser-mapping "^2.10.44"
+    caniuse-lite "^1.0.30001806"
+    electron-to-chromium "^1.5.393"
+    node-releases "^2.0.51"
+    update-browserslist-db "^1.2.3"
 
 bs58@5.0.0, bs58@^5.0.0:
   version "5.0.0"
@@ -8699,6 +8680,16 @@ call-bind@^1.0.2, call-bind@^1.0.5, call-bind@^1.0.7, call-bind@^1.0.8:
     get-intrinsic "^1.2.4"
     set-function-length "^1.2.2"
 
+call-bind@^1.0.9:
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/call-bind/-/call-bind-1.0.9.tgz#39a644700c80bc7d0ca9102fc6d1d43b2fd7eee7"
+  integrity sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==
+  dependencies:
+    call-bind-apply-helpers "^1.0.2"
+    es-define-property "^1.0.1"
+    get-intrinsic "^1.3.0"
+    set-function-length "^1.2.2"
+
 call-bound@^1.0.2, call-bound@^1.0.3, call-bound@^1.0.4:
   version "1.0.4"
   resolved "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz"
@@ -8722,10 +8713,10 @@ camelcase@^6.2.0:
   resolved "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz"
   integrity sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==
 
-caniuse-lite@^1.0.30001735:
-  version "1.0.30001735"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001735.tgz"
-  integrity sha512-EV/laoX7Wq2J9TQlyIXRxTJqIw4sxfXS4OYgudGxBYRuTv0q7AM6yMEpU/Vo1I94thg9U6EZ2NfZx9GJq83u7w==
+caniuse-lite@^1.0.30001806:
+  version "1.0.30001806"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001806.tgz#1bc8e502b723fa393455dfbedd5ccec0c29bb74e"
+  integrity sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw==
 
 canonicalize@^1.0.1:
   version "1.0.8"
@@ -8744,10 +8735,15 @@ catharsis@^0.9.0:
   dependencies:
     lodash "^4.17.15"
 
-cborg@^4.0.0, cborg@^4.0.1, cborg@^4.0.9:
-  version "4.2.13"
-  resolved "https://registry.npmjs.org/cborg/-/cborg-4.2.13.tgz"
-  integrity sha512-HAiZCITe/5Av0ukt6rOYE+VjnuFGfujN3NUKgEbIlONpRpsYMZAa+Bjk16mj6dQMuB0n81AuNrcB9YVMshcrfA==
+cborg@^4.0.1, cborg@^4.0.9:
+  version "4.5.8"
+  resolved "https://registry.yarnpkg.com/cborg/-/cborg-4.5.8.tgz#49cf664711237e4eb6197c841a2de79163e58c62"
+  integrity sha512-6/viltD51JklRhq4L7jC3zgy6gryuG5xfZ3kzpE+PravtyeQLeQmCYLREhQH7pWENg5pY4Yu/XCd6a7dKScVlw==
+
+cborg@^5.0.0, cborg@^5.0.1:
+  version "5.1.11"
+  resolved "https://registry.yarnpkg.com/cborg/-/cborg-5.1.11.tgz#39b8c4c65862be796b769f2eb7e81507261808a0"
+  integrity sha512-oc6Pzg/gkTobxHZNgMmny+G99dOeBMbAmnGHcZWMKtolxZBIVwfi0Pj0khxEtNU8HMFdbT5sK0HmtgecDUPP0A==
 
 chai@^5.1.2:
   version "5.3.3"
@@ -8773,10 +8769,10 @@ char-regex@^1.0.2:
   resolved "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz"
   integrity sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==
 
-chardet@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.npmjs.org/chardet/-/chardet-2.1.0.tgz"
-  integrity sha512-bNFETTG/pM5ryzQ9Ad0lJOTa6HWD/YsScAR3EnCPZRPlQh77JocYktSHOUHelyhm8IARL+o4c4F1bP5KVOjiRA==
+chardet@^2.1.1:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/chardet/-/chardet-2.2.0.tgz#005d664f2cbd4961888d2e2c32c5a69e59d8eec4"
+  integrity sha512-rddelWYNPRrXq6PtNEN2S3f6t9ILzvqaN5pVgi4kqt9jHQaXIial9PznB5iSPVlQSLNaaH22ItWz3EJtQ10+OA==
 
 check-error@^2.1.1:
   version "2.1.1"
@@ -8785,7 +8781,7 @@ check-error@^2.1.1:
 
 chokidar@^3.6.0:
   version "3.6.0"
-  resolved "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.6.0.tgz#197c6cc669ef2a8dc5e7b4d97ee4e092c3eb0d5b"
   integrity sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==
   dependencies:
     anymatch "~3.1.2"
@@ -8803,18 +8799,19 @@ chownr@^1.1.1:
   resolved "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz"
   integrity sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==
 
-ci-info@^3.2.0, ci-info@^3.7.0:
+ci-info@^3.2.0:
   version "3.9.0"
   resolved "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz"
   integrity sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==
 
 cipher-base@^1.0.1, cipher-base@^1.0.4:
-  version "1.0.6"
-  resolved "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.6.tgz"
-  integrity sha512-3Ek9H3X6pj5TgenXYtNWdaBon1tgYCaebd+XPg0keyjEbEfkD4KkmAxkQ/i1vYvxdcT5nscLBfq9VJRmCBcFSw==
+  version "1.0.7"
+  resolved "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.7.tgz"
+  integrity sha512-Mz9QMT5fJe7bKI7MH31UilT5cEK5EHHRCccw/YRFsRY47AuNgaV6HY3rscp0/I4Q+tTW/5zoqpSeRRI54TkDWA==
   dependencies:
     inherits "^2.0.4"
     safe-buffer "^5.2.1"
+    to-buffer "^1.2.2"
 
 cjs-module-lexer@^1.0.0:
   version "1.4.3"
@@ -8964,22 +8961,27 @@ convert-source-map@^2.0.0:
   resolved "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz"
   integrity sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==
 
-core-js-compat@^3.43.0:
-  version "3.45.0"
-  resolved "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.45.0.tgz"
-  integrity sha512-gRoVMBawZg0OnxaVv3zpqLLxaHmsubEGyTnqdpI/CEBvX4JadI1dMSHxagThprYRtSVbuQxvi6iUatdPxohHpA==
+core-js-compat@^3.48.0:
+  version "3.50.0"
+  resolved "https://registry.yarnpkg.com/core-js-compat/-/core-js-compat-3.50.0.tgz#d5922c2a692ab1cba6078c920e7c5567421ae08e"
+  integrity sha512-XGpFGbMLHwSt74YLTKho7Ib242qi6O8MSX+sRokV4oz7iKXvQWGYZthjIhjRGMxjzVkAubBO512dKGYcefmX3Q==
   dependencies:
-    browserslist "^4.25.1"
+    browserslist "^4.28.7"
 
 core-js@^2.4.0:
   version "2.6.12"
   resolved "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz"
   integrity sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==
 
-core-js@^3.30.2:
-  version "3.45.0"
-  resolved "https://registry.npmjs.org/core-js/-/core-js-3.45.0.tgz"
-  integrity sha512-c2KZL9lP4DjkN3hk/an4pWn5b5ZefhRJnAc42n6LJ19kSnbeRbdQZE5dSeE2LBol1OwJD3X1BQvFTAsa8ReeDA==
+core-js@^3.48.0:
+  version "3.50.0"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.50.0.tgz#a18646fcb0097650189b4504c803e887bcae4c0a"
+  integrity sha512-BRWgOLKkFeCgRudR6zrs8p9XJZcE14grzKMMssoYrk6krtuEZ7MTKPIY5RzOnqsEKIR9kst7wNzphttraT+Yqw==
+
+core-util-is@~1.0.0:
+  version "1.0.3"
+  resolved "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz"
+  integrity sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==
 
 "cosmjs-types-cjs@npm:cosmjs-types@^0.7.2":
   version "0.7.2"
@@ -9033,14 +9035,14 @@ credentials-context@^2.0.0:
 
 cross-fetch@^3.0.6, cross-fetch@^3.1.5:
   version "3.2.0"
-  resolved "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.2.0.tgz"
+  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.2.0.tgz#34e9192f53bc757d6614304d9e5e6fb4edb782e3"
   integrity sha512-Q+xVJLoGOeIMXZmbUK4HYk+69cQH6LudR0Vu/pRm2YlU/hDV9CiS0gKUMaWY5f2NeUH9C1nV3bsTlCo0FsTV1Q==
   dependencies:
     node-fetch "^2.7.0"
 
 cross-fetch@^4.0.0:
   version "4.1.0"
-  resolved "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.1.0.tgz"
+  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-4.1.0.tgz#8f69355007ee182e47fa692ecbaa37a52e43c3d2"
   integrity sha512-uKm5PU+MHTootlWEY+mZ4vvXoCn4fLQxT9dSc1sXVMSFkINTJVN8cAQROpwcKm8bJ/c7rgZVIBWzH5T78sNZZw==
   dependencies:
     node-fetch "^2.7.0"
@@ -9125,14 +9127,7 @@ debug@^3.2.7:
   dependencies:
     ms "^2.1.1"
 
-debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, debug@^4.3.4, debug@^4.3.5, debug@^4.4.1:
-  version "4.4.1"
-  resolved "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz"
-  integrity sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==
-  dependencies:
-    ms "^2.1.3"
-
-debug@^4.3.7, debug@^4.4.3:
+debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, debug@^4.3.4, debug@^4.3.5, debug@^4.3.7, debug@^4.4.3:
   version "4.4.3"
   resolved "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz"
   integrity sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==
@@ -9147,9 +9142,9 @@ decompress-response@^6.0.0:
     mimic-response "^3.1.0"
 
 dedent@^1.0.0:
-  version "1.6.0"
-  resolved "https://registry.npmjs.org/dedent/-/dedent-1.6.0.tgz"
-  integrity sha512-F1Z+5UCFpmQUzJa11agbyPVMbpgT/qA3/SKyJ1jyBgm7dUcUEa8v9JwDkerSQXfakBwFljIxhOJqGkjUwZ9FSA==
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/dedent/-/dedent-1.7.2.tgz#34e2264ab538301e27cf7b07bf2369c19baa8dd9"
+  integrity sha512-WzMx3mW98SN+zn3hgemf4OzdmyNhhhKz5Ay0pUfQiMQ3e1g+xmTJWp/pKdwKVXhdSkAEGIIzqeuWrL3mV/AXbA==
 
 deep-eql@^5.0.1:
   version "5.0.2"
@@ -9236,9 +9231,9 @@ detect-indent@^6.0.0:
   integrity sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==
 
 detect-libc@^2.0.0:
-  version "2.0.4"
-  resolved "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.4.tgz"
-  integrity sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA==
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-2.1.2.tgz#689c5dcdc1900ef5583a4cb9f6d7b473742074ad"
+  integrity sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==
 
 detect-newline@^3.0.0:
   version "3.1.0"
@@ -9246,14 +9241,14 @@ detect-newline@^3.0.0:
   integrity sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==
 
 "did-jwt-cjs@npm:did-jwt@^8.0.15":
-  version "8.0.17"
-  resolved "https://registry.npmjs.org/did-jwt/-/did-jwt-8.0.17.tgz"
-  integrity sha512-qWPog796seH8CzvNShvqvs6YeCRVAYWmKzcPtirnhvH6wjiFvhquztJZwr5E9VHnTosW6V7bclWzrp7/HGJbSw==
+  version "8.0.18"
+  resolved "https://registry.npmjs.org/did-jwt/-/did-jwt-8.0.18.tgz"
+  integrity sha512-yS3Y+aUKjYqRFrgR/RY77NuOOqS7SFfvfFH4THhWD6+hkxeUZcKQSsdNZ12QR1Vd48yP9exwae2wzbuOZn0NqQ==
   dependencies:
     "@noble/ciphers" "^1.0.0"
     "@noble/curves" "^1.0.0"
     "@noble/hashes" "^1.3.0"
-    "@scure/base" "^1.1.3"
+    "@scure/base" "^2.0.0"
     canonicalize "^2.0.0"
     did-resolver "^4.1.0"
     multibase "^4.0.6"
@@ -9261,14 +9256,14 @@ detect-newline@^3.0.0:
     uint8arrays "3.1.1"
 
 did-jwt@^8.0.16:
-  version "8.0.17"
-  resolved "https://registry.npmjs.org/did-jwt/-/did-jwt-8.0.17.tgz"
-  integrity sha512-qWPog796seH8CzvNShvqvs6YeCRVAYWmKzcPtirnhvH6wjiFvhquztJZwr5E9VHnTosW6V7bclWzrp7/HGJbSw==
+  version "8.0.18"
+  resolved "https://registry.npmjs.org/did-jwt/-/did-jwt-8.0.18.tgz"
+  integrity sha512-yS3Y+aUKjYqRFrgR/RY77NuOOqS7SFfvfFH4THhWD6+hkxeUZcKQSsdNZ12QR1Vd48yP9exwae2wzbuOZn0NqQ==
   dependencies:
     "@noble/ciphers" "^1.0.0"
     "@noble/curves" "^1.0.0"
     "@noble/hashes" "^1.3.0"
-    "@scure/base" "^1.1.3"
+    "@scure/base" "^2.0.0"
     canonicalize "^2.0.0"
     did-resolver "^4.1.0"
     multibase "^4.0.6"
@@ -9346,7 +9341,7 @@ domhandler@^5.0.2, domhandler@^5.0.3:
 
 domutils@^3.0.1, domutils@^3.1.0:
   version "3.2.2"
-  resolved "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz"
+  resolved "https://registry.yarnpkg.com/domutils/-/domutils-3.2.2.tgz#edbfe2b668b0c1d97c24baf0f1062b132221bc78"
   integrity sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==
   dependencies:
     dom-serializer "^2.0.0"
@@ -9372,10 +9367,10 @@ ed25519-signature-2018-context@^1.1.0:
   resolved "https://registry.npmjs.org/ed25519-signature-2018-context/-/ed25519-signature-2018-context-1.1.0.tgz"
   integrity sha512-ppDWYMNwwp9bploq0fS4l048vHIq41nWsAbPq6H4mNVx9G/GxW3fwg4Ln0mqctP13MoEpREK7Biz8TbVVdYXqA==
 
-electron-to-chromium@^1.5.204:
-  version "1.5.207"
-  resolved "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.207.tgz"
-  integrity sha512-mryFrrL/GXDTmAtIVMVf+eIXM09BBPlO5IQ7lUyKmK8d+A4VpRGG+M3ofoVef6qyF8s60rJei8ymlJxjUA8Faw==
+electron-to-chromium@^1.5.393:
+  version "1.5.401"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.401.tgz#3e931926d8fdc117f6a834e58daa74c1114200d8"
+  integrity sha512-H6ViHN68nGYlChEvlIU67fn8O2/tpbWQPwck98yaJmh+08LSvHiydzDQ6oXNccLU3kNRVIRS9A4mA7CG+i6fLQ==
 
 elliptic@6.5.4:
   version "6.5.4"
@@ -9425,14 +9420,14 @@ enabled@2.0.x:
 
 end-of-stream@^1.1.0, end-of-stream@^1.4.1:
   version "1.4.5"
-  resolved "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz"
+  resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.5.tgz#7344d711dea40e0b74abc2ed49778743ccedb08c"
   integrity sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==
   dependencies:
     once "^1.4.0"
 
 enquirer@^2.4.1:
   version "2.4.1"
-  resolved "https://registry.npmjs.org/enquirer/-/enquirer-2.4.1.tgz"
+  resolved "https://registry.yarnpkg.com/enquirer/-/enquirer-2.4.1.tgz#93334b3fbd74fc7097b224ab4a8fb7e40bf4ae56"
   integrity sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==
   dependencies:
     ansi-colors "^4.1.1"
@@ -9461,9 +9456,9 @@ error-ex@^1.3.1:
     is-arrayish "^0.2.1"
 
 es-abstract@^1.23.2, es-abstract@^1.23.5, es-abstract@^1.23.9, es-abstract@^1.24.0:
-  version "1.24.0"
-  resolved "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.0.tgz"
-  integrity sha512-WSzPgsdLtTcQwm4CROfS5ju2Wa1QQcVeT37jFjYzdFz1r9ahadC8B8/a4qxJxM+09F18iumCdRmlr96ZYkQvEg==
+  version "1.24.2"
+  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.24.2.tgz#2dbd38c180735ee983f77585140a2706a963ed9a"
+  integrity sha512-2FpH9Q5i2RRwyEP1AylXe6nYLR5OhaJTZwmlcP0dL/+JCbgg7yyEo/sEK6HeGZRf3dFpWwThaRHVApXSkW3xeg==
   dependencies:
     array-buffer-byte-length "^1.0.2"
     arraybuffer.prototype.slice "^1.0.4"
@@ -9527,7 +9522,7 @@ es-array-method-boxes-properly@^1.0.0:
 
 es-define-property@^1.0.0, es-define-property@^1.0.1:
   version "1.0.1"
-  resolved "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz"
+  resolved "https://registry.yarnpkg.com/es-define-property/-/es-define-property-1.0.1.tgz#983eb2f9a6724e9303f61addf011c72e09e0b0fa"
   integrity sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==
 
 es-errors@^1.3.0:
@@ -9555,7 +9550,14 @@ es-module-lexer@^1.5.4:
   resolved "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz"
   integrity sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==
 
-es-object-atoms@^1.0.0, es-object-atoms@^1.1.1:
+es-object-atoms@^1.0.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/es-object-atoms/-/es-object-atoms-1.1.2.tgz#a2d0b373205724dfa525d23b0c3e1b1ca582c99b"
+  integrity sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==
+  dependencies:
+    es-errors "^1.3.0"
+
+es-object-atoms@^1.1.1:
   version "1.1.1"
   resolved "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz"
   integrity sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==
@@ -9695,15 +9697,15 @@ eslint-import-resolver-node@^0.3.9:
     resolve "^1.22.4"
 
 eslint-module-utils@^2.12.1:
-  version "2.12.1"
-  resolved "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.12.1.tgz"
-  integrity sha512-L8jSWTze7K2mTg0vos/RuLRS5soomksDPoJLXIslC7c8Wmut3bx7CPpJijDcBZtxQ5lrbUdM+s0OlNbz0DCDNw==
+  version "2.14.0"
+  resolved "https://registry.yarnpkg.com/eslint-module-utils/-/eslint-module-utils-2.14.0.tgz#611f8e1c6ceb29a93eb949e1cc670b8287764819"
+  integrity sha512-W2WCRZ9Dqntd+2u8jJcVMV2PKulc6RdLgUUoh/yQr3uB6lo/ZOeGx11sv60/8S4QFFKNslAlWhr9u0Ef7ZW6Ig==
   dependencies:
     debug "^3.2.7"
 
 eslint-plugin-import@^2.20.2:
   version "2.32.0"
-  resolved "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.32.0.tgz"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.32.0.tgz#602b55faa6e4caeaa5e970c198b5c00a37708980"
   integrity sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==
   dependencies:
     "@rtsao/scc" "^1.1.0"
@@ -9773,7 +9775,7 @@ eslint-visitor-keys@^1.0.0:
 
 eslint-visitor-keys@^2.1.0:
   version "2.1.0"
-  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz#f65328259305927392c938ed44eb0a5c9b2bd303"
+  resolved "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz"
   integrity sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==
 
 eslint-visitor-keys@^3.3.0, eslint-visitor-keys@^3.4.1, eslint-visitor-keys@^3.4.3:
@@ -10122,9 +10124,9 @@ expand-template@^2.0.3:
   integrity sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==
 
 expect-type@^1.1.0:
-  version "1.2.2"
-  resolved "https://registry.npmjs.org/expect-type/-/expect-type-1.2.2.tgz"
-  integrity sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA==
+  version "1.3.0"
+  resolved "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz"
+  integrity sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==
 
 expect@^29.0.0, expect@^29.7.0:
   version "29.7.0"
@@ -10157,7 +10159,7 @@ fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   resolved "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
 
-fast-glob@3.3.2:
+fast-glob@3.3.2, fast-glob@^3.2.9:
   version "3.3.2"
   resolved "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz"
   integrity sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==
@@ -10168,7 +10170,7 @@ fast-glob@3.3.2:
     merge2 "^1.3.0"
     micromatch "^4.0.4"
 
-fast-glob@3.3.3, fast-glob@^3.0.3, fast-glob@^3.2.9:
+fast-glob@^3.0.3:
   version "3.3.3"
   resolved "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz"
   integrity sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==
@@ -10200,9 +10202,9 @@ fast-uri@^3.0.1:
   integrity sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==
 
 fastq@^1.6.0:
-  version "1.19.1"
-  resolved "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz"
-  integrity sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==
+  version "1.20.1"
+  resolved "https://registry.yarnpkg.com/fastq/-/fastq-1.20.1.tgz#ca750a10dc925bc8b18839fd203e3ef4b3ced675"
+  integrity sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==
   dependencies:
     reusify "^1.0.4"
 
@@ -10215,7 +10217,7 @@ fb-watchman@^2.0.0:
 
 fdir@^6.2.0:
   version "6.5.0"
-  resolved "https://registry.yarnpkg.com/fdir/-/fdir-6.5.0.tgz#ed2ab967a331ade62f18d077dae192684d50d350"
+  resolved "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz"
   integrity sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==
 
 fecha@^4.2.0:
@@ -10231,22 +10233,21 @@ fetch-blob@^3.1.2, fetch-blob@^3.1.4:
     node-domexception "^1.0.0"
     web-streams-polyfill "^3.0.3"
 
-fetch-sparql-endpoint@^5.1.0:
-  version "5.1.0"
-  resolved "https://registry.npmjs.org/fetch-sparql-endpoint/-/fetch-sparql-endpoint-5.1.0.tgz"
-  integrity sha512-ylROBEdVOVzaGdngq3hSGuA/cDtmRiMmPMU75dsu9xatdKEtU39vRp3HbVxdgzqDDX4HU0FnTBQ/+ciMaEBdbA==
+fetch-sparql-endpoint@^6.2.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/fetch-sparql-endpoint/-/fetch-sparql-endpoint-6.2.0.tgz#a9989ca5d46ba68824bd64f6b98fba78bf39e0f9"
+  integrity sha512-NDbTgK2dPcNA4P2mXVZDbwIA3DY2k2TpEF5+GmCsCNrIbAnAl938JU41SZ2sCSkBXvBoVvb2q5eJ0u7W4K5aog==
   dependencies:
-    "@rdfjs/types" "*"
     "@types/n3" "^1.0.0"
     "@types/readable-stream" "^4.0.0"
     "@types/sparqljs" "^3.0.0"
     is-stream "^2.0.0"
     n3 "^1.0.0"
-    rdf-string "^1.0.0"
+    rdf-string "^2.0.0"
     readable-from-web "^1.0.0"
     sparqljs "^3.0.0"
-    sparqljson-parse "^2.0.0"
-    sparqlxml-parse "^2.0.0"
+    sparqljson-parse "^3.0.0"
+    sparqlxml-parse "^3.0.0"
     stream-to-string "^1.0.0"
     yargs "^17.0.0"
 
@@ -10267,9 +10268,9 @@ file-entry-cache@^6.0.1:
     token-types "^4.1.1"
 
 file-type@^21.0.0, file-type@^21.3.2:
-  version "21.3.2"
-  resolved "https://registry.yarnpkg.com/file-type/-/file-type-21.3.2.tgz#b28bb3a19ea4b03f59af31546b9d95ee8a3623eb"
-  integrity sha512-DLkUvGwep3poOV2wpzbHCOnSKGk1LzyXTv+aHFgN2VFl96wnp8YA9YjO2qPzg5PuL8q/SW9Pdi6WTkYOIh995w==
+  version "21.3.4"
+  resolved "https://registry.npmjs.org/file-type/-/file-type-21.3.4.tgz"
+  integrity sha512-Ievi/yy8DS3ygGvT47PjSfdFoX+2isQueoYP1cntFW1JLYAuS4GD7NUPGg4zv2iZfV52uDyk5w5Z0TdpRS6Q1g==
   dependencies:
     "@tokenizer/inflate" "^0.4.1"
     strtok3 "^10.3.4"
@@ -10330,9 +10331,9 @@ flat@^5.0.2:
   integrity sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==
 
 flatted@^3.2.9:
-  version "3.4.2"
-  resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.4.2.tgz#f5c23c107f0f37de8dbdf24f13722b3b98d52726"
-  integrity sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==
+  version "3.3.3"
+  resolved "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz"
+  integrity sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==
 
 fn.name@1.x.x:
   version "1.1.0"
@@ -10416,7 +10417,7 @@ fs.realpath@^1.0.0:
 
 fsevents@^2.3.2, fsevents@~2.3.2, fsevents@~2.3.3:
   version "2.3.3"
-  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.3.tgz#cac6407785d03675a2a5e1a5305c697b347d90d6"
+  resolved "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz"
   integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
 
 function-bind@^1.1.2:
@@ -10429,7 +10430,22 @@ function-timeout@^0.1.0:
   resolved "https://registry.npmjs.org/function-timeout/-/function-timeout-0.1.1.tgz"
   integrity sha512-0NVVC0TaP7dSTvn1yMiy6d6Q8gifzbvQafO46RtLG/kHJUBNd+pVRGOBoK44wNBvtSPUJRfdVvkFdD3p0xvyZg==
 
-function.prototype.name@^1.1.6, function.prototype.name@^1.1.8:
+function.prototype.name@^1.1.6:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/function.prototype.name/-/function.prototype.name-1.2.0.tgz#758f3e84fa542672454bd5e14cb081a5ce07f70c"
+  integrity sha512-jObKIik1P2QjPHP5nz5BaOtUlfgS0fWo8IUByNXkM+o+02sJOi94em77GwJKQSJ3gfPHdgzLNrHc1uokV4P/ew==
+  dependencies:
+    call-bind "^1.0.9"
+    call-bound "^1.0.4"
+    es-define-property "^1.0.1"
+    es-errors "^1.3.0"
+    functions-have-names "^1.2.3"
+    has-property-descriptors "^1.0.2"
+    hasown "^2.0.4"
+    is-callable "^1.2.7"
+    is-document.all "^1.0.0"
+
+function.prototype.name@^1.1.8:
   version "1.1.8"
   resolved "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.8.tgz"
   integrity sha512-e5iwyodOHhbMr/yNrc7fDYG4qlbIvI5gajyzPnb5TCwyhjApznQh1BMFou9b30SevY43gCJKXycoCBjMbsuW0Q==
@@ -10458,7 +10474,7 @@ get-caller-file@^2.0.5:
 
 get-intrinsic@^1.1.3, get-intrinsic@^1.2.2, get-intrinsic@^1.2.4, get-intrinsic@^1.2.5, get-intrinsic@^1.2.6, get-intrinsic@^1.2.7, get-intrinsic@^1.3.0:
   version "1.3.0"
-  resolved "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz"
+  resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.3.0.tgz#743f0e3b6964a93a5491ed1bffaae054d7f98d01"
   integrity sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==
   dependencies:
     call-bind-apply-helpers "^1.0.2"
@@ -10524,9 +10540,9 @@ glob-parent@^6.0.2:
     is-glob "^4.0.3"
 
 glob@^10.3.7, glob@^10.4.1:
-  version "10.4.5"
-  resolved "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz"
-  integrity sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==
+  version "10.5.0"
+  resolved "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz"
+  integrity sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==
   dependencies:
     foreground-child "^3.1.0"
     jackspeak "^3.1.2"
@@ -10627,13 +10643,13 @@ graphql-to-sparql@^4.0.0:
     sparqlalgebrajs "^4.0.0"
 
 graphql@^15.5.2:
-  version "15.10.1"
-  resolved "https://registry.npmjs.org/graphql/-/graphql-15.10.1.tgz"
-  integrity sha512-BL/Xd/T9baO6NFzoMpiMD7YUZ62R6viR5tp/MULVEnbYJXZA//kRNW7J0j1w/wXArgL0sCxhDfK5dczSKn3+cg==
+  version "15.10.2"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-15.10.2.tgz#f57f8665cea9e77a80264d7eeb0d687079714e78"
+  integrity sha512-1PRqdDPAmViWr4h1GVBT8RoPZfWSGZa7kDzleTilOfVIslsgf+cia3Nl95v1KDmR4iERPaT7WzQ+tN4MJmbg3w==
 
 has-bigints@^1.0.2:
   version "1.1.0"
-  resolved "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz"
+  resolved "https://registry.yarnpkg.com/has-bigints/-/has-bigints-1.1.0.tgz#28607e965ac967e03cd2a2c70a2636a1edad49fe"
   integrity sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==
 
 has-flag@^4.0.0:
@@ -10667,14 +10683,15 @@ has-tostringtag@^1.0.2:
   dependencies:
     has-symbols "^1.0.3"
 
-hash-base@^3.0.0:
-  version "3.1.0"
-  resolved "https://registry.npmjs.org/hash-base/-/hash-base-3.1.0.tgz"
-  integrity sha512-1nmYp/rhMDiE7AYkDw+lLwlAzz0AntGIe51F3RfFfEqyQ3feY2eI/NcwC6umIQVOASPMsWJLJScWKSSvzL9IVA==
+hash-base@^3.0.0, hash-base@^3.1.2:
+  version "3.1.2"
+  resolved "https://registry.npmjs.org/hash-base/-/hash-base-3.1.2.tgz"
+  integrity sha512-Bb33KbowVTIj5s7Ked1OsqHUeCpz//tPwR+E2zJgJKo9Z5XolZ9b6bdUgjmYlwnWhoOQKoTd1TYToZGn5mAYOg==
   dependencies:
     inherits "^2.0.4"
-    readable-stream "^3.6.0"
-    safe-buffer "^5.2.0"
+    readable-stream "^2.3.8"
+    safe-buffer "^5.2.1"
+    to-buffer "^1.2.1"
 
 hash-wasm@^4.12.0:
   version "4.12.0"
@@ -10706,6 +10723,13 @@ hasown@^2.0.2:
   version "2.0.2"
   resolved "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz"
   integrity sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==
+  dependencies:
+    function-bind "^1.1.2"
+
+hasown@^2.0.3, hasown@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/hasown/-/hasown-2.0.4.tgz#8c62d8cb90beb2aad5d0a5b67581ad9854c3f003"
+  integrity sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==
   dependencies:
     function-bind "^1.1.2"
 
@@ -10794,9 +10818,9 @@ http-link-header@^1.0.2:
   integrity sha512-3cZ0SRL8fb9MUlU3mKM61FcQvPfXx2dBrZW3Vbg5CXa8jFlK8OaEpePenLe1oEXQduhz8b0QjsqfS59QP4AJDQ==
 
 human-id@^4.1.1:
-  version "4.1.1"
-  resolved "https://registry.npmjs.org/human-id/-/human-id-4.1.1.tgz"
-  integrity sha512-3gKm/gCSUipeLsRYZbbdA1BD83lBoWUkZ7G9VFrhWPAU76KwYo5KR8V28bpoPm/ygy0x5/GCbpRQdY7VLYCoIg==
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/human-id/-/human-id-4.2.0.tgz#9a60548267dd8c8a012b0b8e7667e6cd2f1a170e"
+  integrity sha512-K3GbkIWqyvvlpfhBPlbEvD97TtqBpAYA4kt+cn2lD2x2HuohzZCibcA2nOlnJT6exqvJLggoB5nv2dNf192nEA==
 
 human-signals@^2.1.0:
   version "2.1.0"
@@ -10808,10 +10832,10 @@ human-signals@^4.3.0:
   resolved "https://registry.npmjs.org/human-signals/-/human-signals-4.3.1.tgz"
   integrity sha512-nZXjEF2nbo7lIw3mgYjItAfgQXog3OjJogSbKa2CQIIvSGWcKgeJnQlNXip6NglNzYH45nSRiEVimMvYL8DDqQ==
 
-iconv-lite@^0.6.3:
-  version "0.6.3"
-  resolved "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz"
-  integrity sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==
+iconv-lite@^0.7.0:
+  version "0.7.3"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.7.3.tgz#84ee12f963e7de50bc01a13e160a078b3b0f415f"
+  integrity sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==
   dependencies:
     safer-buffer ">= 2.1.2 < 3.0.0"
 
@@ -10826,14 +10850,19 @@ ignore@^5.1.1, ignore@^5.2.0:
   integrity sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==
 
 immutable@^3.8.2:
-  version "3.8.3"
-  resolved "https://registry.yarnpkg.com/immutable/-/immutable-3.8.3.tgz#0a8d2494a94d4b2d4f0e99986e74dd25d1e9a859"
-  integrity sha512-AUY/VyX0E5XlibOmWt10uabJzam1zlYjwiEgQSDc5+UIkFNaF9WM0JxXKaNMGf+F/ffUF+7kRKXM9A7C0xXqMg==
+  version "3.8.2"
+  resolved "https://registry.npmjs.org/immutable/-/immutable-3.8.2.tgz"
+  integrity sha512-15gZoQ38eYjEjxkorfbcgBKBL6R7T459OuK+CpcWt7O3KF4uPCx2tD0uFETlUDIyo+1789crbMhTvQBSR5yBMg==
 
-immutable@^4.1.0, immutable@^4.3.7:
-  version "4.3.8"
-  resolved "https://registry.yarnpkg.com/immutable/-/immutable-4.3.8.tgz#02d183c7727fb2bb1d5d0380da0d779dce9296a7"
-  integrity sha512-d/Ld9aLbKpNwyl0KiM2CT1WYvkitQ1TSvmRtkcV8FKStiDoA7Slzgjmb/1G2yhKM1p0XeNOieaTbFZmU1d3Xuw==
+immutable@^4.1.0:
+  version "4.3.7"
+  resolved "https://registry.npmjs.org/immutable/-/immutable-4.3.7.tgz"
+  integrity sha512-1hqclzwYwjRDFLjcFxOM5AYkkG0rpFPpr1RLPMEuGczoS7YA8gLhy8SWXYRAA/XwfEHpfo3cw5JGioS32fnMRw==
+
+immutable@^5.1.3:
+  version "5.1.9"
+  resolved "https://registry.yarnpkg.com/immutable/-/immutable-5.1.9.tgz#ac23c3a01992ab665e14ac9ffff298f28cd74a0c"
+  integrity sha512-m8nVez3rwrgmWxtLMt1ZYXB2Lv7OKYn/disyxAlSDYAlKSlFoPPfIAmAM/M5xqL4m4C/wAPw7S2/CNaUii1Hxg==
 
 import-fresh@^3.2.1:
   version "3.3.1"
@@ -10864,7 +10893,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@^2.0.1, inherits@^2.0.3, inherits@^2.0.4:
+inherits@2, inherits@^2.0.1, inherits@^2.0.3, inherits@^2.0.4, inherits@~2.0.3:
   version "2.0.4"
   resolved "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -10876,7 +10905,7 @@ ini@~1.3.0:
 
 interface-blockstore@^5.0.0, interface-blockstore@^5.2.10, interface-blockstore@^5.2.9:
   version "5.3.2"
-  resolved "https://registry.npmjs.org/interface-blockstore/-/interface-blockstore-5.3.2.tgz"
+  resolved "https://registry.yarnpkg.com/interface-blockstore/-/interface-blockstore-5.3.2.tgz#0fb32bb94c12ba5211d417b83abd1f34ed785779"
   integrity sha512-oA9Pjkxun/JHAsZrYEyKX+EoPjLciTzidE7wipLc/3YoHDjzsnXRJzAzFJXNUvogtY4g7hIwxArx8+WKJs2RIg==
   dependencies:
     interface-store "^6.0.0"
@@ -10884,7 +10913,7 @@ interface-blockstore@^5.0.0, interface-blockstore@^5.2.10, interface-blockstore@
 
 interface-datastore@^8.0.0, interface-datastore@^8.1.0, interface-datastore@^8.2.11, interface-datastore@^8.3.1:
   version "8.3.2"
-  resolved "https://registry.npmjs.org/interface-datastore/-/interface-datastore-8.3.2.tgz"
+  resolved "https://registry.yarnpkg.com/interface-datastore/-/interface-datastore-8.3.2.tgz#1ae2f78d1cbc7a99421d551fd0cec00b8859399d"
   integrity sha512-R3NLts7pRbJKc3qFdQf+u40hK8XWc0w4Qkx3OFEstC80VoaDUABY/dXA2EJPhtNC+bsrf41Ehvqb6+pnIclyRA==
   dependencies:
     interface-store "^6.0.0"
@@ -10897,7 +10926,7 @@ interface-store@^5.0.0, interface-store@^5.1.7, interface-store@^5.1.8:
 
 interface-store@^6.0.0:
   version "6.0.3"
-  resolved "https://registry.npmjs.org/interface-store/-/interface-store-6.0.3.tgz"
+  resolved "https://registry.yarnpkg.com/interface-store/-/interface-store-6.0.3.tgz#a4443490976f52e1b40ff99ddfbc690dfbb00863"
   integrity sha512-+WvfEZnFUhRwFxgz+QCQi7UC6o9AM0EHM9bpIe2Nhqb100NHCsTvNAn4eJgvgV2/tmLo1MP9nGxQKEcZTAueLA==
 
 internal-slot@^1.1.0:
@@ -10934,7 +10963,7 @@ ipns@^9.0.0:
 
 is-arguments@^1.1.1:
   version "1.2.0"
-  resolved "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz"
+  resolved "https://registry.yarnpkg.com/is-arguments/-/is-arguments-1.2.0.tgz#ad58c6aecf563b78ef2bf04df540da8f5d7d8e1b"
   integrity sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==
   dependencies:
     call-bound "^1.0.2"
@@ -10997,7 +11026,14 @@ is-callable@^1.2.7:
   resolved "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz"
   integrity sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==
 
-is-core-module@^2.13.0, is-core-module@^2.16.0, is-core-module@^2.16.1:
+is-core-module@^2.13.0, is-core-module@^2.16.1:
+  version "2.16.2"
+  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.16.2.tgz#3e07450a8080ebce3fbf0cac494f4d2ab324e082"
+  integrity sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==
+  dependencies:
+    hasown "^2.0.3"
+
+is-core-module@^2.16.0:
   version "2.16.1"
   resolved "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz"
   integrity sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==
@@ -11020,6 +11056,13 @@ is-date-object@^1.0.5, is-date-object@^1.1.0:
   dependencies:
     call-bound "^1.0.2"
     has-tostringtag "^1.0.2"
+
+is-document.all@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-document.all/-/is-document.all-1.0.0.tgz#163a4bfb362c6ed7b118ce46cdecc4e37dee3195"
+  integrity sha512-+XSoyS05OdBbhFuELhgTCpFNHkpBOJqtsZfUFFpe5QTw+9Sjbh8zitxhQkYAo6wV7e1Vb8cAPvpCk9jGam/82g==
+  dependencies:
+    call-bound "^1.0.4"
 
 is-electron@^2.2.0:
   version "2.2.2"
@@ -11220,14 +11263,14 @@ is-weakmap@^2.0.2:
 
 is-weakref@^1.0.2, is-weakref@^1.1.1:
   version "1.1.1"
-  resolved "https://registry.npmjs.org/is-weakref/-/is-weakref-1.1.1.tgz"
+  resolved "https://registry.yarnpkg.com/is-weakref/-/is-weakref-1.1.1.tgz#eea430182be8d64174bd96bffbc46f21bf3f9293"
   integrity sha512-6i9mGWSlqzNMEqpCp93KwRS1uUOodk2OJ6b+sq7ZPDSy2WuI5NFIxp/254TytR8ftefexkWn5xNiHUNpPOfSew==
   dependencies:
     call-bound "^1.0.3"
 
 is-weakset@^2.0.3:
   version "2.0.4"
-  resolved "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.4.tgz"
+  resolved "https://registry.yarnpkg.com/is-weakset/-/is-weakset-2.0.4.tgz#c9f5deb0bc1906c6d6f1027f284ddf459249daca"
   integrity sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==
   dependencies:
     call-bound "^1.0.3"
@@ -11242,6 +11285,11 @@ isarray@^2.0.5:
   version "2.0.5"
   resolved "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz"
   integrity sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==
+
+isarray@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+  integrity sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==
 
 isexe@^2.0.0:
   version "2.0.0"
@@ -11314,16 +11362,16 @@ istanbul-lib-source-maps@^5.0.6:
 
 istanbul-reports@^3.1.3, istanbul-reports@^3.1.7:
   version "3.2.0"
-  resolved "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz"
+  resolved "https://registry.yarnpkg.com/istanbul-reports/-/istanbul-reports-3.2.0.tgz#cb4535162b5784aa623cee21a7252cf2c807ac93"
   integrity sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==
   dependencies:
     html-escaper "^2.0.0"
     istanbul-lib-report "^3.0.0"
 
 it-all@^3.0.0, it-all@^3.0.6:
-  version "3.0.9"
-  resolved "https://registry.npmjs.org/it-all/-/it-all-3.0.9.tgz"
-  integrity sha512-fz1oJJ36ciGnu2LntAlE6SA97bFZpW7Rnt0uEc1yazzR2nKokZLr8lIRtgnpex4NsmaBcvHF+Z9krljWFy/mmg==
+  version "3.0.11"
+  resolved "https://registry.yarnpkg.com/it-all/-/it-all-3.0.11.tgz#9c3e7b640c871ada270a18fbb7dee26aa0c70fd7"
+  integrity sha512-Gvqj6MO4GMLnFdtE68HZRpGBskNC+9+GQ+JevTGNYLyhjUuPhjDLU3jN1LpBemXJDW1bRSkczqA/qGyKlPKrcQ==
 
 it-byte-stream@^1.0.0, it-byte-stream@^1.0.12:
   version "1.1.1"
@@ -11335,26 +11383,26 @@ it-byte-stream@^1.0.0, it-byte-stream@^1.0.12:
     uint8arraylist "^2.4.8"
 
 it-drain@^3.0.5, it-drain@^3.0.7:
-  version "3.0.10"
-  resolved "https://registry.npmjs.org/it-drain/-/it-drain-3.0.10.tgz"
-  integrity sha512-0w/bXzudlyKIyD1+rl0xUKTI7k4cshcS43LTlBiGFxI8K1eyLydNPxGcsVLsFVtKh1/ieS8AnVWt6KwmozxyEA==
+  version "3.0.12"
+  resolved "https://registry.yarnpkg.com/it-drain/-/it-drain-3.0.12.tgz#c1f9da36dcd987a2108b47ef3595ce2046158843"
+  integrity sha512-RaFA9X1PF2Pf1Jlqhgf5PlXLgf6CaZt7tSzhia+EkEVcAJRKa0Uhr8UnjVv0GmOA3Air9jDJfIX2KIvz5hZ1Ag==
 
 it-filter@^3.0.4:
-  version "3.1.4"
-  resolved "https://registry.npmjs.org/it-filter/-/it-filter-3.1.4.tgz"
-  integrity sha512-80kWEKgiFEa4fEYD3mwf2uygo1dTQ5Y5midKtL89iXyjinruA/sNXl6iFkTcdNedydjvIsFhWLiqRPQP4fAwWQ==
+  version "3.1.6"
+  resolved "https://registry.yarnpkg.com/it-filter/-/it-filter-3.1.6.tgz#9dc2fb545bdaa6c3751961fa767aba6fa9cbd8d4"
+  integrity sha512-yXiGPAvJn/exXjVFSCMQc3+J/7RLpOMwKoY2DH1yMhF4lYkdRoAdOwU0vnDACAlRAexf7AZvESZIc9mzhEoi/A==
   dependencies:
     it-peekable "^3.0.0"
 
 it-first@^3.0.1, it-first@^3.0.3, it-first@^3.0.4, it-first@^3.0.6:
-  version "3.0.9"
-  resolved "https://registry.npmjs.org/it-first/-/it-first-3.0.9.tgz"
-  integrity sha512-ZWYun273Gbl7CwiF6kK5xBtIKR56H1NoRaiJek2QzDirgen24u8XZ0Nk+jdnJSuCTPxC2ul1TuXKxu/7eK6NuA==
+  version "3.0.11"
+  resolved "https://registry.yarnpkg.com/it-first/-/it-first-3.0.11.tgz#e59f9659ceb20b8fc1f2d862106fe24f9ce84f47"
+  integrity sha512-0ig8DKpg09V1o7JBagm3oPx3VY7WYfU5w3lpbLbqzijnfMPSvMGoMZuLm17h/RgOJXKP+9mt7vsCNiU2TW8TkQ==
 
 it-foreach@^2.0.6:
-  version "2.1.4"
-  resolved "https://registry.npmjs.org/it-foreach/-/it-foreach-2.1.4.tgz"
-  integrity sha512-gFntBbNLpVK9uDmaHusugICD8/Pp+OCqbF5q1Z8K+B8WaG20YgMePWbMxI1I25+JmNWWr3hk0ecKyiI9pOLgeA==
+  version "2.1.7"
+  resolved "https://registry.yarnpkg.com/it-foreach/-/it-foreach-2.1.7.tgz#080aba3e0b682e3aaa9983c4846574d4e2380dce"
+  integrity sha512-HoZgIF7DGU1X/8svRuJ7aPl6sge8W6MQxmMomkeAABNXJXoiXEU0xnvulzncRdd013Kh9SubXWhx6YjYw6lu5A==
   dependencies:
     it-peekable "^3.0.0"
 
@@ -11380,28 +11428,28 @@ it-length-prefixed@^9.0.0, it-length-prefixed@^9.0.1, it-length-prefixed@^9.0.4:
     uint8arrays "^5.0.1"
 
 it-length@^3.0.6:
-  version "3.0.9"
-  resolved "https://registry.npmjs.org/it-length/-/it-length-3.0.9.tgz"
-  integrity sha512-cPhRPzyulYqyL7x4sX4MOjG/xu3vvEIFAhJ1aCrtrnbfxloCOtejOONib5oC3Bz8tLL6b6ke6+YHu4Bm6HCG7A==
+  version "3.0.11"
+  resolved "https://registry.yarnpkg.com/it-length/-/it-length-3.0.11.tgz#f3d43d1368e2bc289b53c8ef8a27a0a535f0bcf0"
+  integrity sha512-j0uukHdr3zoLm4dcozDoyv5khQrOI8dfXMSSEqaxorfOtleh1KwRVbdnTmzj6HVkHgTM1jcx+bhAcnTkbpHl+g==
 
 it-map@^3.0.4, it-map@^3.0.5, it-map@^3.1.0:
-  version "3.1.4"
-  resolved "https://registry.npmjs.org/it-map/-/it-map-3.1.4.tgz"
-  integrity sha512-QB9PYQdE9fUfpVFYfSxBIyvKynUCgblb143c+ktTK6ZuKSKkp7iH58uYFzagqcJ5HcqIfn1xbfaralHWam+3fg==
+  version "3.1.6"
+  resolved "https://registry.yarnpkg.com/it-map/-/it-map-3.1.6.tgz#087ffa2710b8deb5067c254ba3f8059d368abdef"
+  integrity sha512-wCix0FXImtIPIxhCnbz35RqWs00e/CReSZX9nZq1j46JcAzBBp57ob9/2l1WnDYEaUURIR8xCyg2NsWbOwBJFQ==
   dependencies:
     it-peekable "^3.0.0"
 
 it-merge@^3.0.0, it-merge@^3.0.3, it-merge@^3.0.5:
-  version "3.0.12"
-  resolved "https://registry.npmjs.org/it-merge/-/it-merge-3.0.12.tgz"
-  integrity sha512-nnnFSUxKlkZVZD7c0jYw6rDxCcAQYcMsFj27thf7KkDhpj0EA0g9KHPxbFzHuDoc6US2EPS/MtplkNj8sbCx4Q==
+  version "3.0.14"
+  resolved "https://registry.yarnpkg.com/it-merge/-/it-merge-3.0.14.tgz#6469dab1a2f9ca718d26944f7aa1e4eb7a875d72"
+  integrity sha512-D3t1Go2G2SQMkTujaA6EVojJPJKA9pFksxlSPDRBfrHKhWl6O40vEP7Itr5eCAjyCQH5p9+BFFVIy9bhLM4ZuQ==
   dependencies:
     it-queueless-pushable "^2.0.0"
 
 it-ndjson@^1.0.4:
-  version "1.1.4"
-  resolved "https://registry.npmjs.org/it-ndjson/-/it-ndjson-1.1.4.tgz"
-  integrity sha512-ZMgTUrNo/UQCeRUT3KqnC0UaClzU6D+ItSmzVt7Ks7pcJ7DboYeYBSPeFLAaEthf5zlvaApDuACLmOWepgkrRg==
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/it-ndjson/-/it-ndjson-1.1.6.tgz#684aab5e76a14d624acc308c2b445722160eb3b5"
+  integrity sha512-qseYKspd95qnYUnJ2DE8R25N2+Q+cPCEXTTpyLe7FHaxjbOc/wtyOgKbuzJrQS9bnFJ6yM9wVooC3C0pX44IWQ==
   dependencies:
     uint8arraylist "^2.4.8"
 
@@ -11414,16 +11462,16 @@ it-pair@^2.0.6:
     p-defer "^4.0.0"
 
 it-parallel@^3.0.7:
-  version "3.0.13"
-  resolved "https://registry.npmjs.org/it-parallel/-/it-parallel-3.0.13.tgz"
-  integrity sha512-85PPJ/O8q97Vj9wmDTSBBXEkattwfQGruXitIzrh0RLPso6RHfiVqkuTqBNufYYtB1x6PSkh0cwvjmMIkFEPHA==
+  version "3.0.16"
+  resolved "https://registry.yarnpkg.com/it-parallel/-/it-parallel-3.0.16.tgz#444c4e06720766682fb36d49a3fe1ec53206ba33"
+  integrity sha512-qr3nTgj4fraSfr6Ix9JkHsy/Yb/4vmS3QIAu3fsX52r2SOTLbohXoixKp6AIhTJcorpKwjP0VFcpHr5V54jivA==
   dependencies:
     p-defer "^4.0.1"
 
 it-peekable@^3.0.0:
-  version "3.0.8"
-  resolved "https://registry.npmjs.org/it-peekable/-/it-peekable-3.0.8.tgz"
-  integrity sha512-7IDBQKSp/dtBxXV3Fj0v3qM1jftJ9y9XrWLRIuU1X6RdKqWiN60syNwP0fiDxZD97b8SYM58dD3uklIk1TTQAw==
+  version "3.0.10"
+  resolved "https://registry.yarnpkg.com/it-peekable/-/it-peekable-3.0.10.tgz#bd4be5de24cf1d052cab4b0e89618991908000a0"
+  integrity sha512-2E6+p1pelZOhzp69aaiiBuEybWzAl10uYbIdCR3Pxy8bFNnS/kgpbLtGbNbIZ6RVdU7yHHkmATYwjy52GfFEKA==
 
 it-pipe@^3.0.1:
   version "3.0.1"
@@ -11451,15 +11499,15 @@ it-pushable@^3.1.2, it-pushable@^3.2.3:
     p-defer "^4.0.0"
 
 it-queue@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.npmjs.org/it-queue/-/it-queue-1.1.0.tgz"
-  integrity sha512-aK9unJRIaJc9qiv53LByhF7/I2AuD7Ro4oLfLieVLL9QXNvRx++ANMpv8yCp2UO0KAtBuf70GOxSYb6ElFVRpQ==
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/it-queue/-/it-queue-1.1.4.tgz#bb5f1ced9b2942b496645cafc2e590b39dbe829b"
+  integrity sha512-cGH0+YfMPmwQ+lV+MhJcOXqOgE04h0zQCXvDUmvGGTyW0VqxJZbi7V+PQFEuPVN/5dHQg5RY9aVjMCgmxXaE5Q==
   dependencies:
-    abort-error "^1.0.1"
+    abort-error "^1.0.2"
     it-pushable "^3.2.3"
-    main-event "^1.0.0"
-    race-event "^1.3.0"
-    race-signal "^1.1.3"
+    main-event "^1.0.1"
+    race-event "^1.6.1"
+    race-signal "^2.0.0"
 
 it-queueless-pushable@^1.0.0:
   version "1.0.2"
@@ -11470,13 +11518,13 @@ it-queueless-pushable@^1.0.0:
     race-signal "^1.1.3"
 
 it-queueless-pushable@^2.0.0:
-  version "2.0.2"
-  resolved "https://registry.npmjs.org/it-queueless-pushable/-/it-queueless-pushable-2.0.2.tgz"
-  integrity sha512-2BqIt7XvDdgEgudLAdJkdseAwbVSBc0yAd8yPVHrll4eBuJPWIj9+8C3OIxzEKwhswLtd3bi+yLrzgw9gCyxMA==
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/it-queueless-pushable/-/it-queueless-pushable-2.0.5.tgz#893a8e0282f8d5b02239b0075fe594b9776296ed"
+  integrity sha512-BaKqGLL1AQMR1AEaxiM09vzJQVXHHhfhh9UV0qPqORw/8Rm8igDQqT1qHregfHIb1NIW9jxQ/aXBibHJyuivuQ==
   dependencies:
-    abort-error "^1.0.1"
+    abort-error "^1.0.2"
     p-defer "^4.0.1"
-    race-signal "^1.1.3"
+    race-signal "^2.0.0"
 
 it-reader@^6.0.1:
   version "6.0.4"
@@ -11487,9 +11535,9 @@ it-reader@^6.0.1:
     uint8arraylist "^2.0.0"
 
 it-sort@^3.0.4:
-  version "3.0.9"
-  resolved "https://registry.npmjs.org/it-sort/-/it-sort-3.0.9.tgz"
-  integrity sha512-jsM6alGaPiQbcAJdzMsuMh00uJcI+kD9TBoScB8TR75zUFOmHvhSsPi+Dmh2zfVkcoca+14EbfeIZZXTUGH63w==
+  version "3.0.11"
+  resolved "https://registry.yarnpkg.com/it-sort/-/it-sort-3.0.11.tgz#663aadd9e7a8e68df0bf0fcd32ce69bbca3b7df8"
+  integrity sha512-eZ22LAoNLx4i4gVV44tJPoUYf/o+mHKa6+OigdVH/hmsdA2qoJN6MNPvKZyZKBf6+S/8PBE44zyvkzdYGkRhbA==
   dependencies:
     it-all "^3.0.0"
 
@@ -11499,9 +11547,9 @@ it-stream-types@^2.0.1, it-stream-types@^2.0.2:
   integrity sha512-Rz/DEZ6Byn/r9+/SBCuJhpPATDF9D+dz5pbgSUyBsCDtza6wtNATrz/jz1gDyNanC3XdLboriHnOC925bZRBww==
 
 it-take@^3.0.1, it-take@^3.0.4, it-take@^3.0.5:
-  version "3.0.9"
-  resolved "https://registry.npmjs.org/it-take/-/it-take-3.0.9.tgz"
-  integrity sha512-XMeUbnjOcgrhFXPUqa7H0VIjYSV/BvyxxjCp76QHVAFDJw2LmR1SHxUFiqyGeobgzJr7P2ZwSRRJQGn4D2BVlA==
+  version "3.0.11"
+  resolved "https://registry.yarnpkg.com/it-take/-/it-take-3.0.11.tgz#46b709b01a77cecabd30bf3d3f3b0f4d56404f0a"
+  integrity sha512-zvoeEjLViGFyhYT5KNCgmcIH90Si8lCve4aTMvgej/ZQRfB9YzrcJW3UHIJjbQ9TiAnsT4vsWDImEFQNk5xmnA==
 
 it-ws@^6.1.1:
   version "6.1.5"
@@ -11896,18 +11944,18 @@ jose@^4.3.8:
   integrity sha512-1vUQX+IdDMVPj4k8kOxgUqlcK518yluMuGZwqlr44FS1ppZB/5GWh4rZG89erpOBOJjU/OBsnCVFfapsRz6nEA==
 
 jose@^6.2.3:
-  version "6.2.3"
-  resolved "https://registry.yarnpkg.com/jose/-/jose-6.2.3.tgz#0975197ad973251221c658a3cddc4b951a250c2d"
-  integrity sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==
+  version "6.2.8"
+  resolved "https://registry.npmjs.org/jose/-/jose-6.2.8.tgz"
+  integrity sha512-Bsdjwm3Qsd/P0jR+BHDe3LytDfY7WBq2HmCCLIwuVRHMuEC9ae7/R474GIUdF1NgCyZjzVo/A9DOiOBtXq8ZoQ==
 
 js-base64@^3.7.6:
-  version "3.7.8"
-  resolved "https://registry.npmjs.org/js-base64/-/js-base64-3.7.8.tgz"
-  integrity sha512-hNngCeKxIUQiEUN3GPJOkz4wF/YvdUdbNL9hsBcMQTkKzboD7T/q3OYOuuPZLUE6dBxSGpwhk5mwuDud7JVAow==
+  version "3.9.2"
+  resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-3.9.2.tgz#e40151b78f76d3294340edbb79b231ba82193ba1"
+  integrity sha512-6zayE8QlUdiweYI6cETD/XBSqFcoCUlufn/29PJR99r82x1yDnIprRca0YvAYpAW+ez0GuQkVBC6xG5QkD7OjA==
 
 js-sha256@^0.11.0:
   version "0.11.1"
-  resolved "https://registry.npmjs.org/js-sha256/-/js-sha256-0.11.1.tgz"
+  resolved "https://registry.yarnpkg.com/js-sha256/-/js-sha256-0.11.1.tgz#712262e8fc9569d6f7f6eea72c0d8e5ccc7c976c"
   integrity sha512-o6WSo/LUvY2uC4j7mO50a2ms7E/EAdbP0swigLV+nzHKTTaYnaLIWJ02VdXrsJX0vGedDESQnLsOekr94ryfjg==
 
 js-sha3@0.5.5:
@@ -11931,17 +11979,24 @@ js-tokens@^4.0.0:
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
 js-yaml@^3.13.1, js-yaml@^3.6.1:
-  version "3.14.2"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.14.2.tgz#77485ce1dd7f33c061fd1b16ecea23b55fcb04b0"
-  integrity sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==
+  version "3.14.1"
+  resolved "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz"
+  integrity sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"
 
 js-yaml@^4.1.0:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.1.1.tgz#854c292467705b699476e1a2decc0c8a3458806b"
-  integrity sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==
+  version "4.1.0"
+  resolved "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz"
+  integrity sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==
+  dependencies:
+    argparse "^2.0.1"
+
+js-yaml@^4.1.1:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.3.1.tgz#01216c001d67f48e2cd560d708c7af21090a3848"
+  integrity sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==
   dependencies:
     argparse "^2.0.1"
 
@@ -11983,15 +12038,10 @@ jsep@^1.4.0:
   resolved "https://registry.npmjs.org/jsep/-/jsep-1.4.0.tgz"
   integrity sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==
 
-jsesc@^3.0.2:
+jsesc@^3.0.2, jsesc@~3.1.0:
   version "3.1.0"
   resolved "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz"
   integrity sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==
-
-jsesc@~3.0.2:
-  version "3.0.2"
-  resolved "https://registry.npmjs.org/jsesc/-/jsesc-3.0.2.tgz"
-  integrity sha512-xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g==
 
 json-buffer@3.0.1:
   version "3.0.1"
@@ -12075,12 +12125,12 @@ jsonld-context-parser@^3.0.0:
     http-link-header "^1.0.2"
     relative-to-absolute-iri "^1.0.5"
 
-jsonld-signatures@^9.3.1:
-  version "9.3.1"
-  resolved "https://registry.npmjs.org/jsonld-signatures/-/jsonld-signatures-9.3.1.tgz"
-  integrity sha512-OasKERvvbfbuItVFrb0pOHiclHPvT98IAorayZnEj48/E0Vz3rTPLzC14rDi1CEXjiiTGeNadLzTLdomdeZEAQ==
+jsonld-signatures@^10.0.0:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/jsonld-signatures/-/jsonld-signatures-10.0.0.tgz#7342d70479f8f450148086c96e48517deeaefdf3"
+  integrity sha512-Zvwwm2xO93QUaEi8LQGh96Sk2J9TS/VLTuXP+WiHQzwKEryNs/2r/1dcaGJ2y5uIHCwPB1nYq0W1A+U2uOvHUA==
   dependencies:
-    jsonld "^5.0.0"
+    jsonld "^6.0.0"
     security-context "^4.0.0"
     serialize-error "^8.0.1"
 
@@ -12110,16 +12160,6 @@ jsonld-streaming-serializer@^3.0.1:
     buffer "^6.0.3"
     jsonld-context-parser "^3.0.0"
     readable-stream "^4.0.0"
-
-jsonld@5.2.0, jsonld@^5.0.0:
-  version "5.2.0"
-  resolved "https://registry.npmjs.org/jsonld/-/jsonld-5.2.0.tgz"
-  integrity sha512-JymgT6Xzk5CHEmHuEyvoTNviEPxv6ihLWSPu1gFdtjSAyM6cFqNrv02yS/SIur3BBIkCf0HjizRc24d8/FfQKw==
-  dependencies:
-    "@digitalbazaar/http-client" "^3.2.0"
-    canonicalize "^1.0.1"
-    lru-cache "^6.0.0"
-    rdf-canonize "^3.0.0"
 
 jsonld@^6.0.0:
   version "6.0.0"
@@ -12203,9 +12243,9 @@ ky@^0.33.3:
   integrity sha512-CasD9OCEQSFIam2U8efFK81Yeg8vNMTBUqtMOHlrcWQHqUX3HeCl9Dr31u4toV7emlH8Mymk5+9p0lL6mKb/Xw==
 
 ky@^1.0.1:
-  version "1.8.2"
-  resolved "https://registry.npmjs.org/ky/-/ky-1.8.2.tgz"
-  integrity sha512-XybQJ3d4Ea1kI27DoelE5ZCT3bSJlibYTtQuMsyzKox3TMyayw1asgQdl54WroAm+fIA3ZCr8zXW2RpR7qWVpA==
+  version "1.12.0"
+  resolved "https://registry.npmjs.org/ky/-/ky-1.12.0.tgz"
+  integrity sha512-YRLmSUHCwOJRBMArtqMRLOmO7fewn3yOoui6aB8ERkRVXupa0UiaQaKbIXteMt4jUElhbdqTMsLFHs8APxxUoQ==
 
 leven@^3.1.0:
   version "3.1.0"
@@ -12322,9 +12362,9 @@ lodash.startcase@^4.4.0:
   integrity sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==
 
 lodash@^4.17.15, lodash@^4.17.21:
-  version "4.18.1"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.18.1.tgz#ff2b66c1f6326d59513de2407bf881439812771c"
-  integrity sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==
+  version "4.17.21"
+  resolved "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz"
+  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
 logform@^2.7.0:
   version "2.7.0"
@@ -12415,9 +12455,9 @@ magicast@^0.3.5:
     source-map-js "^1.2.0"
 
 main-event@^1.0.0, main-event@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.npmjs.org/main-event/-/main-event-1.0.1.tgz"
-  integrity sha512-NWtdGrAca/69fm6DIVd8T9rtfDII4Q8NQbIbsKQq2VzS9eqOGYs8uaNQjcuaCq/d9H/o625aOTJX2Qoxzqw0Pw==
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/main-event/-/main-event-1.0.4.tgz#371eb627575ba4379fa35c854b8952208f1fcdc3"
+  integrity sha512-sKazUjIy2Jalv5lkQ446iOcrx8Q7TkaCuk6xfnzg5uUqMusMLDMPmRDmSNE2kjSVpSTJo4j1bQZusS+Ib7Bvrg==
 
 make-dir@^2.0.0, make-dir@^2.1.0:
   version "2.1.0"
@@ -12542,14 +12582,7 @@ minimalistic-crypto-utils@^1.0.1:
   resolved "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz"
   integrity sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg==
 
-minimatch@*:
-  version "10.0.3"
-  resolved "https://registry.npmjs.org/minimatch/-/minimatch-10.0.3.tgz"
-  integrity sha512-IPZ167aShDZZUMdRk66cyQAW3qr0WzbHkPdMYa8bzZhlHhO3jALbKdxcaak7W9FfT2rZNpQuUu4Od7ILEpXSaw==
-  dependencies:
-    "@isaacs/brace-expansion" "^5.0.0"
-
-minimatch@^3.0.4, minimatch@^3.0.5, minimatch@^3.1.1, minimatch@^3.1.2:
+minimatch@*, minimatch@^3.0.4, minimatch@^3.0.5, minimatch@^3.1.1, minimatch@^3.1.2:
   version "3.1.2"
   resolved "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz"
   integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
@@ -12592,7 +12625,7 @@ mkdirp@^1.0.4:
 
 mortice@^3.0.4:
   version "3.3.1"
-  resolved "https://registry.npmjs.org/mortice/-/mortice-3.3.1.tgz"
+  resolved "https://registry.yarnpkg.com/mortice/-/mortice-3.3.1.tgz#ff52db518da2f5f389abf987c01fc190638c6a2f"
   integrity sha512-t3oESfijIPGsmsdLEKjF+grHfrbnKSXflJtgb1wY14cjxZpS6GnhHRXTxxzCAoCCnq1YYfpEPwY3gjiCPhOufQ==
   dependencies:
     abort-error "^1.0.0"
@@ -12644,10 +12677,20 @@ multicast-dns@^7.2.5:
   resolved "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz"
   integrity sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg==
 
-multiformats@^13.0.0, multiformats@^13.0.1, multiformats@^13.1.0, multiformats@^13.3.6:
-  version "13.4.0"
-  resolved "https://registry.npmjs.org/multiformats/-/multiformats-13.4.0.tgz"
-  integrity sha512-Mkb/QcclrJxKC+vrcIFl297h52QcKh2Az/9A5vbWytbQt4225UWWWmIuSsKksdww9NkIeYcA7DkfftyLuC/JSg==
+multiformats@^13.0.0, multiformats@^13.0.1, multiformats@^13.1.0:
+  version "13.4.2"
+  resolved "https://registry.yarnpkg.com/multiformats/-/multiformats-13.4.2.tgz#309ee17d3946db9a6954cf6832aeb2b4b10dd0f3"
+  integrity sha512-eh6eHCrRi1+POZ3dA+Dq1C6jhP1GNtr9CRINMb67OKzqW9I5DUuZM/3jLPlzhgpGeiNUlEGEbkCYChXMCc/8DQ==
+
+multiformats@^13.3.6:
+  version "13.4.1"
+  resolved "https://registry.npmjs.org/multiformats/-/multiformats-13.4.1.tgz"
+  integrity sha512-VqO6OSvLrFVAYYjgsr8tyv62/rCQhPgsZUXLTqoFLSgdkgiUYKYeArbt1uWLlEpkjxQe+P0+sHlbPEte1Bi06Q==
+
+multiformats@^14.0.0:
+  version "14.0.5"
+  resolved "https://registry.yarnpkg.com/multiformats/-/multiformats-14.0.5.tgz#3d9819edefb885d9029cedcae565fd0a8f3052df"
+  integrity sha512-vbIm83F2yZ1pWJGS0yl0ysracIvv56LtbrIyiIQHoLdYDJOMoLfVFsXhh9DUH4SFdkdkFhucyWniihsNzVEjkQ==
 
 multiformats@^9.4.2, multiformats@^9.5.4, multiformats@^9.6.2:
   version "9.9.0"
@@ -12661,8 +12704,16 @@ murmurhash3js-revisited@^3.0.0:
 
 n3@^1.0.0, n3@^1.16.3, n3@^1.17.0, n3@^1.17.4:
   version "1.26.0"
-  resolved "https://registry.npmjs.org/n3/-/n3-1.26.0.tgz"
+  resolved "https://registry.yarnpkg.com/n3/-/n3-1.26.0.tgz#3d69de04bee680b9ebec9dbc1033dc1e6934d351"
   integrity sha512-SQknS0ua90rN+3RHuk8BeIqeYyqIH/+ecViZxX08jR4j6MugqWRjtONl3uANG/crWXnOM2WIqBJtjIhVYFha+w==
+  dependencies:
+    buffer "^6.0.3"
+    readable-stream "^4.0.0"
+
+n3@^2.0.0:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/n3/-/n3-2.1.2.tgz#c75cc9fe0ba694f79f6f492e2ff05287ed25d083"
+  integrity sha512-8DD60rrjJDmeNgLV/zlTiWubxHXLj7te9+uh/IS611fUIgduz4SoeqkOwCQPPpHZ2E/Y26KE+9rm8q8A5mrWvQ==
   dependencies:
     buffer "^6.0.3"
     readable-stream "^4.0.0"
@@ -12698,9 +12749,9 @@ netmask@^2.0.2:
   integrity sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==
 
 node-abi@^3.3.0:
-  version "3.75.0"
-  resolved "https://registry.npmjs.org/node-abi/-/node-abi-3.75.0.tgz"
-  integrity sha512-OhYaY5sDsIka7H7AtijtI9jwGYLyl29eQn/W623DiN/MIv5sUqc4g7BIDThX+gb7di9f6xK02nkp8sdfFWZLTg==
+  version "3.94.0"
+  resolved "https://registry.yarnpkg.com/node-abi/-/node-abi-3.94.0.tgz#007181ed0d1b56ae9670ea6c084d2bf83538405f"
+  integrity sha512-W5ZNO5KRPB5TkYmGVD9F6YqhsglXJzE6etpbmT+f6EQElhiX/UTG551cnsRGvLG3fyZEg9HwaDmNmj5nwJ4z9g==
   dependencies:
     semver "^7.3.5"
 
@@ -12732,7 +12783,7 @@ node-domexception@^1.0.0:
 
 node-domexception@^2.0.1:
   version "2.0.2"
-  resolved "https://registry.npmjs.org/node-domexception/-/node-domexception-2.0.2.tgz"
+  resolved "https://registry.yarnpkg.com/node-domexception/-/node-domexception-2.0.2.tgz#9ac29eb0b97ce65d4c647c1ebcd314d4c2859c4a"
   integrity sha512-Qf9vHK9c5MGgUXj8SnucCIS4oEPuUstjRaMplLGeZpbWMfNV1rvEcXuwoXfN51dUfD1b4muPHPQtCx/5Dj/QAA==
 
 node-environment-flags@^1.0.5:
@@ -12745,7 +12796,7 @@ node-environment-flags@^1.0.5:
 
 node-fetch@^2.7.0:
   version "2.7.0"
-  resolved "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.7.0.tgz#d0f0fa6e3e2dc1d27efcd8ad99d550bda94d187d"
   integrity sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==
   dependencies:
     whatwg-url "^5.0.0"
@@ -12761,7 +12812,7 @@ node-fetch@^3.2.10:
 
 node-gyp-build@^4.2.0:
   version "4.8.4"
-  resolved "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz"
+  resolved "https://registry.yarnpkg.com/node-gyp-build/-/node-gyp-build-4.8.4.tgz#8a70ee85464ae52327772a90d66c6077a900cfc8"
   integrity sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==
 
 node-int64@^0.4.0:
@@ -12769,10 +12820,10 @@ node-int64@^0.4.0:
   resolved "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz"
   integrity sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==
 
-node-releases@^2.0.19:
-  version "2.0.19"
-  resolved "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz"
-  integrity sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==
+node-releases@^2.0.51:
+  version "2.0.52"
+  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.52.tgz#d8283ba25e577a4d9756d5b45eca353ba5500300"
+  integrity sha512-MRlTqhAfoMx/4mhEbPo3Hi02g9LJZaJkka69V6h67Cb1gjrAG0jsTE4CZX1eptNx+VCAwJmfpnDIF4P0Nh1A7A==
 
 normalize-path@^3.0.0, normalize-path@~3.0.0:
   version "3.0.0"
@@ -12833,7 +12884,7 @@ object.assign@^4.1.2, object.assign@^4.1.4, object.assign@^4.1.7:
 
 object.entries@^1.1.2:
   version "1.1.9"
-  resolved "https://registry.npmjs.org/object.entries/-/object.entries-1.1.9.tgz"
+  resolved "https://registry.yarnpkg.com/object.entries/-/object.entries-1.1.9.tgz#e4770a6a1444afb61bd39f984018b5bede25f8b3"
   integrity sha512-8u/hfXFRBD1O0hPUjioLhoWFHRmt6tKA4/vZPyckBr18l1KE9uHrFaFaUi8MDRTpi4uak2goyPTSNJLXX2k2Hw==
   dependencies:
     call-bind "^1.0.8"
@@ -12875,7 +12926,7 @@ object.groupby@^1.0.3:
 
 object.values@^1.2.1:
   version "1.2.1"
-  resolved "https://registry.npmjs.org/object.values/-/object.values-1.2.1.tgz"
+  resolved "https://registry.yarnpkg.com/object.values/-/object.values-1.2.1.tgz#deed520a50809ff7f75a7cfd4bc64c7a038c6216"
   integrity sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==
   dependencies:
     call-bind "^1.0.8"
@@ -12984,7 +13035,7 @@ p-limit@^3.0.2, p-limit@^3.1.0:
 
 p-limit@^6.1.0:
   version "6.2.0"
-  resolved "https://registry.npmjs.org/p-limit/-/p-limit-6.2.0.tgz"
+  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-6.2.0.tgz#c254d22ba6aeef441a3564c5e6c2f2da59268a0f"
   integrity sha512-kuUqqHNUqoIWp/c467RI4X6mmyuojY5jGutNU0wVTmEOOfcuwLqyMVoAi9MKi2Ak+5i9+nhmrK4ufZE8069kHA==
   dependencies:
     yocto-queue "^1.1.1"
@@ -13040,20 +13091,15 @@ package-json-from-dist@^1.0.0:
 
 package-manager-detector@^0.2.0:
   version "0.2.11"
-  resolved "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-0.2.11.tgz"
+  resolved "https://registry.yarnpkg.com/package-manager-detector/-/package-manager-detector-0.2.11.tgz#3af0b34f99d86d24af0a0620603d2e1180d05c9c"
   integrity sha512-BEnLolu+yuz22S56CU1SUKq3XC3PkwD5wv4ikR4MfGvnRVcmzXR9DwSlW2fEamyTPyXHomBJRzgapeuBvRNzJQ==
   dependencies:
     quansync "^0.2.7"
 
-pako@^2.0.4:
+pako@^2.0.4, pako@^2.1.0:
   version "2.1.0"
   resolved "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz"
   integrity sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==
-
-pako@^2.1.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/pako/-/pako-2.2.0.tgz#246b9d4c841a8d308e484c0d03786651b143e63a"
-  integrity sha512-zJq6RP/5q+TO2OpFV3FHzlPnFjmkb7Nc99a5SNjJE+uu/PkpChs+NIZSSzbBoD+6kjiISXjfYdwj1ZRQ81dz/w==
 
 parent-module@^1.0.0:
   version "1.0.1"
@@ -13146,14 +13192,14 @@ picocolors@^1.1.0, picocolors@^1.1.1:
   integrity sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==
 
 picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.2.2, picomatch@^2.2.3, picomatch@^2.3.1:
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.2.tgz#5a942915e26b372dc0f0e6753149a16e6b1c5601"
-  integrity sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==
+  version "2.3.1"
+  resolved "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz"
+  integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
 
 picomatch@^4.0.2:
-  version "4.0.4"
-  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-4.0.4.tgz#fd6f5e00a143086e074dffe4c924b8fb293b0589"
-  integrity sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==
+  version "4.0.5"
+  resolved "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz"
+  integrity sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==
 
 pify@^4.0.1:
   version "4.0.1"
@@ -13162,7 +13208,7 @@ pify@^4.0.1:
 
 pirates@^4.0.4, pirates@^4.0.6:
   version "4.0.7"
-  resolved "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz"
+  resolved "https://registry.yarnpkg.com/pirates/-/pirates-4.0.7.tgz#643b4a18c4257c8a65104b73f3049ce9a0a15e22"
   integrity sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==
 
 pkg-dir@^3.0.0:
@@ -13181,7 +13227,7 @@ pkg-dir@^4.2.0:
 
 possible-typed-array-names@^1.0.0:
   version "1.1.0"
-  resolved "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz"
+  resolved "https://registry.yarnpkg.com/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz#93e3582bc0e5426586d9d07b79ee40fc841de4ae"
   integrity sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==
 
 postcss@^8.4.43:
@@ -13235,6 +13281,11 @@ pretty-format@^29.0.0, pretty-format@^29.7.0:
     ansi-styles "^5.0.0"
     react-is "^18.0.0"
 
+process-nextick-args@~2.0.0:
+  version "2.0.1"
+  resolved "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz"
+  integrity sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==
+
 process@^0.11.10:
   version "0.11.10"
   resolved "https://registry.npmjs.org/process/-/process-0.11.10.tgz"
@@ -13285,7 +13336,7 @@ protobufjs@^6.8.8, protobufjs@~6.11.2, protobufjs@~6.11.3:
     "@types/node" ">=13.7.0"
     long "^4.0.0"
 
-protobufjs@^7.4.0:
+protobufjs@^7.4.0, protobufjs@^7.5.3:
   version "7.5.4"
   resolved "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz"
   integrity sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==
@@ -13303,37 +13354,28 @@ protobufjs@^7.4.0:
     "@types/node" ">=13.7.0"
     long "^5.0.0"
 
-protobufjs@^8.0.0:
-  version "8.0.0"
-  resolved "https://registry.npmjs.org/protobufjs/-/protobufjs-8.0.0.tgz"
-  integrity sha512-jx6+sE9h/UryaCZhsJWbJtTEy47yXoGNYI4z8ZaRncM0zBKeRqjO2JEcOUYwrYGb1WLhXM1FfMzW3annvFv0rw==
-  dependencies:
-    "@protobufjs/aspromise" "^1.1.2"
-    "@protobufjs/base64" "^1.1.2"
-    "@protobufjs/codegen" "^2.0.4"
-    "@protobufjs/eventemitter" "^1.1.0"
-    "@protobufjs/fetch" "^1.1.0"
-    "@protobufjs/float" "^1.0.2"
-    "@protobufjs/inquire" "^1.1.0"
-    "@protobufjs/path" "^1.1.2"
-    "@protobufjs/pool" "^1.1.0"
-    "@protobufjs/utf8" "^1.1.0"
-    "@types/node" ">=13.7.0"
-    long "^5.0.0"
-
-protons-runtime@^5.0.0, protons-runtime@^5.2.1, protons-runtime@^5.4.0, protons-runtime@^5.5.0:
+protons-runtime@^5.0.0, protons-runtime@^5.2.1, protons-runtime@^5.4.0:
   version "5.6.0"
-  resolved "https://registry.npmjs.org/protons-runtime/-/protons-runtime-5.6.0.tgz"
+  resolved "https://registry.yarnpkg.com/protons-runtime/-/protons-runtime-5.6.0.tgz#df1ef57497d04529a23ee6020f1c24f1d15db141"
   integrity sha512-/Kde+sB9DsMFrddJT/UZWe6XqvL7SL5dbag/DBCElFKhkwDj7XKt53S+mzLyaDP5OqS0wXjV5SA572uWDaT0Hg==
   dependencies:
     uint8-varint "^2.0.2"
     uint8arraylist "^2.4.3"
     uint8arrays "^5.0.1"
 
+protons-runtime@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/protons-runtime/-/protons-runtime-7.0.0.tgz#4d4a851f873ed91620965661642aa75b88f04a4b"
+  integrity sha512-r/e72006xoVND4Uvf1aIs4OQOkJaASBU3ip4DzOWAktoKAkTiOYqKoS3TYMBm8HnnYU8+h0uEzr5gIRwk/pmTg==
+  dependencies:
+    uint8-varint "^3.0.0"
+    uint8arraylist "^3.0.0"
+    uint8arrays "^6.0.0"
+
 pump@^3.0.0:
-  version "3.0.3"
-  resolved "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz"
-  integrity sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/pump/-/pump-3.0.4.tgz#1f313430527fa8b905622ebd22fe1444e757ab3c"
+  integrity sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==
   dependencies:
     end-of-stream "^1.1.0"
     once "^1.3.1"
@@ -13350,19 +13392,19 @@ pure-rand@^6.0.0:
 
 pvtsutils@^1.3.5, pvtsutils@^1.3.6:
   version "1.3.6"
-  resolved "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.3.6.tgz"
+  resolved "https://registry.yarnpkg.com/pvtsutils/-/pvtsutils-1.3.6.tgz#ec46e34db7422b9e4fdc5490578c1883657d6001"
   integrity sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg==
   dependencies:
     tslib "^2.8.1"
 
-pvutils@^1.1.3:
-  version "1.1.3"
-  resolved "https://registry.npmjs.org/pvutils/-/pvutils-1.1.3.tgz"
-  integrity sha512-pMpnA0qRdFp32b1sJl1wOJNxZLQ2cbQx+k6tjNtZ8CpvVhNqEPRgivZ2WOUev2YMajecdH7ctUPDvEe87nariQ==
+pvutils@^1.1.5:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/pvutils/-/pvutils-1.2.0.tgz#4b5487a9cccd52d275b0538775790a3ca982bc22"
+  integrity sha512-BbubeCEyTuQjVMakvJQ/Sxbc93F2pwmbsxONT/ZRrwU7Ua38d8unYTwXpTVLAKJ4BDuH9IGztCjQcd/N/39Dvg==
 
 quansync@^0.2.7:
   version "0.2.11"
-  resolved "https://registry.npmjs.org/quansync/-/quansync-0.2.11.tgz"
+  resolved "https://registry.yarnpkg.com/quansync/-/quansync-0.2.11.tgz#f9c3adda2e1272e4f8cf3f1457b04cbdb4ee692a"
   integrity sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA==
 
 queue-microtask@^1.2.2:
@@ -13370,9 +13412,9 @@ queue-microtask@^1.2.2:
   resolved "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz"
   integrity sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==
 
-race-event@^1.2.0, race-event@^1.3.0:
+race-event@^1.2.0, race-event@^1.3.0, race-event@^1.6.1:
   version "1.6.1"
-  resolved "https://registry.npmjs.org/race-event/-/race-event-1.6.1.tgz"
+  resolved "https://registry.yarnpkg.com/race-event/-/race-event-1.6.1.tgz#3f1ab9ada27c28282bc430bb16f92e89304c41d9"
   integrity sha512-vi7WH5g5KoTFpu2mme/HqZiWH14XSOtg5rfp6raBskBHl7wnmy3F/biAIyY5MsK+BHWhoPhxtZ1Y2R7OHHaWyQ==
   dependencies:
     abort-error "^1.0.1"
@@ -13381,6 +13423,11 @@ race-signal@^1.0.2, race-signal@^1.1.3:
   version "1.1.3"
   resolved "https://registry.npmjs.org/race-signal/-/race-signal-1.1.3.tgz"
   integrity sha512-Mt2NznMgepLfORijhQMncE26IhkmjEphig+/1fKC0OtaKwys/gpvpmswSjoN01SS+VO951mj0L4VIDXdXsjnfA==
+
+race-signal@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/race-signal/-/race-signal-2.0.0.tgz#979d58493098ad6a6b556ef5b07b897d253d6b0f"
+  integrity sha512-P31bLhE4ByBX/70QDXMutxnqgwrF1WUXea1O8DXuviAgkdbQ1iQMQotNgzJIBC9yUSn08u/acZrMUhgw7w6GpA==
 
 randombytes@^2.0.5, randombytes@^2.1.0:
   version "2.1.0"
@@ -13416,14 +13463,14 @@ rdf-canonize@^3.0.0, rdf-canonize@^3.4.0:
 
 rdf-data-factory@^1.0.1, rdf-data-factory@^1.1.0, rdf-data-factory@^1.1.2:
   version "1.1.3"
-  resolved "https://registry.npmjs.org/rdf-data-factory/-/rdf-data-factory-1.1.3.tgz"
+  resolved "https://registry.yarnpkg.com/rdf-data-factory/-/rdf-data-factory-1.1.3.tgz#11b39e0c80e51bca83828b2ddaa686f733be966f"
   integrity sha512-ny6CI7m2bq4lfQQmDYvcb2l1F9KtGwz9chipX4oWu2aAtVoXjb7k3d8J1EsgAsEbMXnBipB/iuRen5H2fwRWWQ==
   dependencies:
     "@rdfjs/types" "^1.0.0"
 
-rdf-data-factory@^2.0.0:
+rdf-data-factory@^2.0.0, rdf-data-factory@^2.0.1:
   version "2.0.2"
-  resolved "https://registry.npmjs.org/rdf-data-factory/-/rdf-data-factory-2.0.2.tgz"
+  resolved "https://registry.yarnpkg.com/rdf-data-factory/-/rdf-data-factory-2.0.2.tgz#dfac1fdf99502f3b6d61f8e99e97af2490346e32"
   integrity sha512-WzPoYHwQYWvIP9k+7IBLY1b4nIDitzAK4mA37WumAF/Cjvu/KOtYJH9IPZnUTWNSd5K2+pq4vrcE9WZC4sRHhg==
   dependencies:
     "@rdfjs/types" "^2.0.0"
@@ -13437,6 +13484,15 @@ rdf-isomorphic@^1.3.0:
     hash.js "^1.1.7"
     rdf-string "^1.6.0"
     rdf-terms "^1.7.0"
+
+rdf-isomorphic@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/rdf-isomorphic/-/rdf-isomorphic-2.0.1.tgz#55f001d282af1aed12912f6d4d4074588d548969"
+  integrity sha512-8pfA3PeDs1sVrZ2R3dCR4KRM69m3pQGhzviNQq5Az/+Zch4I+fKstjGxCZ5ADAFPsm9zxHk8zMEQ/BFcqlnLKw==
+  dependencies:
+    imurmurhash "^0.1.4"
+    rdf-string "^2.0.0"
+    rdf-terms "^2.0.0"
 
 rdf-literal@^1.2.0, rdf-literal@^1.3.2:
   version "1.3.2"
@@ -13498,7 +13554,7 @@ rdf-quad@^1.5.0:
 
 rdf-streaming-store@^2.1.1:
   version "2.1.1"
-  resolved "https://registry.npmjs.org/rdf-streaming-store/-/rdf-streaming-store-2.1.1.tgz"
+  resolved "https://registry.yarnpkg.com/rdf-streaming-store/-/rdf-streaming-store-2.1.1.tgz#efa450533a96cadf80a49228ae092c7bb389d2c6"
   integrity sha512-hw9n1WdsSI74d89EDGQv5dYb5PaFXjjm4BqdSwJ7JMa5Cx27pwtv5qbXZvSXZmle90/myI2At+TIpdLJQmujBg==
   dependencies:
     "@rdfjs/types" "*"
@@ -13517,7 +13573,14 @@ rdf-string-ttl@^1.3.2:
     "@rdfjs/types" "*"
     rdf-data-factory "^1.1.0"
 
-rdf-string@^1.0.0, rdf-string@^1.5.0, rdf-string@^1.6.0, rdf-string@^1.6.1, rdf-string@^1.6.3:
+rdf-string-ttl@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/rdf-string-ttl/-/rdf-string-ttl-2.0.1.tgz#74ece2fa804c32fe7de3531b1feb7e1e580a1d80"
+  integrity sha512-xIZdC6uur9OwaCQrOsjuzLpnQCNGuJFWnYIAdF48tg3wzG5QzsgDMTJISCVh+M2p1e9ivIXlEauSdWokAhpZgA==
+  dependencies:
+    rdf-data-factory "^2.0.0"
+
+rdf-string@^1.5.0, rdf-string@^1.6.0, rdf-string@^1.6.1, rdf-string@^1.6.3:
   version "1.6.3"
   resolved "https://registry.npmjs.org/rdf-string/-/rdf-string-1.6.3.tgz"
   integrity sha512-HIVwQ2gOqf+ObsCLSUAGFZMIl3rh9uGcRf1KbM85UDhKqP+hy6qj7Vz8FKt3GA54RiThqK3mNcr66dm1LP0+6g==
@@ -13527,7 +13590,7 @@ rdf-string@^1.0.0, rdf-string@^1.5.0, rdf-string@^1.6.0, rdf-string@^1.6.1, rdf-
 
 rdf-string@^2.0.0, rdf-string@^2.0.1:
   version "2.0.1"
-  resolved "https://registry.npmjs.org/rdf-string/-/rdf-string-2.0.1.tgz"
+  resolved "https://registry.yarnpkg.com/rdf-string/-/rdf-string-2.0.1.tgz#9beff12486a653d6fb0f229a5e0e5f3cc2e962c6"
   integrity sha512-SMW4ponnKNrsP9kYpOLyICeM4UJmEXIeS3zri7kPK9gzLFsHD88oiza8LnokNYxd76zW4JoYWD+v4x0g8rJBjw==
   dependencies:
     rdf-data-factory "^2.0.0"
@@ -13543,7 +13606,7 @@ rdf-terms@^1.10.0, rdf-terms@^1.11.0, rdf-terms@^1.7.0:
 
 rdf-terms@^2.0.0:
   version "2.0.0"
-  resolved "https://registry.npmjs.org/rdf-terms/-/rdf-terms-2.0.0.tgz"
+  resolved "https://registry.yarnpkg.com/rdf-terms/-/rdf-terms-2.0.0.tgz#18b868263b5e38a9ded0e55b564a4a2933d5f533"
   integrity sha512-9O+ifVcvY4ZktOr+uXKswoOV6airAsIKeqCr+C47kFZBB8X+NyPSqDRGgI6X+je8It6z2e9jZhWwjJiEZ8Yn5Q==
   dependencies:
     rdf-data-factory "^2.0.0"
@@ -13611,7 +13674,20 @@ readable-stream-node-to-web@^1.0.1:
   resolved "https://registry.npmjs.org/readable-stream-node-to-web/-/readable-stream-node-to-web-1.0.1.tgz"
   integrity sha512-OGzi2VKLa8H259kAx7BIwuRrXHGcxeHj4RdASSgEGBP9Q2wowdPvBc65upF4Q9O05qWgKqBw1+9PiLTtObl7uQ==
 
-readable-stream@^3.1.1, readable-stream@^3.4.0, readable-stream@^3.6.0, readable-stream@^3.6.2:
+readable-stream@^2.3.8:
+  version "2.3.8"
+  resolved "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz"
+  integrity sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==
+  dependencies:
+    core-util-is "~1.0.0"
+    inherits "~2.0.3"
+    isarray "~1.0.0"
+    process-nextick-args "~2.0.0"
+    safe-buffer "~5.1.1"
+    string_decoder "~1.1.1"
+    util-deprecate "~1.0.1"
+
+readable-stream@^3.1.1, readable-stream@^3.4.0, readable-stream@^3.6.2:
   version "3.6.2"
   resolved "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz"
   integrity sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==
@@ -13664,10 +13740,10 @@ reflect.getprototypeof@^1.0.6, reflect.getprototypeof@^1.0.9:
     get-proto "^1.0.1"
     which-builtin-type "^1.2.1"
 
-regenerate-unicode-properties@^10.2.0:
-  version "10.2.0"
-  resolved "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-10.2.0.tgz"
-  integrity sha512-DqHn3DwbmmPVzeKj9woBadqmXxLvQoQIwu7nopMc72ztvxVmVk2SBhSnx67zuye5TP+lJsb/TBQsjLKhnDf3MA==
+regenerate-unicode-properties@^10.2.2:
+  version "10.2.2"
+  resolved "https://registry.yarnpkg.com/regenerate-unicode-properties/-/regenerate-unicode-properties-10.2.2.tgz#aa113812ba899b630658c7623466be71e1f86f66"
+  integrity sha512-m03P+zhBeQd1RGnYxrGyDAPpWX/epKirLrp8e3qevZdVkKtnCrjjWczIbYc8+xd6vcTStVlqfycTx1KR4LOr0g==
   dependencies:
     regenerate "^1.4.2"
 
@@ -13688,7 +13764,7 @@ regenerator-runtime@^0.14.0:
 
 regexp.prototype.flags@^1.5.1, regexp.prototype.flags@^1.5.4:
   version "1.5.4"
-  resolved "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz"
+  resolved "https://registry.yarnpkg.com/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz#1ad6c62d44a259007e55b3970e00f746efbcaa19"
   integrity sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==
   dependencies:
     call-bind "^1.0.8"
@@ -13698,29 +13774,29 @@ regexp.prototype.flags@^1.5.1, regexp.prototype.flags@^1.5.4:
     gopd "^1.2.0"
     set-function-name "^2.0.2"
 
-regexpu-core@^6.2.0:
-  version "6.2.0"
-  resolved "https://registry.npmjs.org/regexpu-core/-/regexpu-core-6.2.0.tgz"
-  integrity sha512-H66BPQMrv+V16t8xtmq+UC0CBpiTBA60V8ibS1QVReIp8T1z8hwFxqcGzm9K6lgsN7sB5edVH8a+ze6Fqm4weA==
+regexpu-core@^6.3.1:
+  version "6.4.0"
+  resolved "https://registry.yarnpkg.com/regexpu-core/-/regexpu-core-6.4.0.tgz#3580ce0c4faedef599eccb146612436b62a176e5"
+  integrity sha512-0ghuzq67LI9bLXpOX/ISfve/Mq33a4aFRzoQYhnnok1JOFpmE/A2TBGkNVenOGEeSBCjIiWcc6MVOG5HEQv0sA==
   dependencies:
     regenerate "^1.4.2"
-    regenerate-unicode-properties "^10.2.0"
+    regenerate-unicode-properties "^10.2.2"
     regjsgen "^0.8.0"
-    regjsparser "^0.12.0"
+    regjsparser "^0.13.0"
     unicode-match-property-ecmascript "^2.0.0"
-    unicode-match-property-value-ecmascript "^2.1.0"
+    unicode-match-property-value-ecmascript "^2.2.1"
 
 regjsgen@^0.8.0:
   version "0.8.0"
-  resolved "https://registry.npmjs.org/regjsgen/-/regjsgen-0.8.0.tgz"
+  resolved "https://registry.yarnpkg.com/regjsgen/-/regjsgen-0.8.0.tgz#df23ff26e0c5b300a6470cad160a9d090c3a37ab"
   integrity sha512-RvwtGe3d7LvWiDQXeQw8p5asZUmfU1G/l6WbUXeHta7Y2PEIvBTwH6E2EfmYUK8pxcxEdEmaomqyp0vZZ7C+3Q==
 
-regjsparser@^0.12.0:
-  version "0.12.0"
-  resolved "https://registry.npmjs.org/regjsparser/-/regjsparser-0.12.0.tgz"
-  integrity sha512-cnE+y8bz4NhMjISKbgeVJtqNbtf5QpjZP+Bslo+UqkIt9QPnX9q095eiRRASJG1/tz6dlNr6Z5NsBiWYokp6EQ==
+regjsparser@^0.13.0:
+  version "0.13.2"
+  resolved "https://registry.yarnpkg.com/regjsparser/-/regjsparser-0.13.2.tgz#f654734b5c588b22ba3e21693b30523417180808"
+  integrity sha512-NgRBy2Nx/bE+9F27nVHnqcN5HjyLmecqsqx2PJHu3/IEtADD4WuxuXIVExD5PoSDFVrl78dOonfcOe5O+5nbzQ==
   dependencies:
-    jsesc "~3.0.2"
+    jsesc "~3.1.0"
 
 relative-to-absolute-iri@^1.0.0, relative-to-absolute-iri@^1.0.2, relative-to-absolute-iri@^1.0.5, relative-to-absolute-iri@^1.0.7:
   version "1.0.7"
@@ -13766,7 +13842,7 @@ resolve.exports@^2.0.0:
   resolved "https://registry.npmjs.org/resolve.exports/-/resolve.exports-2.0.3.tgz"
   integrity sha512-OcXjMsGdhL4XnbShKpAcSqPMzQoYkYyhbEaeSko47MjRP9NfEQMhZkXL1DoFlt9LWQn4YttrdnV6X2OiyzBi+A==
 
-resolve@^1.12.0, resolve@^1.20.0, resolve@^1.22.1, resolve@^1.22.10, resolve@^1.22.4:
+resolve@^1.12.0, resolve@^1.20.0, resolve@^1.22.1, resolve@^1.22.4:
   version "1.22.10"
   resolved "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz"
   integrity sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==
@@ -13775,9 +13851,19 @@ resolve@^1.12.0, resolve@^1.20.0, resolve@^1.22.1, resolve@^1.22.10, resolve@^1.
     path-parse "^1.0.7"
     supports-preserve-symlinks-flag "^1.0.0"
 
+resolve@^1.22.11:
+  version "1.22.12"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.12.tgz#f5b2a680897c69c238a13cd16b15671f8b73549f"
+  integrity sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==
+  dependencies:
+    es-errors "^1.3.0"
+    is-core-module "^2.16.1"
+    path-parse "^1.0.7"
+    supports-preserve-symlinks-flag "^1.0.0"
+
 reusify@^1.0.4:
   version "1.1.0"
-  resolved "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz"
+  resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.1.0.tgz#0fe13b9522e1473f51b558ee796e08f11f9b489f"
   integrity sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==
 
 rify@^0.7.1:
@@ -13800,12 +13886,12 @@ rimraf@^5.0.5:
     glob "^10.3.7"
 
 ripemd160@^2.0.1, ripemd160@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz"
-  integrity sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==
+  version "2.0.3"
+  resolved "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.3.tgz"
+  integrity sha512-5Di9UC0+8h1L6ZD2d7awM7E/T4uA1fJRlx6zk/NvdCCVEoAnFqvHmCuNeIKoCeIixBX/q8uM+6ycDvF8woqosA==
   dependencies:
-    hash-base "^3.0.0"
-    inherits "^2.0.1"
+    hash-base "^3.1.2"
+    inherits "^2.0.4"
 
 rollup-plugin-copy@^3.4.0:
   version "3.5.0"
@@ -13827,19 +13913,12 @@ rollup-plugin-inject@^3.0.0:
     magic-string "^0.25.3"
     rollup-pluginutils "^2.8.1"
 
-rollup-plugin-multi-input@^1.3.2:
+rollup-plugin-multi-input@^1.3.2, rollup-plugin-multi-input@^1.4.1:
   version "1.5.0"
   resolved "https://registry.npmjs.org/rollup-plugin-multi-input/-/rollup-plugin-multi-input-1.5.0.tgz"
   integrity sha512-Tgb/pz1VxzYCk/MPTh0dhLb/zme4tWb72S9KtwVgGVupkdngUPQZqRUld25f8tAb18z1lfvz4Mn7ihDQLr+L9g==
   dependencies:
     fast-glob "3.3.2"
-
-rollup-plugin-multi-input@^1.4.1:
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/rollup-plugin-multi-input/-/rollup-plugin-multi-input-1.8.0.tgz#86db72bab69ef4e78c14947109d7780391e4af54"
-  integrity sha512-X8nSq29ZzFrc1LJSZ3d3nS7jE54g3oVLVwqkzJacwABvk5FikKmq275xrmz0mSoJxHUsLsN7taJbwhrv9qoW7A==
-  dependencies:
-    fast-glob "3.3.3"
 
 rollup-plugin-node-polyfills@^0.2.1:
   version "0.2.1"
@@ -13873,68 +13952,69 @@ rollup@2.79.2:
     fsevents "~2.3.2"
 
 rollup@^4.20.0:
-  version "4.53.2"
-  resolved "https://registry.npmjs.org/rollup/-/rollup-4.53.2.tgz"
-  integrity sha512-MHngMYwGJVi6Fmnk6ISmnk7JAHRNF0UkuucA0CUW3N3a4KnONPEZz+vUanQP/ZC/iY1Qkf3bwPWzyY84wEks1g==
+  version "4.53.5"
+  resolved "https://registry.npmjs.org/rollup/-/rollup-4.53.5.tgz"
+  integrity sha512-iTNAbFSlRpcHeeWu73ywU/8KuU/LZmNCSxp6fjQkJBD3ivUb8tpDrXhIxEzA05HlYMEwmtaUnb3RP+YNv162OQ==
   dependencies:
     "@types/estree" "1.0.8"
   optionalDependencies:
-    "@rollup/rollup-android-arm-eabi" "4.53.2"
-    "@rollup/rollup-android-arm64" "4.53.2"
-    "@rollup/rollup-darwin-arm64" "4.53.2"
-    "@rollup/rollup-darwin-x64" "4.53.2"
-    "@rollup/rollup-freebsd-arm64" "4.53.2"
-    "@rollup/rollup-freebsd-x64" "4.53.2"
-    "@rollup/rollup-linux-arm-gnueabihf" "4.53.2"
-    "@rollup/rollup-linux-arm-musleabihf" "4.53.2"
-    "@rollup/rollup-linux-arm64-gnu" "4.53.2"
-    "@rollup/rollup-linux-arm64-musl" "4.53.2"
-    "@rollup/rollup-linux-loong64-gnu" "4.53.2"
-    "@rollup/rollup-linux-ppc64-gnu" "4.53.2"
-    "@rollup/rollup-linux-riscv64-gnu" "4.53.2"
-    "@rollup/rollup-linux-riscv64-musl" "4.53.2"
-    "@rollup/rollup-linux-s390x-gnu" "4.53.2"
-    "@rollup/rollup-linux-x64-gnu" "4.53.2"
-    "@rollup/rollup-linux-x64-musl" "4.53.2"
-    "@rollup/rollup-openharmony-arm64" "4.53.2"
-    "@rollup/rollup-win32-arm64-msvc" "4.53.2"
-    "@rollup/rollup-win32-ia32-msvc" "4.53.2"
-    "@rollup/rollup-win32-x64-gnu" "4.53.2"
-    "@rollup/rollup-win32-x64-msvc" "4.53.2"
+    "@rollup/rollup-android-arm-eabi" "4.53.5"
+    "@rollup/rollup-android-arm64" "4.53.5"
+    "@rollup/rollup-darwin-arm64" "4.53.5"
+    "@rollup/rollup-darwin-x64" "4.53.5"
+    "@rollup/rollup-freebsd-arm64" "4.53.5"
+    "@rollup/rollup-freebsd-x64" "4.53.5"
+    "@rollup/rollup-linux-arm-gnueabihf" "4.53.5"
+    "@rollup/rollup-linux-arm-musleabihf" "4.53.5"
+    "@rollup/rollup-linux-arm64-gnu" "4.53.5"
+    "@rollup/rollup-linux-arm64-musl" "4.53.5"
+    "@rollup/rollup-linux-loong64-gnu" "4.53.5"
+    "@rollup/rollup-linux-ppc64-gnu" "4.53.5"
+    "@rollup/rollup-linux-riscv64-gnu" "4.53.5"
+    "@rollup/rollup-linux-riscv64-musl" "4.53.5"
+    "@rollup/rollup-linux-s390x-gnu" "4.53.5"
+    "@rollup/rollup-linux-x64-gnu" "4.53.5"
+    "@rollup/rollup-linux-x64-musl" "4.53.5"
+    "@rollup/rollup-openharmony-arm64" "4.53.5"
+    "@rollup/rollup-win32-arm64-msvc" "4.53.5"
+    "@rollup/rollup-win32-ia32-msvc" "4.53.5"
+    "@rollup/rollup-win32-x64-gnu" "4.53.5"
+    "@rollup/rollup-win32-x64-msvc" "4.53.5"
     fsevents "~2.3.2"
 
 rollup@^4.28.0:
-  version "4.60.1"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-4.60.1.tgz#b4aa2bcb3a5e1437b5fad40d43fe42d4bde7a42d"
-  integrity sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==
+  version "4.62.4"
+  resolved "https://registry.npmjs.org/rollup/-/rollup-4.62.4.tgz"
+  integrity sha512-RXOqwaPsBGjMNMa4sQjDjHieHEZDFoj/Rdr46l2MU5DfEs16wHJPC2RPTPHWhNl+M3aI472LLqFkFKut4SblOg==
   dependencies:
-    "@types/estree" "1.0.8"
+    "@types/estree" "1.0.9"
   optionalDependencies:
-    "@rollup/rollup-android-arm-eabi" "4.60.1"
-    "@rollup/rollup-android-arm64" "4.60.1"
-    "@rollup/rollup-darwin-arm64" "4.60.1"
-    "@rollup/rollup-darwin-x64" "4.60.1"
-    "@rollup/rollup-freebsd-arm64" "4.60.1"
-    "@rollup/rollup-freebsd-x64" "4.60.1"
-    "@rollup/rollup-linux-arm-gnueabihf" "4.60.1"
-    "@rollup/rollup-linux-arm-musleabihf" "4.60.1"
-    "@rollup/rollup-linux-arm64-gnu" "4.60.1"
-    "@rollup/rollup-linux-arm64-musl" "4.60.1"
-    "@rollup/rollup-linux-loong64-gnu" "4.60.1"
-    "@rollup/rollup-linux-loong64-musl" "4.60.1"
-    "@rollup/rollup-linux-ppc64-gnu" "4.60.1"
-    "@rollup/rollup-linux-ppc64-musl" "4.60.1"
-    "@rollup/rollup-linux-riscv64-gnu" "4.60.1"
-    "@rollup/rollup-linux-riscv64-musl" "4.60.1"
-    "@rollup/rollup-linux-s390x-gnu" "4.60.1"
-    "@rollup/rollup-linux-x64-gnu" "4.60.1"
-    "@rollup/rollup-linux-x64-musl" "4.60.1"
-    "@rollup/rollup-openbsd-x64" "4.60.1"
-    "@rollup/rollup-openharmony-arm64" "4.60.1"
-    "@rollup/rollup-win32-arm64-msvc" "4.60.1"
-    "@rollup/rollup-win32-ia32-msvc" "4.60.1"
-    "@rollup/rollup-win32-x64-gnu" "4.60.1"
-    "@rollup/rollup-win32-x64-msvc" "4.60.1"
+    "@napi-rs/lzma-linux-x64-gnu" "1.5.1"
+    "@rollup/rollup-android-arm-eabi" "4.62.4"
+    "@rollup/rollup-android-arm64" "4.62.4"
+    "@rollup/rollup-darwin-arm64" "4.62.4"
+    "@rollup/rollup-darwin-x64" "4.62.4"
+    "@rollup/rollup-freebsd-arm64" "4.62.4"
+    "@rollup/rollup-freebsd-x64" "4.62.4"
+    "@rollup/rollup-linux-arm-gnueabihf" "4.62.4"
+    "@rollup/rollup-linux-arm-musleabihf" "4.62.4"
+    "@rollup/rollup-linux-arm64-gnu" "4.62.4"
+    "@rollup/rollup-linux-arm64-musl" "4.62.4"
+    "@rollup/rollup-linux-loong64-gnu" "4.62.4"
+    "@rollup/rollup-linux-loong64-musl" "4.62.4"
+    "@rollup/rollup-linux-ppc64-gnu" "4.62.4"
+    "@rollup/rollup-linux-ppc64-musl" "4.62.4"
+    "@rollup/rollup-linux-riscv64-gnu" "4.62.4"
+    "@rollup/rollup-linux-riscv64-musl" "4.62.4"
+    "@rollup/rollup-linux-s390x-gnu" "4.62.4"
+    "@rollup/rollup-linux-x64-gnu" "4.62.4"
+    "@rollup/rollup-linux-x64-musl" "4.62.4"
+    "@rollup/rollup-openbsd-x64" "4.62.4"
+    "@rollup/rollup-openharmony-arm64" "4.62.4"
+    "@rollup/rollup-win32-arm64-msvc" "4.62.4"
+    "@rollup/rollup-win32-ia32-msvc" "4.62.4"
+    "@rollup/rollup-win32-x64-gnu" "4.62.4"
+    "@rollup/rollup-win32-x64-msvc" "4.62.4"
     fsevents "~2.3.2"
 
 run-parallel@^1.1.9:
@@ -13951,7 +14031,18 @@ rxjs@^7.4.0:
   dependencies:
     tslib "^2.1.0"
 
-safe-array-concat@^1.1.2, safe-array-concat@^1.1.3:
+safe-array-concat@^1.1.2:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/safe-array-concat/-/safe-array-concat-1.1.4.tgz#a54cc9b61a57f33b42abad3cbdda3a2b38cc5719"
+  integrity sha512-wtZlHyOje6OZTGqAoaDKxFkgRtkF9CnHAVnCHKfuj200wAgL+bSJhdsCD2l0Qx/2ekEXjPWcyKkfGb5CPboslg==
+  dependencies:
+    call-bind "^1.0.9"
+    call-bound "^1.0.4"
+    get-intrinsic "^1.3.0"
+    has-symbols "^1.1.0"
+    isarray "^2.0.5"
+
+safe-array-concat@^1.1.3:
   version "1.1.3"
   resolved "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.3.tgz"
   integrity sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==
@@ -13962,12 +14053,12 @@ safe-array-concat@^1.1.2, safe-array-concat@^1.1.3:
     has-symbols "^1.1.0"
     isarray "^2.0.5"
 
-safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.2, safe-buffer@^5.2.0, safe-buffer@^5.2.1, safe-buffer@~5.2.0:
+safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.2, safe-buffer@^5.2.1, safe-buffer@~5.2.0:
   version "5.2.1"
   resolved "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
 
-safe-buffer@~5.1.1:
+safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
   resolved "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz"
   integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
@@ -13996,7 +14087,7 @@ safe-stable-stringify@^2.3.1:
 
 "safer-buffer@>= 2.1.2 < 3.0.0":
   version "2.1.2"
-  resolved "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz"
+  resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
 sanitize-filename@^1.6.3:
@@ -14064,9 +14155,9 @@ semver@^6.3.0, semver@^6.3.1:
   integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
 
 semver@^7.3.2, semver@^7.3.5, semver@^7.3.7, semver@^7.5.3, semver@^7.5.4, semver@^7.6.0:
-  version "7.7.2"
-  resolved "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz"
-  integrity sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==
+  version "7.8.5"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.8.5.tgz#39b646037dd50c14fb451e7e4cac58ed8b863f69"
+  integrity sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==
 
 serialize-error@^8.0.1:
   version "8.1.0"
@@ -14139,20 +14230,20 @@ sha.js@^2.4.0, sha.js@^2.4.11:
 
 shaclc-parse@^1.4.0:
   version "1.4.3"
-  resolved "https://registry.npmjs.org/shaclc-parse/-/shaclc-parse-1.4.3.tgz"
+  resolved "https://registry.yarnpkg.com/shaclc-parse/-/shaclc-parse-1.4.3.tgz#56de4d03408f0768bf66c70d655cff33ccae410d"
   integrity sha512-MQJWVFjfzzMUvieFO0STWjIo49ywy63UkVSsr0e8+8xHUns6X+i3yWYxNKd+GtSEJjBNZxxrUubog+hnd7PvRA==
   dependencies:
     "@rdfjs/types" "^2.0.0"
     n3 "^1.16.3"
 
 shaclc-write@^1.4.2:
-  version "1.5.0"
-  resolved "https://registry.npmjs.org/shaclc-write/-/shaclc-write-1.5.0.tgz"
-  integrity sha512-5+uFmw28BUqCW5UC4FyFwB8VTsdzPyh4LB2pAI5DRjn6xWgl1bsfied9K9HbQYrONNtmhLpPFse79N3Tvj+kLA==
+  version "1.6.3"
+  resolved "https://registry.yarnpkg.com/shaclc-write/-/shaclc-write-1.6.3.tgz#a15942e9c11795bc64573e35ed3ee3872cf3f6ce"
+  integrity sha512-R6rHiDov9kppjXTTaSwuaOUC3JXhJWvlrxR++Eng1jNdtD3oywkAagRu6mS5rzTcMA4WBxLUXdJxu4CbPOG04A==
   dependencies:
     "@jeswr/prefixcc" "^1.2.1"
-    n3 "^1.16.3"
-    rdf-string-ttl "^1.3.2"
+    n3 "^2.0.0"
+    rdf-string-ttl "^2.0.1"
 
 shallow-clone@^3.0.0:
   version "3.0.1"
@@ -14181,6 +14272,14 @@ side-channel-list@^1.0.0:
     es-errors "^1.3.0"
     object-inspect "^1.13.3"
 
+side-channel-list@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/side-channel-list/-/side-channel-list-1.0.1.tgz#c2e0b5a14a540aebee3bbc6c3f8666cc9b509127"
+  integrity sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==
+  dependencies:
+    es-errors "^1.3.0"
+    object-inspect "^1.13.4"
+
 side-channel-map@^1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz"
@@ -14202,7 +14301,18 @@ side-channel-weakmap@^1.0.2:
     object-inspect "^1.13.3"
     side-channel-map "^1.0.1"
 
-side-channel@^1.0.4, side-channel@^1.1.0:
+side-channel@^1.0.4:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/side-channel/-/side-channel-1.1.1.tgz#ea02c62e05dc4bea67d4442f0fb71ee192f8e0ab"
+  integrity sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==
+  dependencies:
+    es-errors "^1.3.0"
+    object-inspect "^1.13.4"
+    side-channel-list "^1.0.1"
+    side-channel-map "^1.0.1"
+    side-channel-weakmap "^1.0.2"
+
+side-channel@^1.1.0:
   version "1.1.0"
   resolved "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz"
   integrity sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==
@@ -14319,7 +14429,7 @@ sparqlalgebrajs@^3.0.1:
     rdf-string "^1.6.0"
     sparqljs "^3.4.2"
 
-sparqlalgebrajs@^4.0.0, sparqlalgebrajs@^4.2.0, sparqlalgebrajs@^4.3.7, sparqlalgebrajs@^4.3.8:
+sparqlalgebrajs@^4.0.0, sparqlalgebrajs@^4.2.0:
   version "4.3.8"
   resolved "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-4.3.8.tgz"
   integrity sha512-Xo1/5icRtVk2N38BrY9NXN8N/ZPjULlns7sDHv0nlcGOsOediBLWVy8LmV+Q90RHvb3atZZbrFy3VqrM4iXciA==
@@ -14332,6 +14442,20 @@ sparqlalgebrajs@^4.0.0, sparqlalgebrajs@^4.2.0, sparqlalgebrajs@^4.3.7, sparqlal
     rdf-isomorphic "^1.3.0"
     rdf-string "^1.6.0"
     rdf-terms "^1.10.0"
+    sparqljs "^3.7.1"
+
+sparqlalgebrajs@^5.0.2:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/sparqlalgebrajs/-/sparqlalgebrajs-5.0.2.tgz#ec61c85bdfc053095815c5b375703cb78849b424"
+  integrity sha512-Xz7byRqWqCMkbM+3ogGmKO/wsezQKQQNleoggP03sCTTFfCh/ZlN5CGt+HkrOenDSktZ93jpKFbbaIRjLOYtWw==
+  dependencies:
+    "@types/sparqljs" "^3.1.3"
+    fast-deep-equal "^3.1.3"
+    minimist "^1.2.6"
+    rdf-data-factory "^2.0.1"
+    rdf-isomorphic "^2.0.0"
+    rdf-string "^2.0.0"
+    rdf-terms "^2.0.0"
     sparqljs "^3.7.1"
 
 sparqljs@^3.0.0, sparqljs@^3.4.2, sparqljs@^3.7.1:
@@ -14352,6 +14476,16 @@ sparqljson-parse@^2.0.0:
     rdf-data-factory "^1.1.0"
     readable-stream "^4.0.0"
 
+sparqljson-parse@^3.0.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/sparqljson-parse/-/sparqljson-parse-3.3.0.tgz#d6770a1f3fd4fd2e168c2cc7027eaaa72051a31c"
+  integrity sha512-XrmkCsrx4n69Ak63Ju7t91hVlWw7YhEPPdA+giW2GRTosQxPur0JWh7rQin/8aT0WjKZgBgGpsNnVBYyyWUq1w==
+  dependencies:
+    "@bergos/jsonparse" "^1.4.1"
+    "@types/readable-stream" "^4.0.0"
+    rdf-data-factory "^2.0.0"
+    readable-stream "^4.0.0"
+
 sparqljson-to-tree@^3.0.1:
   version "3.0.2"
   resolved "https://registry.npmjs.org/sparqljson-to-tree/-/sparqljson-to-tree-3.0.2.tgz"
@@ -14361,17 +14495,16 @@ sparqljson-to-tree@^3.0.1:
     rdf-literal "^1.3.2"
     sparqljson-parse "^2.0.0"
 
-sparqlxml-parse@^2.0.0:
-  version "2.1.1"
-  resolved "https://registry.npmjs.org/sparqlxml-parse/-/sparqlxml-parse-2.1.1.tgz"
-  integrity sha512-71sltShF6gDAzuKWEHNeij7r0Mv5VqRrvJing6W4WHJ12GRe6+t1IRTv6MeqxYN3XJmKevs7B3HCBUo7wceeJQ==
+sparqlxml-parse@^3.0.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/sparqlxml-parse/-/sparqlxml-parse-3.3.0.tgz#829d01c2ca38e92180fe20957a192d6d0d797c81"
+  integrity sha512-FUVgcUr2YePDtDuu/UcMTF2ODiKBQdZdcfTSvaR3QhWVAcBmIGX4r4apsePK1zCc1kkRR53JBHXHJho/Pk538g==
   dependencies:
-    "@rdfjs/types" "*"
     "@rubensworks/saxes" "^6.0.1"
-    "@types/readable-stream" "^2.3.13"
+    "@types/readable-stream" "^4.0.0"
     buffer "^6.0.3"
-    rdf-data-factory "^1.1.0"
-    readable-stream "^4.0.0"
+    rdf-data-factory "^2.0.0"
+    readable-stream "^4.5.2"
 
 spawndamnit@^3.0.1:
   version "3.0.1"
@@ -14417,7 +14550,7 @@ std-env@^3.8.0:
 
 stop-iteration-iterator@^1.0.0, stop-iteration-iterator@^1.1.0:
   version "1.1.0"
-  resolved "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz"
+  resolved "https://registry.yarnpkg.com/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz#f481ff70a548f6124d0312c3aa14cbfa7aa542ad"
   integrity sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==
   dependencies:
     es-errors "^1.3.0"
@@ -14521,6 +14654,13 @@ string_decoder@^1.1.1, string_decoder@^1.3.0:
   dependencies:
     safe-buffer "~5.2.0"
 
+string_decoder@~1.1.1:
+  version "1.1.1"
+  resolved "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz"
+  integrity sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==
+  dependencies:
+    safe-buffer "~5.1.0"
+
 "strip-ansi-cjs@npm:strip-ansi@^6.0.1":
   version "6.0.1"
   resolved "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz"
@@ -14580,9 +14720,9 @@ strip-json-comments@~2.0.1:
   integrity sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==
 
 strtok3@^10.3.4:
-  version "10.3.4"
-  resolved "https://registry.npmjs.org/strtok3/-/strtok3-10.3.4.tgz"
-  integrity sha512-KIy5nylvC5le1OdaaoCJ07L+8iQzJHGH6pWDuzS+d07Cu7n1MZ2x26P8ZKIWfbK02+XIL8Mp4RkWeqdUCrDMfg==
+  version "10.3.5"
+  resolved "https://registry.npmjs.org/strtok3/-/strtok3-10.3.5.tgz"
+  integrity sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA==
   dependencies:
     "@tokenizer/token" "^0.3.0"
 
@@ -14638,9 +14778,9 @@ taffydb@2.6.2:
   integrity sha512-y3JaeRSplks6NYQuCOj3ZFMO3j60rTwbuKCvZxsAraGYH2epusatvZ0baZYA01WsGqJBq/Dl6vOrMUJqyMj8kA==
 
 tar-fs@^2.0.0:
-  version "2.1.4"
-  resolved "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz"
-  integrity sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==
+  version "2.1.5"
+  resolved "https://registry.yarnpkg.com/tar-fs/-/tar-fs-2.1.5.tgz#33e9c29413dce0c58ada7ff77db4e5a30afffe70"
+  integrity sha512-OboTd8mmMhZDNPV+UjQcK9yKAatXu2aJ+r1w4im1Otd4M4fl2hwvdoXUxIYHFTHWK/3y3FarBP70v3vwmGlOxw==
   dependencies:
     chownr "^1.1.1"
     mkdirp-classic "^0.5.2"
@@ -14664,12 +14804,12 @@ term-size@^2.1.0:
   integrity sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==
 
 terser@^5.0.0:
-  version "5.43.1"
-  resolved "https://registry.npmjs.org/terser/-/terser-5.43.1.tgz"
-  integrity sha512-+6erLbBm0+LROX2sPXlUYx/ux5PyE9K/a92Wrt6oA+WDAoFTdpHE5tCYCI5PNzq2y8df4rA+QgHLJuR4jNymsg==
+  version "5.49.2"
+  resolved "https://registry.yarnpkg.com/terser/-/terser-5.49.2.tgz#cc08cfb6097e5da650bfd45c769ebd15c514fc23"
+  integrity sha512-rGbJiKeQ4WDe3EXlDAIaQcwftVfv2Q8o1awFNfvXolJYKkb1AuZY1RTOmqx4LJXZENbWZA7eIsYGHuEzHsi1nQ==
   dependencies:
     "@jridgewell/source-map" "^0.3.3"
-    acorn "^8.14.0"
+    acorn "^8.15.0"
     commander "^2.20.0"
     source-map-support "~0.5.20"
 
@@ -14748,10 +14888,10 @@ tmpl@1.0.5:
   resolved "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz"
   integrity sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==
 
-to-buffer@^1.2.0:
-  version "1.2.1"
-  resolved "https://registry.npmjs.org/to-buffer/-/to-buffer-1.2.1.tgz"
-  integrity sha512-tB82LpAIWjhLYbqjx3X4zEeHN6M8CiuOEy2JY8SEQVdYRe3CCHOFaqrBW1doLDrfpWhplcW7BL+bO3/6S3pcDQ==
+to-buffer@^1.2.0, to-buffer@^1.2.1, to-buffer@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.npmjs.org/to-buffer/-/to-buffer-1.2.2.tgz"
+  integrity sha512-db0E3UJjcFhpDhAF4tLo03oli3pwl3dbnzXOUIlRKrp+ldk/VUxzpWYZENsw2SZiuBjHAk7DfB0VU7NKdpb6sw==
   dependencies:
     isarray "^2.0.5"
     safe-buffer "^5.2.1"
@@ -14774,7 +14914,7 @@ token-types@^4.1.1:
 
 token-types@^6.1.1:
   version "6.1.2"
-  resolved "https://registry.yarnpkg.com/token-types/-/token-types-6.1.2.tgz#18d0fd59b996d421f9f83914d6101c201bd08129"
+  resolved "https://registry.npmjs.org/token-types/-/token-types-6.1.2.tgz"
   integrity sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==
   dependencies:
     "@borewit/text-codec" "^0.2.1"
@@ -14813,9 +14953,9 @@ tslib@^1.8.1:
   resolved "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tslib@^2.0.0, tslib@^2.1.0, tslib@^2.6.2, tslib@^2.7.0, tslib@^2.8.1:
+tslib@^2.0.0, tslib@^2.1.0, tslib@^2.6.2, tslib@^2.8.1:
   version "2.8.1"
-  resolved "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
   integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
 
 tsutils@^3.21.0:
@@ -14839,12 +14979,12 @@ turbo-darwin-64@2.0.5:
 
 turbo-darwin-arm64@2.0.5:
   version "2.0.5"
-  resolved "https://registry.yarnpkg.com/turbo-darwin-arm64/-/turbo-darwin-arm64-2.0.5.tgz#a1e47e97cca55ba6e15d52f2ae7af41e74a4d837"
+  resolved "https://registry.npmjs.org/turbo-darwin-arm64/-/turbo-darwin-arm64-2.0.5.tgz"
   integrity sha512-//5y4RJvnal8CttOLBwlaBqblcQb1qTlIxLN+I8O3E3rPuvHOupNKB9ZJxYIQ8oWf8ns8Ec8cxQ0GSBLTJIMtA==
 
 turbo-linux-64@2.0.5:
   version "2.0.5"
-  resolved "https://registry.npmjs.org/turbo-linux-64/-/turbo-linux-64-2.0.5.tgz"
+  resolved "https://registry.yarnpkg.com/turbo-linux-64/-/turbo-linux-64-2.0.5.tgz#ef9da9b8d90ab2d9d0c1c473ee27426e03cdc953"
   integrity sha512-LDtEDU2Gm8p3lKu//aHXZFRKUCVu68BNF9LQ+HmiCKFpNyK7khpMTxIAAUhDqt+AzlrbxtrxcCpCJaWg1JDjHg==
 
 turbo-linux-arm64@2.0.5:
@@ -14971,10 +15111,18 @@ uint8-varint@^2.0.1, uint8-varint@^2.0.2, uint8-varint@^2.0.3, uint8-varint@^2.0
     uint8arraylist "^2.0.0"
     uint8arrays "^5.0.0"
 
+uint8-varint@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/uint8-varint/-/uint8-varint-3.0.0.tgz#073d9a1eb24fcb52fae6763511722b7c60b4a951"
+  integrity sha512-S4DdpXBaLwKcFo7f0bWzWfHjbZ/i3QhM842qn+ZvHjxqFCfUcEB9SQNcmI69S+zMlcmIcKxsk9Iyw77S2Kxv6Q==
+  dependencies:
+    uint8arraylist "^3.0.1"
+    uint8arrays "^6.1.0"
+
 uint8array-extras@^1.4.0:
-  version "1.4.1"
-  resolved "https://registry.npmjs.org/uint8array-extras/-/uint8array-extras-1.4.1.tgz"
-  integrity sha512-+NWHrac9dvilNgme+gP4YrBSumsaMZP0fNBtXXFIf33RLLKEcBUKaQZ7ULUbS0sBfcjxIZ4V96OTRkCbM7hxpw==
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/uint8array-extras/-/uint8array-extras-1.5.0.tgz#10d2a85213de3ada304fea1c454f635c73839e86"
+  integrity sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==
 
 uint8arraylist@^2.0.0, uint8arraylist@^2.4.3, uint8arraylist@^2.4.8:
   version "2.4.8"
@@ -14982,6 +15130,13 @@ uint8arraylist@^2.0.0, uint8arraylist@^2.4.3, uint8arraylist@^2.4.8:
   integrity sha512-vc1PlGOzglLF0eae1M8mLRTBivsvrGsdmJ5RbK3e+QRvRLOZfZhQROTwH/OfyF3+ZVUg9/8hE8bmKP2CvP9quQ==
   dependencies:
     uint8arrays "^5.0.1"
+
+uint8arraylist@^3.0.0, uint8arraylist@^3.0.1, uint8arraylist@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/uint8arraylist/-/uint8arraylist-3.0.2.tgz#ca67cba700d0aafec34f8f547f40adc3ee769a57"
+  integrity sha512-LDVoq9BQaGJzGDUovEnoX6rpKCvnY/Jbtws4ikwnBzjRbq5qBAFpBZevUEbSmMM87aO0Sp+wOZy2ZXf5yODmXQ==
+  dependencies:
+    uint8arrays "^6.0.0"
 
 "uint8arrays-cjs@npm:uint8arrays@^3.1.1":
   version "3.1.1"
@@ -15011,6 +15166,13 @@ uint8arrays@^5.0.0, uint8arrays@^5.0.1, uint8arrays@^5.0.2, uint8arrays@^5.1.0:
   dependencies:
     multiformats "^13.0.0"
 
+uint8arrays@^6.0.0, uint8arrays@^6.1.0, uint8arrays@^6.1.1:
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/uint8arrays/-/uint8arrays-6.1.1.tgz#c2b59dddacc69ac4813ea29ac4b8d727189de522"
+  integrity sha512-iz7JN0XCSZYA111lhFG2Ui9EhFvTNekqSRHw3lvMHq+dzwWy1OQftxFQREEh4rffU0oSoXdQHsk2TiHKVm4fsA==
+  dependencies:
+    multiformats "^14.0.0"
+
 unbox-primitive@^1.1.0:
   version "1.1.0"
   resolved "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.1.0.tgz"
@@ -15022,19 +15184,14 @@ unbox-primitive@^1.1.0:
     which-boxed-primitive "^1.1.1"
 
 underscore@~1.13.2:
-  version "1.13.8"
-  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.13.8.tgz#a93a21186c049dbf0e847496dba72b7bd8c1e92b"
-  integrity sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==
+  version "1.13.7"
+  resolved "https://registry.npmjs.org/underscore/-/underscore-1.13.7.tgz"
+  integrity sha512-GMXzWtsc57XAtguZgaQViUOzs0KTkk8ojr3/xAxXLITqf/3EMwxC0inyETfDFjH/Krbhuep0HNbbjI9i/q3F3g==
 
 undici-types@~5.26.4:
   version "5.26.5"
   resolved "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz"
   integrity sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==
-
-undici-types@~7.10.0:
-  version "7.10.0"
-  resolved "https://registry.npmjs.org/undici-types/-/undici-types-7.10.0.tgz"
-  integrity sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==
 
 undici-types@~7.16.0:
   version "7.16.0"
@@ -15049,13 +15206,13 @@ undici@^5.21.2:
     "@fastify/busboy" "^2.0.0"
 
 undici@^6.6.2:
-  version "6.21.3"
-  resolved "https://registry.npmjs.org/undici/-/undici-6.21.3.tgz"
-  integrity sha512-gBLkYIlEnSp8pFbT64yFgGE6UIB9tAkhukC23PmMDCe5Nd+cRqKxSjw5y54MK2AZMgZfJWMaNE4nYUHgi1XEOw==
+  version "6.28.0"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-6.28.0.tgz#9f0e385744fef5021d6596c5bccd783f61193c1c"
+  integrity sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==
 
 unicode-canonical-property-names-ecmascript@^2.0.0:
   version "2.0.1"
-  resolved "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-2.0.1.tgz"
+  resolved "https://registry.yarnpkg.com/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-2.0.1.tgz#cb3173fe47ca743e228216e4a3ddc4c84d628cc2"
   integrity sha512-dA8WbNeb2a6oQzAQ55YlT5vQAWGV9WXOsi3SskE3bcCdM0P4SDd+24zS/OCacdRq5BkdsRj9q3Pg6YyQoxIGqg==
 
 unicode-match-property-ecmascript@^2.0.0:
@@ -15066,10 +15223,10 @@ unicode-match-property-ecmascript@^2.0.0:
     unicode-canonical-property-names-ecmascript "^2.0.0"
     unicode-property-aliases-ecmascript "^2.0.0"
 
-unicode-match-property-value-ecmascript@^2.1.0:
-  version "2.2.0"
-  resolved "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-2.2.0.tgz"
-  integrity sha512-4IehN3V/+kkr5YeSSDDQG8QLqO26XpL2XP3GQtqwlT/QYSECAwFztxVHjlbh0+gjJ3XmNLS0zDsbgs9jWKExLg==
+unicode-match-property-value-ecmascript@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-2.2.1.tgz#65a7adfad8574c219890e219285ce4c64ed67eaa"
+  integrity sha512-JQ84qTuMg4nVkx8ga4A16a1epI9H6uTXAknqxkGF/aFfRLw1xC/Bp24HNLaZhHSkWd3+84t8iXnp1J0kYcZHhg==
 
 unicode-property-aliases-ecmascript@^2.0.0:
   version "2.1.0"
@@ -15081,10 +15238,10 @@ universalify@^0.1.0:
   resolved "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz"
   integrity sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==
 
-update-browserslist-db@^1.1.3:
-  version "1.1.3"
-  resolved "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz"
-  integrity sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==
+update-browserslist-db@^1.2.3:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz#64d76db58713136acbeb4c49114366cc6cc2e80d"
+  integrity sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==
   dependencies:
     escalade "^3.2.0"
     picocolors "^1.1.1"
@@ -15101,7 +15258,7 @@ utf8-byte-length@^1.0.1:
   resolved "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.5.tgz"
   integrity sha512-Xn0w3MtiQ6zoz2vFyUVruaCL53O/DwUvkEeOvj+uulMm0BkUGYWmBYVyElqZaSLhY6ZD0ulfU3aBra2aVT4xfA==
 
-util-deprecate@^1.0.1:
+util-deprecate@^1.0.1, util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
   integrity sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==
@@ -15127,9 +15284,9 @@ uuid@^10.0.0:
   integrity sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==
 
 uuid@^11.0.0:
-  version "11.1.0"
-  resolved "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz"
-  integrity sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==
+  version "11.1.1"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-11.1.1.tgz#f6d81d2e1c65d00762e5e29b16c5d2d995e208ad"
+  integrity sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==
 
 uuid@^13.0.0:
   version "13.0.0"
@@ -15244,15 +15401,15 @@ web-streams-ponyfill@^1.4.2:
   integrity sha512-LCHW+fE2UBJ2vjhqJujqmoxh1ytEDEr0dPO3CabMdMDJPKmsaxzS90V1Ar6LtNE5VHLqxR4YMEj1i4lzMAccIA==
 
 webcrypto-core@^1.8.0:
-  version "1.8.1"
-  resolved "https://registry.npmjs.org/webcrypto-core/-/webcrypto-core-1.8.1.tgz"
-  integrity sha512-P+x1MvlNCXlKbLSOY4cYrdreqPG5hbzkmawbcXLKN/mf6DZW0SdNNkZ+sjwsqVkI4A4Ko2sPZmkZtCKY58w83A==
+  version "1.9.2"
+  resolved "https://registry.yarnpkg.com/webcrypto-core/-/webcrypto-core-1.9.2.tgz#22dd6a0fb55217b1301eab7151d01d5c68e52ccb"
+  integrity sha512-gsXecm82UQNlTBURJGuqOWy1Ww08S3kZUcr3aOJS02Pk0xLtkfeUAVC0u0xhgdonFme80edSJUIJyuvL/7250Q==
   dependencies:
-    "@peculiar/asn1-schema" "^2.3.13"
+    "@peculiar/asn1-schema" "^2.7.0"
     "@peculiar/json-schema" "^1.1.12"
-    asn1js "^3.0.5"
-    pvtsutils "^1.3.5"
-    tslib "^2.7.0"
+    "@peculiar/utils" "^2.0.2"
+    asn1js "^3.0.10"
+    tslib "^2.8.1"
 
 webcrypto-shim@^0.1.7:
   version "0.1.7"
@@ -15319,13 +15476,26 @@ which-collection@^1.0.1, which-collection@^1.0.2:
     is-weakmap "^2.0.2"
     is-weakset "^2.0.3"
 
-which-typed-array@^1.1.13, which-typed-array@^1.1.16, which-typed-array@^1.1.19:
+which-typed-array@^1.1.13, which-typed-array@^1.1.16:
   version "1.1.19"
   resolved "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.19.tgz"
   integrity sha512-rEvr90Bck4WZt9HHFC4DJMsjvu7x+r6bImz0/BrbWb7A2djJ8hnZMrWnHo9F8ssv0OMErasDhftrfROTyqSDrw==
   dependencies:
     available-typed-arrays "^1.0.7"
     call-bind "^1.0.8"
+    call-bound "^1.0.4"
+    for-each "^0.3.5"
+    get-proto "^1.0.1"
+    gopd "^1.2.0"
+    has-tostringtag "^1.0.2"
+
+which-typed-array@^1.1.19:
+  version "1.1.22"
+  resolved "https://registry.yarnpkg.com/which-typed-array/-/which-typed-array-1.1.22.tgz#8f3cc78aefb40b437346dd40a1dbfa5d1da43fe9"
+  integrity sha512-fvO4ExWMFsqyhG3AiPAObMuY1lxaqgYcxbc49CNdWDDECOJNgQyvsOWVwbZc+qf3rzRtxojBK+CMEv0Ld5CYpw==
+  dependencies:
+    available-typed-arrays "^1.0.7"
+    call-bind "^1.0.9"
     call-bound "^1.0.4"
     for-each "^0.3.5"
     get-proto "^1.0.1"
@@ -15429,9 +15599,9 @@ ws@^7:
   integrity sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==
 
 ws@^8.17.0, ws@^8.4.0:
-  version "8.18.3"
-  resolved "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz"
-  integrity sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==
+  version "8.21.2"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.21.2.tgz#e6976cfe96161d40420689a5f051378d11b0f0ce"
+  integrity sha512-54dMVAo4WIe6SKy3vBgN+9bJZqqQ8IMRevAkOLQALhi49qkkQDQfWdAZ8KQlXiEabw88ARXXdUrlvtbKQX+aKw==
 
 xhr2@0.1.3:
   version "0.1.3"
@@ -15513,11 +15683,11 @@ yocto-queue@^0.1.0:
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
 
 yocto-queue@^1.1.1:
-  version "1.2.1"
-  resolved "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.1.tgz"
-  integrity sha512-AyeEbWOu/TAXdxlV9wmGcR0+yh2j3vYPGOECcIj2S7MkrLyC7ne+oye2BKTItt0ii2PHk4cDy+95+LshzbXnGg==
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-1.2.2.tgz#3e09c95d3f1aa89a58c114c99223edf639152c00"
+  integrity sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==
 
 zod@^4.4.3:
   version "4.4.3"
-  resolved "https://registry.yarnpkg.com/zod/-/zod-4.4.3.tgz#b680f172885d18bbebf21a834ea25e55a1bbf356"
+  resolved "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz"
   integrity sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==


### PR DESCRIPTION
  - New file src/vc/crypto/JsonWebKey.js — extracted JsonWebKey from @transmute/json-web-signature (you only ever imported JsonWebKey, which never touches jsonld/http-client). Repointed the 2 imports in JsonWebSignature2020.js and vc/helpers.js.
  
  - package.json: removed @transmute/json-web-signature; added its 4 clean sub-deps (ed25519-key-pair, secp256k1-key-pair, jose-ld, web-crypto-key-pair) as direct deps; bumped jsonld-signatures ^9.3.1 → ^10.0.0 (uses jsonld@6, same major you already run);
